### PR TITLE
feat(tools): reorder tool cards

### DIFF
--- a/content/tools/animal-reid/index.md
+++ b/content/tools/animal-reid/index.md
@@ -1,5 +1,6 @@
 ---
 title: Animal reID
+weight: 40
 show_title: true
 button_cta: Try Demo
 icon: /images/logos/reid-icon.png

--- a/content/tools/biowatch/index.md
+++ b/content/tools/biowatch/index.md
@@ -1,5 +1,6 @@
 ---
 title: Biowatch
+weight: 30
 show_title: true
 button_cta: Download and Install
 icon: /images/logos/biowatch-icon.png

--- a/content/tools/pyronear/index.md
+++ b/content/tools/pyronear/index.md
@@ -1,5 +1,6 @@
 ---
 title: Pyronear
+weight: 10
 show_title: false
 button_cta: Visit Pyronear
 icon: /images/logos/pyronear_logo_letters.png

--- a/content/tools/salmonvision/index.md
+++ b/content/tools/salmonvision/index.md
@@ -1,5 +1,6 @@
 ---
 title: SalmonVision
+weight: 20
 show_title: false
 button_cta: Visit SalmonVision
 icon: /images/logos/salmon-vision-logo.svg


### PR DESCRIPTION
Reorders the tool cards on the Tools page to: **Pyronear → SalmonVision → Biowatch → Animal reID**.

## Change
- Added `weight` front matter to each tool (Pyronear `10`, SalmonVision `20`, Biowatch `30`, Animal reID `40`).
- `layouts/tools/list.html` uses Hugo's default page sort, which honors `weight` first — no template change needed. Previously the cards fell back to date ordering.

## Verification
Static `hugo` build confirms the rendered order in `public/tools/index.html`:
Pyronear, SalmonVision, Biowatch, Animal reID.