### PR TITLE
feat(projects): rename section to Featured Projects and reorder top picks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -145,7 +145,7 @@ pagerSize = 6
 
   [params.projects.completed]
     enable = true
-    projects_title= "👨🏻‍💻 Completed Projects"
+    projects_title= "👨🏻‍💻 Featured Projects"
     limit = 6
 
   [params.projects.fundraising]

--- a/content/projects/early_forest_fire_detection.md
+++ b/content/projects/early_forest_fire_detection.md
@@ -15,6 +15,7 @@ tools:
   - MLOps
 status: completed
 pinned: true
+weight: 1
 date: 2024-04-23
 image: /images/projects/early_forest_fire_detection/cover.png
 ---

--- a/content/projects/elephants_passive_acoustic_monitoring.md
+++ b/content/projects/elephants_passive_acoustic_monitoring.md
@@ -18,6 +18,7 @@ tools:
   - Machine Learning
 status: completed
 pinned: true
+weight: 3
 date: 2024-06-26
 image: /images/projects/forest_elephants_passive_acoustic_monitoring/cover.png
 ---

--- a/content/projects/wild_salmon_migration_monitoring.md
+++ b/content/projects/wild_salmon_migration_monitoring.md
@@ -26,6 +26,7 @@ tools:
   - Drones
 status: completed
 pinned: true
+weight: 2
 date: 2024-08-20
 image: /images/projects/wild_salmon_migration_monitoring/cover.png
 ---


### PR DESCRIPTION
## Summary
- Rename the homepage "👨🏻‍💻 Completed Projects" section to "👨🏻‍💻 Featured Projects"
- Add frontmatter weights to pin Early Forest Fire Detection, Wild Salmon Migration Monitoring, and Forest Elephants Passive Acoustic Monitoring at the top of the homepage and /projects listing (remaining projects keep their date-descending order)

## Test plan
- [x] `hugo` builds cleanly
- [x] Verified rendered homepage shows the new title and the three projects first, followed by Smolt Salmon Sonar, Wadden Sea Seal, and Trout Identification