### PR TITLE
feat(header): replace social icons with Support button

### DIFF
--- a/assets/sass/3-modules/_header.scss
+++ b/assets/sass/3-modules/_header.scss
@@ -333,8 +333,13 @@
   padding-top: 40px;
 
   .button {
-    padding: 12px 24px;
-    font-size: 16px;
+    color: var(--dark);
+    background: var(--tertiary-color);
+
+    &:hover {
+      color: var(--dark);
+      background: #c97a5c;
+    }
   }
 
   @media (max-width: $desktop) {

--- a/assets/sass/3-modules/_header.scss
+++ b/assets/sass/3-modules/_header.scss
@@ -328,12 +328,19 @@
   }
 }
 
-.social-nav {
+.header__cta {
   justify-self: end;
   padding-top: 40px;
 
+  .button {
+    padding: 12px 24px;
+    font-size: 16px;
+  }
+
   @media (max-width: $desktop) {
-    display: none;
+    margin-left: auto;
+    margin-right: 16px;
+    padding-top: 32px;
   }
 }
 
@@ -350,6 +357,7 @@
     display: flex;
     align-items: center;
     padding-top: 32px;
+    order: 1;
   }
 }
 

--- a/assets/sass/3-modules/_social.scss
+++ b/assets/sass/3-modules/_social.scss
@@ -1,10 +1,4 @@
 /* Social */
-.social-nav {
-  @media (max-width: $desktop) {
-    display: none;
-  }
-}
-
 .social-footer {
   margin-left: 0px;
 }

--- a/config.toml
+++ b/config.toml
@@ -70,11 +70,6 @@ pagerSize = 6
     weight = 4
 
   [[menu.main]]
-    name = "Support"
-    url = "/support/"
-    weight = 5
-
-  [[menu.main]]
     name = "Contact"
     url = "/contact/"
     weight = 6

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -65,11 +65,9 @@
           </div>
         </nav>
 
-        {{ if .Site.Params.social }}
-        <div class="social-nav">
-          {{ partial "social-links.html" . }}
+        <div class="header__cta">
+          <a class="button" href="{{ "/support/" | relLangURL }}">Support</a>
         </div>
-        {{ end }}
 
       </div>
     </div>


### PR DESCRIPTION
## What

Replaces the GitHub/HuggingFace icons in the header with a **Support** button pinned to the top right.

## Changes

- `layouts/partials/header.html` — swap the `social-nav` icon block for a `header__cta` div with a Support button linking to `/support/`
- `config.toml` — remove the now-redundant Support entry from the main nav menu (footer menu unchanged)
- `assets/sass/3-modules/_header.scss` — style the button in the tertiary terracotta (`--tertiary-color`) with dark text (white fails contrast on this shade) and a darker-terracotta hover, since the site-wide dark-teal hover clashed; unlike the old icons, the button stays visible on mobile, sitting left of the hamburger
- `assets/sass/3-modules/_social.scss` — drop the orphaned `.social-nav` rule (footer social icons untouched, so GitHub/HF stay reachable there)

## Notes

- Rebased on top of #38, so the button inherits the redesigned shadow/press interaction
- Verified via static build screenshots at 1600/800/420/375px widths, including the open hamburger menu state (overlay cleanly covers the button)