### PR TITLE
feat(tools): showcase the temporal smoke verifier on the Pyronear tool page

### DIFF
--- a/content/spaces/temporal_smoke_verification.md
+++ b/content/spaces/temporal_smoke_verification.md
@@ -1,0 +1,20 @@
+---
+title: Temporal Smoke Verification
+emoji: 🕐
+summary: The Pyronear temporal verifier judging real camera sequences — a detector proposes candidate regions, they are tracked over time, and a temporal classifier decides whether they behave like smoke. Watch real wildfires get caught and look-alikes get rejected.
+github_repo: https://github.com/pyronear/temporal-model
+date: 2026-06-12
+project: /projects/early_forest_fire_detection/
+hf_space: achouffe-temporal-smoke-pyronear
+hf_space_code: https://huggingface.co/spaces/achouffe/temporal-smoke-pyronear/tree/main
+gradio_js_version: 6.18.0
+manual_steps:
+  - step_name: Pick a sequence
+    description: Choose one of the real camera sequences — two early wildfires and two false-positive look-alikes (clouds, haze).
+  - step_name: Watch it play
+    description: The sequence loops automatically. Each box is a tracked candidate ("tube"), colored by the verdict — orange means judged smoke, gray means rejected.
+  - step_name: See what the classifier sees
+    description: Below the animation, each tube's stabilized crops are laid out over time — the background holds still, so the only thing moving is the candidate.
+  - step_name: Run the model live (optional)
+    description: Re-run the full pipeline from scratch on the Space's hardware to verify the precomputed results.
+---

--- a/content/tools/pyronear/index.md
+++ b/content/tools/pyronear/index.md
@@ -64,3 +64,20 @@ system. The video below shows a thin black smoke rising in the distance.
 <em style="font-size:14px;line-height:1.4em;display:block;">Real-time forest fire detection from 35 kilometers away in Fontainebleau
 </em>
 <br/>
+
+## Try the Models in Your Browser
+
+Two interactive demos let you run the Pyronear models on real data, right
+from this website:
+
+- 🔥 [__Single-frame detection__]({{< ref "/spaces/early_forest_fire_detection" >}}) —
+  upload a camera image and watch the detector draw boxes around smoke.
+- 🕐 [__Temporal smoke verification__]({{< ref "/spaces/temporal_smoke_verification" >}}) —
+  the second-stage model that watches whole *sequences*: real wildfires get
+  caught within minutes while clouds, fog, and haze look-alikes are rejected.
+  This is the model that cuts false alarms by 4× in production.
+
+Below, the temporal verifier judging real camera sequences — pick one and
+watch it play:
+
+{{< hf_space "achouffe-temporal-smoke-pyronear" "6.18.0" >}}

--- a/layouts/shortcodes/hf_space.html
+++ b/layouts/shortcodes/hf_space.html
@@ -1,6 +1,6 @@
 <script
   type="module"
-  src="https://gradio.s3-us-west-2.amazonaws.com/5.4.0/gradio.js"
+  src="https://gradio.s3-us-west-2.amazonaws.com/{{ with .Get 1 }}{{ . }}{{ else }}5.4.0{{ end }}/gradio.js"
 ></script>
 <div class="hf-space__gradio margin-bottom margin-top">
   <gradio-app

--- a/layouts/spaces/single.html
+++ b/layouts/spaces/single.html
@@ -49,7 +49,7 @@
     {{/*load the right gradio version*/}}
     <script
       type="module"
-      src="https://gradio.s3-us-west-2.amazonaws.com/5.4.0/gradio.js"
+      src="https://gradio.s3-us-west-2.amazonaws.com/{{ .Params.gradio_js_version | default "5.4.0" }}/gradio.js"
     ></script>
     <gradio-app
             src="https://{{ .Params.hf_space }}.hf.space"


### PR DESCRIPTION
## Summary
- Adds a "Try the Models in Your Browser" section to the Pyronear tool page, embedding the new [temporal-smoke-pyronear](https://huggingface.co/spaces/achouffe/temporal-smoke-pyronear) Gradio space (real sequences, looping animations, verdict-colored tubes, live CPU re-run) and linking the existing single-frame demo.
- New `content/spaces/temporal_smoke_verification.md` page with manual steps.
- The space embed layout + `hf_space` shortcode accept an optional gradio.js version (the new space runs Gradio 6.18; existing pages keep the 5.4.0 default).

Note: the space is hosted under `achouffe` for now (the `earthtoolsmaker` org is at its free CPU quota — `earthtoolsmaker/temporal-smoke-pyronear` exists with identical content, paused). When the org slot frees up, flip `hf_space`/links and restart the org space.

## Test plan
- [x] `hugo` builds cleanly; tool page + both space pages render with correct gradio.js versions
- [x] Check the embedded space loads on the Netlify preview