### PR TITLE
feat: use home page hero image on tools, spaces and projects pages

### DIFF
--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Projects
 description: We proudly display collaborative projects crafted with passion, simplicity, and creativity!
-image: '/images/pages/projects/hero.jpg'
+image: '/images/pages/home/hero.jpg'
 ---

--- a/content/spaces/_index.md
+++ b/content/spaces/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Spaces
 description: Interact with our latest ML models applied to conservation problems.
-image: /images/spaces/background.jpg
+image: /images/pages/home/hero.jpg
 ---

--- a/content/tools/_index.md
+++ b/content/tools/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Tools
 description: Browse and download conservation software made with 💙
-image: /images/pages/contact/hero.jpg
+image: /images/pages/home/hero.jpg
 ---


### PR DESCRIPTION
## Summary
- Point the hero image of the **tools**, **spaces** and **projects** list pages to the home page hero (`/images/pages/home/hero.jpg`)
- One-line front-matter change in each section's `_index.md`

## Test Plan
- [x] `hugo` builds cleanly
- [x] Generated `/tools/`, `/spaces/` and `/projects/` pages reference the new hero image and its responsive variants
- [x] Visually checked on the local dev server