### PR TITLE
Move Pyronear end-to-end demo video to top of tool page

### DIFF
--- a/content/tools/pyronear/index.md
+++ b/content/tools/pyronear/index.md
@@ -20,6 +20,16 @@ date: 2025-05-01
   </a>
 </div>
 
+The video below, filmed in the Forest of Fontainebleau, shows how the system
+works end to end: a firefighter walks through the full pipeline, from the
+cameras spotting the first signs of smoke to the alert reaching the fire
+department.
+
+<p><iframe src="https://www.youtube.com/embed/W3DxacGsdks" loading="lazy" frameborder="0" allowfullscreen style="width:100%;height:auto;aspect-ratio:16/9;"></iframe></p>
+<em style="font-size:14px;line-height:1.4em;display:block;">End-to-end demonstration of the Pyronear system in the Forest of Fontainebleau
+</em>
+<br/>
+
 ## Wildfire Early Real Time Detection System
 
 Pyronear is a complete fire risk management solution. It consists of an early
@@ -45,16 +55,6 @@ showcases recent fire alerts and enhances fire management efficiency for fire
 departments.
 
 ## See Pyronear in Action
-
-The video below, filmed in the Forest of Fontainebleau, shows how the system
-works end to end: a firefighter walks through the full pipeline, from the
-cameras spotting the first signs of smoke to the alert reaching the fire
-department.
-
-<p><iframe src="https://www.youtube.com/embed/W3DxacGsdks" loading="lazy" frameborder="0" allowfullscreen style="width:100%;height:auto;aspect-ratio:16/9;"></iframe></p>
-<em style="font-size:14px;line-height:1.4em;display:block;">End-to-end demonstration of the Pyronear system in the Forest of Fontainebleau
-</em>
-<br/>
 
 The computer vision model detected a forest fire in Fontainebleau from a
 distance of 35 kilometers in real time, setting a new record for the Pyronear


### PR DESCRIPTION
## What

Moves the end-to-end demo video ("Our Work with Pyronear: AI wildfire in Action", filmed in the Forest of Fontainebleau) to the top of the Pyronear tool page, right after the **Visit Pyronear** CTA button and ahead of all headings.

The video's caption and its descriptive paragraph move with it, since that paragraph specifically describes the end-to-end pipeline shown in this video.

## Page order now

1. Visit Pyronear button
2. End-to-end demo video ← moved here
3. Wildfire Early Real Time Detection System (intro + carousel)
4. Key Features
5. See Pyronear in Action (35 km detection video)
6. Try the Models in Your Browser

Net change: 10 lines moved, no other edits.