### PR TITLE
feat: add Pyronear end-to-end demo video to tool and project pages

### DIFF
--- a/content/projects/early_forest_fire_detection.md
+++ b/content/projects/early_forest_fire_detection.md
@@ -39,6 +39,14 @@ form a resilient and proactive strategy for wildfire prevention and management.
 ![System Overview](/images/projects/early_forest_fire_detection/overview_system.png)
 *Overview of the Pyronear system to monitor forests around the clock*
 
+The video below, filmed in the Forest of Fontainebleau, shows how the system
+works end to end: a firefighter walks through the full pipeline, from the
+cameras spotting the first signs of smoke to the alert reaching the fire
+department.
+
+{{< youtube id=W3DxacGsdks >}}
+<br/>
+
 ## Forests Protection
 
 Protecting forests from fire is crucial for several reasons:

--- a/content/tools/pyronear/index.md
+++ b/content/tools/pyronear/index.md
@@ -46,6 +46,16 @@ departments.
 
 ## See Pyronear in Action
 
+The video below, filmed in the Forest of Fontainebleau, shows how the system
+works end to end: a firefighter walks through the full pipeline, from the
+cameras spotting the first signs of smoke to the alert reaching the fire
+department.
+
+<p><iframe src="https://www.youtube.com/embed/W3DxacGsdks" loading="lazy" frameborder="0" allowfullscreen style="width:100%;height:auto;aspect-ratio:16/9;"></iframe></p>
+<em style="font-size:14px;line-height:1.4em;display:block;">End-to-end demonstration of the Pyronear system in the Forest of Fontainebleau
+</em>
+<br/>
+
 The computer vision model detected a forest fire in Fontainebleau from a
 distance of 35 kilometers in real time, setting a new record for the Pyronear
 system. The video below shows a thin black smoke rising in the distance.


### PR DESCRIPTION
## Summary
- Embed the Fast Forward Demo Day 2026 clip (https://youtu.be/W3DxacGsdks) — a firefighter demonstrating the Pyronear system end to end in the Forest of Fontainebleau
- Tools page (`/tools/pyronear/`): video added at the top of "See Pyronear in Action", above the 35 km detection-record video
- Project page (`/projects/early_forest_fire_detection/`): video added in the Context section after the system-overview diagram

## Test plan
- [x] `hugo` builds cleanly; embed present in generated HTML for both pages
- [x] Verified both pages render correctly via `hugo server`