### PR TITLE
fix(spaces): point bear-detection embeds at the temporary achouffe mirror

### DIFF
--- a/content/posts/how-to-build-a-real-time-bear-detection-system/index.md
+++ b/content/posts/how-to-build-a-real-time-bear-detection-system/index.md
@@ -349,4 +349,4 @@ conflicts across a spectrum of species.
 
 One can try out the model from the [ML Space]({{< ref "/spaces/human_wildlife_bear_conflict" >}}) or directly from the snippet below:
 
-{{< hf_space "earthtoolsmaker-bear-detection" >}}
+{{< hf_space "achouffe-bear-detection" >}}

--- a/content/projects/carpathian-bear-deterrence.md
+++ b/content/projects/carpathian-bear-deterrence.md
@@ -259,4 +259,4 @@ diverse species.
 
 One can try out the model from the [ML Space]({{< ref "/spaces/human_wildlife_bear_conflict" >}}) or directly from the snippet below:
 
-{{< hf_space "earthtoolsmaker-bear-detection" >}}
+{{< hf_space "achouffe-bear-detection" >}}

--- a/content/spaces/human_wildlife_bear_conflict.md
+++ b/content/spaces/human_wildlife_bear_conflict.md
@@ -6,7 +6,7 @@ github_repo: https://github.com/earthtoolsmaker/bear-conservation
 date: 2024-04-03
 hero_image: /images/projects/human_wildlife_conflict_bear/cover.png
 project: /projects/human_wildlife_bear_conflict/
-hf_space: earthtoolsmaker-bear-detection
+hf_space: achouffe-bear-detection
 hf_space_code: https://huggingface.co/spaces/earthtoolsmaker/bear-detection/tree/main
 manual_steps:
   - step_name: Image Selection


### PR DESCRIPTION
## Summary
- `earthtoolsmaker/bear-detection` is paused (org CPU quota), leaving broken embeds on three pages. This flips them to the temporary mirror [`achouffe/bear-detection`](https://huggingface.co/spaces/achouffe/bear-detection) (the duplicate also needed its `sdk_version` aligned to 5.9.1 to build).
- Flip back when the org slot frees — tracked in #28.

## Test plan
- [x] `hugo` builds; all three pages embed `achouffe-bear-detection.hf.space`
- [x] Confirm the mirror space is RUNNING and loads in the Netlify preview