### PR TITLE
feat(home): hide Explore Topics section

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -332,7 +332,7 @@ pagerSize = 6
   #-------------------------------
   # Tags Section
   [params.tags]
-    enable = true
+    enable = false
     tags_title = "✌️ Explore Topics"
 
 


### PR DESCRIPTION
Hides the Explore Topics (tags) section from the homepage.

## Change
Flips `params.tags.enable` from `true` to `false` in `config.toml` — the documented section-toggle pattern. The `section-tags.html` partial is gated on this flag, so it now renders nothing on the homepage.

## Verification
Fresh `hugo` build succeeds and `public/index.html` contains zero references to the section.