### PR TITLE
Redesign buttons with bold offset "ink" style

### DIFF
--- a/assets/sass/0-settings/_color-scheme.scss
+++ b/assets/sass/0-settings/_color-scheme.scss
@@ -46,7 +46,8 @@
 
   --button-color: var(--white);
   --button-background-color: var(--secondary-color);
-  --button-border-color: var(--dark);
+  --button-background-hover: #00444c;
+  --button-shadow-color: var(--dark);
 
   // --border-color: var(--light-gray);
   --border-color: #ede0d4;
@@ -85,7 +86,8 @@
 
   --button-color: var(--dark);
   --button-background-color: var(--light-gray);
-  --button-border-color: var(--light-gray);
+  --button-background-hover: var(--white);
+  --button-shadow-color: var(--light-gray);
 
   --border-color: #252629;
   --border-color-alt: #080b12;

--- a/assets/sass/0-settings/_color-scheme.scss
+++ b/assets/sass/0-settings/_color-scheme.scss
@@ -87,7 +87,7 @@
   --button-color: var(--dark);
   --button-background-color: var(--light-gray);
   --button-background-hover: var(--white);
-  --button-shadow-color: var(--light-gray);
+  --button-shadow-color: var(--gray);
 
   --border-color: #252629;
   --border-color-alt: #080b12;

--- a/assets/sass/0-settings/_color-scheme.scss
+++ b/assets/sass/0-settings/_color-scheme.scss
@@ -45,9 +45,8 @@
   --link-color-hover: var(--dark);
 
   --button-color: var(--white);
-  --button-color-hover: var(--white);
-  --button-background-color: var(--dark);
-  --button-background-hover: var(--primary-color);
+  --button-background-color: var(--secondary-color);
+  --button-border-color: var(--dark);
 
   // --border-color: var(--light-gray);
   --border-color: #ede0d4;
@@ -86,7 +85,7 @@
 
   --button-color: var(--dark);
   --button-background-color: var(--light-gray);
-  --button-background-hover: var(--primary-color);
+  --button-border-color: var(--light-gray);
 
   --border-color: #252629;
   --border-color-alt: #080b12;

--- a/assets/sass/3-modules/_buttons.scss
+++ b/assets/sass/3-modules/_buttons.scss
@@ -1,40 +1,41 @@
 /* Buttons */
 .button {
   display: inline-block;
-  padding: 20px;
-  font-size: 18px;
+  padding: 12px 24px;
+  font-size: 15px;
   font-weight: 700;
-  line-height: 1;
+  line-height: 1.4;
   text-decoration: none;
-  border-radius: 60px;
-  border: 1px solid transparent;
-  outline: none;
+  border-radius: 6px;
+  border: 2px solid var(--button-border-color);
+  box-shadow: 4px 4px 0 var(--button-border-color);
   cursor: pointer;
-  will-change: transform;
-  transition: all .2s;
+  transition: box-shadow .12s ease, transform .12s ease;
   color: var(--button-color);
   background: var(--button-background-color);
 
   &:hover {
-    transform: scale(1.05);
-    color: var(--button-color-hover);
-    background: var(--button-background-hover);
+    transform: translate(3px, 3px);
+    box-shadow: 1px 1px 0 var(--button-border-color);
+  }
+
+  &:active {
+    transform: translate(4px, 4px);
+    box-shadow: 0 0 0 var(--button-border-color);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--secondary-color);
+    outline-offset: 2px;
   }
 
   &--secondary {
-    border: 1px solid var(--button-background-color);
-    color: var(--button-background-color);
-    background: transparent;
-
-    &:hover {
-      border-color: var(--button-background-hover);
-      color: var(--button-background-hover);
-      background: transparent;
-    }
+    color: var(--dark);
+    background: var(--white);
   }
 
   &--middle {
-    padding: 20px 40px;
+    padding: 12px 40px;
   }
 
   &--big {
@@ -43,18 +44,8 @@
   }
 
   &--cta {
-    color: var(--white);
-    background-color: var(--secondary-color);
-    border-radius: 20px;
-
-    &:hover {
-      color: var(--dark);
-      background-color: var(--primary-color);
-    }
-  }
-
-  @media (max-width: $tablet) {
-    font-size: 16px;
+    color: var(--dark);
+    background-color: var(--tertiary-color);
   }
 }
 

--- a/assets/sass/3-modules/_buttons.scss
+++ b/assets/sass/3-modules/_buttons.scss
@@ -18,6 +18,7 @@
     transform: translate(3px, 3px);
     box-shadow: 1px 1px 0 var(--button-shadow-color);
     background: var(--button-background-hover);
+    color: var(--button-color);
   }
 
   &:active {
@@ -36,6 +37,7 @@
 
     &:hover {
       background: #f0f0f0;
+      color: var(--secondary-color);
     }
   }
 
@@ -54,6 +56,7 @@
 
     &:hover {
       background-color: #d77f5e;
+      color: var(--dark);
     }
   }
 }

--- a/assets/sass/3-modules/_buttons.scss
+++ b/assets/sass/3-modules/_buttons.scss
@@ -7,21 +7,22 @@
   line-height: 1.4;
   text-decoration: none;
   border-radius: 6px;
-  border: 2px solid var(--button-border-color);
-  box-shadow: 4px 4px 0 var(--button-border-color);
+  border: none;
+  box-shadow: 4px 4px 0 var(--button-shadow-color);
   cursor: pointer;
-  transition: box-shadow .12s ease, transform .12s ease;
+  transition: box-shadow .12s ease, transform .12s ease, background .12s ease, color .12s ease;
   color: var(--button-color);
   background: var(--button-background-color);
 
   &:hover {
     transform: translate(3px, 3px);
-    box-shadow: 1px 1px 0 var(--button-border-color);
+    box-shadow: 1px 1px 0 var(--button-shadow-color);
+    background: var(--button-background-hover);
   }
 
   &:active {
     transform: translate(4px, 4px);
-    box-shadow: 0 0 0 var(--button-border-color);
+    box-shadow: 0 0 0 var(--button-shadow-color);
   }
 
   &:focus-visible {
@@ -30,8 +31,12 @@
   }
 
   &--secondary {
-    color: var(--dark);
+    color: var(--secondary-color);
     background: var(--white);
+
+    &:hover {
+      background: #f0f0f0;
+    }
   }
 
   &--middle {
@@ -46,6 +51,10 @@
   &--cta {
     color: var(--dark);
     background-color: var(--tertiary-color);
+
+    &:hover {
+      background-color: #d77f5e;
+    }
   }
 }
 

--- a/assets/sass/3-modules/_subscribe.scss
+++ b/assets/sass/3-modules/_subscribe.scss
@@ -89,11 +89,11 @@
       height: 50px;
       font-size: 0;
       border-radius: 50%;
-      border: none;
-      outline: none;
+      border: 2px solid var(--button-border-color);
+      box-shadow: 2px 2px 0 var(--button-border-color);
       color: var(--button-color);
       background: var(--button-background-color);
-      transition: all .2s;
+      transition: box-shadow .12s ease, transform .12s ease;
       cursor: pointer;
 
       i {
@@ -101,8 +101,13 @@
       }
 
       &:hover {
-        color: var(--button-color-hover);
-        background: var(--button-background-hover);
+        transform: translate(2px, 2px);
+        box-shadow: 0 0 0 var(--button-border-color);
+      }
+
+      &:focus-visible {
+        outline: 2px solid var(--secondary-color);
+        outline-offset: 2px;
       }
     }
   }

--- a/assets/sass/3-modules/_subscribe.scss
+++ b/assets/sass/3-modules/_subscribe.scss
@@ -89,11 +89,11 @@
       height: 50px;
       font-size: 0;
       border-radius: 50%;
-      border: 2px solid var(--button-border-color);
-      box-shadow: 2px 2px 0 var(--button-border-color);
+      border: none;
+      box-shadow: 2px 2px 0 var(--button-shadow-color);
       color: var(--button-color);
       background: var(--button-background-color);
-      transition: box-shadow .12s ease, transform .12s ease;
+      transition: box-shadow .12s ease, transform .12s ease, background .12s ease;
       cursor: pointer;
 
       i {
@@ -102,7 +102,8 @@
 
       &:hover {
         transform: translate(2px, 2px);
-        box-shadow: 0 0 0 var(--button-border-color);
+        box-shadow: 0 0 0 var(--button-shadow-color);
+        background: var(--button-background-hover);
       }
 
       &:focus-visible {

--- a/assets/sass/4-layouts/_post.scss
+++ b/assets/sass/4-layouts/_post.scss
@@ -224,13 +224,7 @@
   }
 
   .button {
-    border: none;
     text-decoration: none;
-
-    &:hover {
-      color: var(--button-color-hover);
-      background: var(--button-background-hover);
-    }
   }
 }
 

--- a/assets/sass/4-layouts/_post.scss
+++ b/assets/sass/4-layouts/_post.scss
@@ -223,9 +223,6 @@
     user-select: none;
   }
 
-  .button {
-    text-decoration: none;
-  }
 }
 
 /* Post Share */

--- a/assets/sass/4-layouts/_post.scss
+++ b/assets/sass/4-layouts/_post.scss
@@ -193,7 +193,7 @@
 .page__content {
   color: var(--text-color);
 
-  a {
+  a:not(.button) {
     font-weight: 700;
     border-bottom: 1px solid var(--border-color);
 

--- a/assets/sass/4-layouts/_project.scss
+++ b/assets/sass/4-layouts/_project.scss
@@ -70,7 +70,7 @@
   color: var(--text-color);
   margin-bottom: 80px;
 
-  a {
+  a:not(.button) {
     font-weight: 500;
     border-bottom: 1px solid var(--border-color);
 

--- a/assets/sass/4-layouts/_space.scss
+++ b/assets/sass/4-layouts/_space.scss
@@ -92,7 +92,7 @@
 
   // Gradio container styles moved to 3-modules/_gradio-reset.scss
 
-  a {
+  a:not(.button) {
     font-weight: 500;
     border-bottom: 1px solid var(--border-color);
 

--- a/assets/sass/4-layouts/_support.scss
+++ b/assets/sass/4-layouts/_support.scss
@@ -160,6 +160,11 @@
       background-color: var(--accent-color);
       color: var(--secondary-color);
     }
+
+    // the band shares the buttons' teal focus ring color
+    &:focus-visible {
+      outline-color: var(--white);
+    }
   }
 
   .button--ghost {
@@ -167,9 +172,13 @@
     color: var(--white);
     box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.7);
 
-    &:hover {
+    // the inset ring replaces the offset shadow, so there is nothing to
+    // press into — disable the press motion
+    &:hover,
+    &:active {
       background-color: rgba(255, 255, 255, 0.12);
       color: var(--white);
+      transform: none;
     }
   }
 

--- a/assets/sass/4-layouts/_tool.scss
+++ b/assets/sass/4-layouts/_tool.scss
@@ -23,24 +23,6 @@
   flex-wrap: wrap;
   margin-top: 4rem;
   margin-bottom: 4rem;
-
-  .button {
-    padding-top: 1.125rem;
-    padding-bottom: 1.125rem;
-    padding-left: 2rem;
-    padding-right: 2rem;
-    border-radius: 6px;
-  }
-
-  .tool-button-cta {
-    background-color: var(--secondary-color);
-    color: var(--white);
-  }
-
-  .tool-button-cta:hover {
-    background-color: var(--primary-color);
-    color: var(--dark);
-  }
 }
 
 

--- a/docs/specs/2026-06-12-button-redesign-design.md
+++ b/docs/specs/2026-06-12-button-redesign-design.md
@@ -1,0 +1,82 @@
+# Button Redesign: "Full Ink"
+
+**Date:** 2026-06-12
+**Status:** Approved
+
+## Goal
+
+Replace the current button styles (oversized dark pills with a scale-up hover) with a
+bold "Full Ink" style: inked border, hard offset shadow, press-in hover. Chosen by the
+user from rendered design directions during brainstorming.
+
+## Core style
+
+Applies to `.button` in `assets/sass/3-modules/_buttons.scss` (full rewrite of the
+file's button rules):
+
+- Border: `2px solid #161616` (use `var(--dark)`)
+- Corner radius: `6px`
+- Shadow: `4px 4px 0 #161616` (hard offset, no blur)
+- Padding: `12px 24px`; font-size `15px`; font-weight `700`; line-height `1.4`
+- Transition: `box-shadow .12s ease, transform .12s ease`
+- **Hover (press-in):** `transform: translate(3px, 3px)`; shadow shrinks to `1px 1px 0`
+- **Active (full press):** `transform: translate(4px, 4px)`; shadow `0 0 0` (gone)
+- **Focus:** replace the current `outline: none` with a visible `:focus-visible`
+  outline (e.g. `2px solid var(--secondary-color)` with `2px` offset) for keyboard
+  accessibility
+
+## Variants
+
+Class names are unchanged — no template or content edits needed for the core system.
+
+| Class | Background | Text |
+|---|---|---|
+| `.button` (default) | deep teal `#006d77` (`--secondary-color`) | white |
+| `.button--secondary` | white | dark `#161616` |
+| `.button--cta` | terracotta `#e29578` (`--tertiary-color`) | dark `#161616` |
+
+- `.button--middle` — pure size modifier: wider horizontal padding (`12px 40px`)
+- `.button--big` — unchanged: `display: block; width: 100%`
+- All variants share the same border, shadow, and hover/active/focus behavior.
+
+## Color variables
+
+Button colors stay wired through CSS variables in
+`assets/sass/0-settings/_color-scheme.scss`:
+
+- `--button-color: var(--white)`
+- `--button-background-color: var(--secondary-color)` (was `--dark`)
+- The hover no longer changes colors, so `--button-color-hover` /
+  `--button-background-hover` are removed along with their usages
+  (`_buttons.scss`, `_subscribe.scss`). New variable: `--button-border-color: var(--dark)`,
+  also used for the shadow color.
+- The `:root[dark]` block gets the same treatment for consistency, but dark mode is
+  disabled site-wide (`color_scheme = "light"` in config.toml), so no separate dark
+  design is required.
+
+## Stragglers (full-coverage scope)
+
+1. **Tool page CTAs** — `assets/sass/4-layouts/_tool.scss`
+   (`.tool-container-button-cta`): delete the nested `.button` padding/radius
+   overrides and the `.tool-button-cta` color overrides so the buttons inherit the
+   new standard styles. The flex container layout rules stay.
+2. **Subscribe icon button** — `assets/sass/3-modules/_subscribe.scss`
+   (`.subscribe-button`): keeps its 50px circle (`border-radius: 50%`) and absolute
+   position, but gets the ink treatment: `2px solid var(--dark)` border, `2px 2px 0`
+   offset shadow, press-in hover (`translate(2px, 2px)`, shadow `0 0 0`), teal
+   background.
+
+## Out of scope
+
+- No template (`layouts/`) or content (`content/`) changes.
+- No changes to nav links, tags, cards, or other non-button interactive elements.
+- The `.link-no-decoration` helper and `.button--cta-container` layout block in
+  `_buttons.scss` stay as-is.
+
+## Verification
+
+1. `hugo` builds with no errors.
+2. Visual pass on `hugo -D server`: home page (hero buttons, services "Start a
+   project", timeline), a tool page (Biowatch CTAs), a project page, the subscribe
+   form, blog pagination ("Load More Posts"), and the donate/sponsor CTA shortcode.
+3. Hover, active, and keyboard-focus states behave as specced on each variant.

--- a/docs/specs/2026-06-12-button-redesign-design.md
+++ b/docs/specs/2026-06-12-button-redesign-design.md
@@ -12,14 +12,16 @@ user from rendered design directions during brainstorming.
 ## Core style
 
 Applies to `.button` in `assets/sass/3-modules/_buttons.scss` (full rewrite of the
-file's button rules):
+file's button rules). Revised 2026-06-12 after a second visual iteration: borderless,
+with a hover color change ("Borderless + hover darkens").
 
-- Border: `2px solid #161616` (use `var(--dark)`)
+- No border
 - Corner radius: `6px`
-- Shadow: `4px 4px 0 #161616` (hard offset, no blur)
+- Shadow: `4px 4px 0 #161616` (hard offset, no blur) — the shadow alone defines the edge
 - Padding: `12px 24px`; font-size `15px`; font-weight `700`; line-height `1.4`
-- Transition: `box-shadow .12s ease, transform .12s ease`
-- **Hover (press-in):** `transform: translate(3px, 3px)`; shadow shrinks to `1px 1px 0`
+- Transition: `box-shadow .12s ease, transform .12s ease, background .12s ease, color .12s ease`
+- **Hover (press-in + darken):** `transform: translate(3px, 3px)`; shadow shrinks to
+  `1px 1px 0`; background darkens (per-variant colors below)
 - **Active (full press):** `transform: translate(4px, 4px)`; shadow `0 0 0` (gone)
 - **Focus:** replace the current `outline: none` with a visible `:focus-visible`
   outline (e.g. `2px solid var(--secondary-color)` with `2px` offset) for keyboard
@@ -29,11 +31,11 @@ file's button rules):
 
 Class names are unchanged — no template or content edits needed for the core system.
 
-| Class | Background | Text |
-|---|---|---|
-| `.button` (default) | deep teal `#006d77` (`--secondary-color`) | white |
-| `.button--secondary` | white | dark `#161616` |
-| `.button--cta` | terracotta `#e29578` (`--tertiary-color`) | dark `#161616` |
+| Class | Background | Text | Hover background |
+|---|---|---|---|
+| `.button` (default) | deep teal `#006d77` (`--secondary-color`) | white | darker teal `#00444c` |
+| `.button--secondary` | white | deep teal `#006d77` | light gray `#f0f0f0` |
+| `.button--cta` | terracotta `#e29578` (`--tertiary-color`) | dark `#161616` | deeper terracotta `#d77f5e` |
 
 - `.button--middle` — pure size modifier: wider horizontal padding (`12px 40px`)
 - `.button--big` — unchanged: `display: block; width: 100%`
@@ -46,10 +48,10 @@ Button colors stay wired through CSS variables in
 
 - `--button-color: var(--white)`
 - `--button-background-color: var(--secondary-color)` (was `--dark`)
-- The hover no longer changes colors, so `--button-color-hover` /
-  `--button-background-hover` are removed along with their usages
-  (`_buttons.scss`, `_subscribe.scss`). New variable: `--button-border-color: var(--dark)`,
-  also used for the shadow color.
+- `--button-background-hover: #00444c` (darker teal; variant hover colors are set
+  directly in the variant rules). `--button-color-hover` is removed along with its
+  usages (`_buttons.scss`, `_subscribe.scss`).
+- New variable: `--button-shadow-color: var(--dark)` for the offset shadow.
 - The `:root[dark]` block gets the same treatment for consistency, but dark mode is
   disabled site-wide (`color_scheme = "light"` in config.toml), so no separate dark
   design is required.
@@ -62,9 +64,9 @@ Button colors stay wired through CSS variables in
    new standard styles. The flex container layout rules stay.
 2. **Subscribe icon button** — `assets/sass/3-modules/_subscribe.scss`
    (`.subscribe-button`): keeps its 50px circle (`border-radius: 50%`) and absolute
-   position, but gets the ink treatment: `2px solid var(--dark)` border, `2px 2px 0`
-   offset shadow, press-in hover (`translate(2px, 2px)`, shadow `0 0 0`), teal
-   background.
+   position, but gets the ink treatment: borderless, `2px 2px 0` offset shadow,
+   press-in hover (`translate(2px, 2px)`, shadow `0 0 0`, background darkens to
+   `var(--button-background-hover)`), teal background.
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary
- Rewrites the core `.button` system: borderless faces with a hard 4px offset shadow, 6px radius, smaller sizing (15px / 12px-24px padding), and a press-in hover that also darkens the background (teal → darker teal, white → light gray, terracotta → deeper terracotta)
- Adds proper `:active` (full press) and `:focus-visible` (keyboard outline) states, replacing the old `outline: none`
- Maps variants to the site palette: default teal `#006d77`, secondary white with teal text, CTA terracotta `#e29578`
- Removes local button overrides so everything inherits the new style: tool-page CTAs, post-content buttons, and the subscribe icon button (keeps its circle, gets the ink shadow)
- Excludes buttons from generic content-link styling (`a:not(.button)` in post/page/project/space content), fixing dark-text-on-hover for buttons rendered as links inside content areas
- Design spec committed at `docs/specs/2026-06-12-button-redesign-design.md`

## Test Plan
- [ ] `hugo` builds clean
- [ ] Home hero: teal primary + white secondary, hover presses in and darkens, text stays readable
- [ ] `/about/`: "Start a project" / "Support our work" keep white text on hover
- [ ] `/tools/biowatch/` and `/projects/biowatch-app/`: CTAs inherit the new style
- [ ] `/posts/volunteering_wildlife_rescue_centers/`: in-content donation buttons keep their shadow edge
- [ ] `/support/`: CTA band buttons (white + ghost) still render their intentional local style
- [ ] Keyboard: Tab shows teal focus ring; click shows full press