### PR TITLE
Lighter, minimal blog cards

### DIFF
--- a/assets/sass/3-modules/_article.scss
+++ b/assets/sass/3-modules/_article.scss
@@ -1,40 +1,29 @@
 /* Article */
 .article {
+  display: flex;
+  flex-direction: column;
   margin-bottom: 32px;
 }
 
 .article__content {
   position: relative;
-  border-radius: 22px;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  padding: 14px;
+  border-radius: 16px;
+  background: var(--background-alt-color);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 6px 26px rgba(0, 0, 0, 0.05);
   will-change: transform;
   transition: transform .3s ease;
 
   &:hover {
     transform: translateY(-8px);
-
-    .article__title a {
-      text-decoration-color: var(--primary-color);
-    }
-
-    @media (min-width: $tablet + 1) {
-      .article__image img {
-        -webkit-filter: grayscale(0%);
-        filter: grayscale(0%);
-      }
-    }
   }
-}
-
-.article__head {
-  position: relative;
-  display: block;
-  padding: 18px;
-  border-radius: 22px;
-  background: #ede0d4;
-  transition: transform .3s ease;
 
   @media (max-width: $mobile) {
-    padding: 16px;
+    padding: 12px;
   }
 }
 
@@ -42,28 +31,11 @@
   position: relative;
   display: block;
   width: 100%;
-  height: 100%;
-  border-radius: 9px;
+  border-radius: 10px;
   user-select: none;
   transform: translate(0);
   overflow: hidden;
-  box-shadow: 0px 5px 40px rgba(0, 0, 0, 0.1);
   background-color: var(--background-color);
-
-  &::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background:
-      linear-gradient(180deg, rgba(0, 0, 0, 0.7) 0%, rgba(0, 0, 0, 0) 35%),
-      linear-gradient(180deg, rgba(0, 0, 0, 0) 60%, rgba(0, 0, 0, 0.7) 100%);
-    border-radius: 9px;
-    z-index: 1;
-    pointer-events: none;
-  }
 
   &::after {
     content: "";
@@ -79,44 +51,34 @@
     height: 100%;
     object-fit: cover;
     pointer-events: none;
-
-    @media (min-width: $tablet + 1) {
-      -webkit-filter: grayscale(50%);
-      filter: grayscale(50%);
-      transition: filter 0.3s ease;
-    }
   }
 }
 
 .article__inner {
-  margin: 20px 20px 0;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  margin: 16px 6px 2px;
   line-height: 1;
 
-  @media (max-width: $desktop) {
-    margin: 20px 20px 0;
-  }
-
   @media (max-width: $mobile) {
-    margin: 16px 16px 0;
+    margin: 14px 4px 2px;
   }
 }
 
 .article__info {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+
   .article__title {
     margin-bottom: 8px;
-    font-size: 32px;
+    padding-left: 12px;
+    border-left: 3px solid var(--tertiary-color);
+    font-size: 18px;
     line-height: 1.2;
 
     a {
-      text-decoration: underline;
-      text-decoration-color: transparent;
-      text-decoration-thickness: 2px;
-      text-underline-offset: 3px;
-
-      &:hover {
-        text-decoration-color: var(--primary-color);
-      }
-
       &::after {
         content: "";
         position: absolute;
@@ -125,90 +87,28 @@
         right: 0;
         bottom: 0;
         z-index: 1;
-        border-radius: 22px;
+        border-radius: 16px;
       }
-    }
-
-    @media (max-width: $desktop) {
-      font-size: 30px;
-    }
-
-    @media (max-width: $mobile) {
-      font-size: 26px;
     }
   }
 
   .article__excerpt {
     display: -webkit-box;
     margin-bottom: 0;
-    font-size: 16px;
-    line-height: 1.6;
+    font-size: 14.5px;
+    line-height: 1.55;
+    color: var(--text-alt-color);
     overflow-y: hidden;
-    -webkit-line-clamp: 3;
+    -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
   }
-}
 
-.article__meta {
-  position: absolute;
-  top: 20px;
-  right: 24px;
-  z-index: 2;
-  text-align: right;
-  font-size: 0;
-
-  @media (max-width: $mobile) {
-    top: 16px;
-    right: 20px;
-  }
-
-  .article__date,
-  .article__minutes {
-    font-size: 13px;
+  .article__date {
+    display: block;
+    margin-top: auto;
+    padding-top: 10px;
+    font-size: 12.5px;
     font-weight: 600;
-    line-height: 1.3;
-    color: var(--white);
-    transition: none;
-  }
-}
-
-.article-tags__box {
-  position: absolute;
-  bottom: 20px;
-  left: 0;
-  right: 0;
-  display: flex;
-  flex-wrap: wrap;
-  padding: 0 24px;
-  z-index: 2;
-
-  @media (max-width: $mobile) {
-    bottom: 16px;
-    padding: 0 20px;
-  }
-
-  .article__tag {
-    position: relative;
-    display: inline-block;
-    padding: 5px 10px;
-    margin: 0 4px 4px 0;
-    font-size: 12px;
-    line-height: 1.3;
-    font-weight: 700;
-    text-transform: capitalize;
-    border: 1px solid var(--white);
-    border-radius: 5px;
-    pointer-events: all;
-    color: var(--white);
-    background-color: transparent;
-
-    &:hover {
-      color: var(--dark);
-      background-color: var(--white);
-    }
-
-    &:last-child {
-      margin: 0 0 4px 0;
-    }
+    color: var(--text-alt-color);
   }
 }

--- a/content/posts/_index.md
+++ b/content/posts/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Blog
-description: Explore our newest achievements and ongoing projects as we share insights into conservation methods. 
+description: Stories from the field and under the hood — how open technology helps protect wildlife and the planet.
 image: '/images/projects-hero.jpg'
 ---

--- a/docs/specs/2026-06-13-blog-card-redesign-design.md
+++ b/docs/specs/2026-06-13-blog-card-redesign-design.md
@@ -1,0 +1,81 @@
+# Blog Card Redesign
+
+**Date:** 2026-06-13
+**Status:** Approved
+
+## Problem
+
+The blog post cards (homepage blog section and `/posts` listing) feel dark and
+overpacked. Each card overlays the date, read time, and a row of tag pills
+directly on the cover image, which requires two dark gradient overlays plus a
+50% grayscale filter on the photo to keep the white text legible. The result is
+muddy, dim imagery and a card crowded with competing information.
+
+## Goal
+
+A lighter, calmer, more editorial card: a clean full-color photo and a clear
+text block beneath it. Less information per card, better visual hierarchy.
+
+## Decisions
+
+- **Image:** clean and full color. Remove both dark gradient overlays and the
+  grayscale filter. Keep the current landscape aspect ratio and rounded corners.
+- **Removed entirely:** read time (`· N min read`), tags, and the
+  date/tags-on-image overlays.
+- **Moved below the image:** the date, shown as quiet muted text.
+- **Layout direction:** white/light bordered card panel wrapping image + text
+  (the "minimal + accent" direction), with a thin terracotta accent rule on the
+  title.
+
+## Design
+
+### Card structure (top to bottom), all inside one bordered panel
+
+1. **Cover image** — full color, no overlays, no grayscale. Rounded corners,
+   current landscape ratio preserved.
+2. **Title** — Newsreader serif, weight 600, **18px**, line-height ~1.2, with a
+   **3px terracotta left accent rule** (`--tertiary-color`), ~12px left padding.
+3. **Excerpt** — Mulish, ~14.5px, muted gray, clamped to **2 lines**.
+4. **Date** — ~12.5px, weight 600, muted gray (e.g. `12 Jun, 2026`).
+
+### Panel styling
+
+- Surface, border, and text colors map to existing brand CSS variables so the
+  card adapts to the site's dark-mode toggle:
+
+  | Element        | Light (value)      | Dark (value) | Variable                  |
+  |----------------|--------------------|--------------|---------------------------|
+  | Card surface   | near-white `#fbf6f6` | `#1a1a1f`  | `--background-alt-color`  |
+  | Border (1px)   | sand `#ede0d4`     | `#252629`    | `--border-color`          |
+  | Title          | `#161616`          | `#f0f0f0`    | `--heading-font-color`    |
+  | Excerpt / date | `#60626a`          | `#9e9e9e`    | `--text-alt-color`        |
+  | Accent rule    | terracotta `#e29578` | (same)     | `--tertiary-color`        |
+
+- Soft shadow `0 6px 26px rgba(0, 0, 0, .05)`, border-radius 16px, padding 14px.
+
+### Hover
+
+- Keep the existing lift (`transform: translateY(...)`).
+- Whole card remains clickable via the title link's full-card `::after` overlay.
+
+## Files touched
+
+- `layouts/partials/article.html` — restructure markup: wrap image + text in one
+  panel; drop the `article__meta` (date/read-time) overlay, the
+  `article-tags__box` overlay, and the read-time span; render the date beneath
+  the title/excerpt instead.
+- `layouts/partials/related-posts.html` — the "You may also like" cards on post
+  pages reuse the same `article__` classes, so apply the identical markup
+  restructure here for visual consistency (and to avoid emitting now-unstyled
+  overlay/tag markup).
+- `assets/sass/3-modules/_article.scss` — restyle per above; remove the image
+  gradient `::before` overlay and the grayscale filter rules; remove now-unused
+  overlay/tag styles.
+
+Grid columns (`col-4 col-w-6 col-t-12` for the blog grid, `col-6 col-t-12` for
+related posts) and the blog section partial are unchanged.
+
+## Out of scope
+
+- Tag/category display on cards (tags remain accessible on the post page itself).
+- Project cards (`project-card.html`) and other card types.

--- a/layouts/partials/article.html
+++ b/layouts/partials/article.html
@@ -1,30 +1,17 @@
 <article class="article col col-4 col-w-6 col-t-12">
   <div class="article__content">
     {{ if .Params.Image }}
-    <div class="article__head">
-      <div class="article__image">
-        {{/* Convert /images/... to images/... for assets lookup */}}
-        {{ $imgPath := strings.TrimPrefix "/" .Params.Image }}
-        {{ partial "responsive-image.html" (dict
-          "src" $imgPath
-          "alt" .Title
-          "sizes" "(max-width: 600px) 100vw, (max-width: 900px) 50vw, 400px"
-          "widths" (slice 400 600 800)
-          "lazy" true
-          "lqip" true
-        ) }}
-      </div>
-      {{ if .Params.tags }}
-      <div class="article-tags__box">
-      {{ range ($.GetTerms "tags") }}
-        <a href="{{ .Permalink }}" class="article__tag">{{ .LinkTitle }}</a>
-      {{ end }}
-      </div>
-      {{ end }}
-      <div class="article__meta">
-        <time class="article__date" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format "2 Jan, 2006" }}</time>
-        <span class="article__minutes">· {{ .ReadingTime }} min read</span>
-      </div>
+    <div class="article__image">
+      {{/* Convert /images/... to images/... for assets lookup */}}
+      {{ $imgPath := strings.TrimPrefix "/" .Params.Image }}
+      {{ partial "responsive-image.html" (dict
+        "src" $imgPath
+        "alt" .Title
+        "sizes" "(max-width: 600px) 100vw, (max-width: 900px) 50vw, 400px"
+        "widths" (slice 400 600 800)
+        "lazy" true
+        "lqip" true
+      ) }}
     </div>
     {{ end }}
     <div class="article__inner">
@@ -35,6 +22,7 @@
         {{ if .Params.description }}
         <p class="article__excerpt">{{ .Params.description }}</p>
         {{ end }}
+        <time class="article__date" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format "2 Jan, 2006" }}</time>
       </div>
     </div>
   </div>

--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -16,29 +16,16 @@
         <div class="article col col-6 col-t-12 animate">
           <div class="article__content">
             {{ if .Params.Image }}
-            <div class="article__head">
-              <div class="article__image">
-                {{ $imgPath := strings.TrimPrefix "/" .Params.Image }}
-                {{ partial "responsive-image.html" (dict
-                  "src" $imgPath
-                  "alt" .Title
-                  "sizes" "(max-width: 600px) 100vw, (max-width: 900px) 50vw, 400px"
-                  "widths" (slice 400 600 800)
-                  "lazy" true
-                  "lqip" true
-                ) }}
-              </div>
-              {{ if .Params.tags }}
-              <div class="article-tags__box">
-                {{ range (.GetTerms "tags") }}
-                  <a href="{{ .Permalink }}" class="article__tag">{{ .LinkTitle }}</a>
-                {{ end }}
-              </div>
-              {{ end }}
-              <div class="article__meta">
-                <time class="article__date" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format "2 Jan, 2006" }}</time>
-                <span class="article__minutes">· {{ .ReadingTime }} min read</span>
-              </div>
+            <div class="article__image">
+              {{ $imgPath := strings.TrimPrefix "/" .Params.Image }}
+              {{ partial "responsive-image.html" (dict
+                "src" $imgPath
+                "alt" .Title
+                "sizes" "(max-width: 600px) 100vw, (max-width: 900px) 50vw, 400px"
+                "widths" (slice 400 600 800)
+                "lazy" true
+                "lqip" true
+              ) }}
             </div>
             {{ end }}
             <div class="article__inner">
@@ -49,6 +36,7 @@
                 {{ if .Params.description }}
                 <p class="article__excerpt">{{ .Params.description }}</p>
                 {{ end }}
+                <time class="article__date" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format "2 Jan, 2006" }}</time>
               </div>
             </div>
           </div>

--- a/layouts/shortcodes/article_card.html
+++ b/layouts/shortcodes/article_card.html
@@ -1,46 +1,26 @@
 <article class="article col col-4 col-w-6 col-t-12">
   <div class="article__content">
     {{ if .Get "image" }}
-    <div class="article__head">
-      <div class="article__image">
-        {{ $imgPath := strings.TrimPrefix "/" (.Get "image") }}
-        {{ partial "responsive-image.html" (dict
-          "src" $imgPath
-          "alt" (.Get "title")
-          "sizes" "(max-width: 600px) 100vw, (max-width: 900px) 50vw, 400px"
-          "widths" (slice 400 600 800)
-          "lazy" true
-          "lqip" true
-        ) }}
-      </div>
-
-      {{ if .Get "tags" }}
-      <div class="article-tags__box">
-        {{ $tags := split (.Get "tags") "," }}
-        {{ range $tags }}
-          <span class="article__tag">{{ trim . " " }}</span>
-        {{ end }}
-      </div>
-      {{ end }}
-
-      <div class="article__meta">
-        {{ if .Get "date" }}
-        <time class="article__date">{{ .Get "date" }}</time>
-        {{ end }}
-        {{ if .Get "reading_time" }}
-        <span class="article__minutes">· {{ .Get "reading_time" }} min read</span>
-        {{ end }}
-      </div>
+    <div class="article__image">
+      {{ $imgPath := strings.TrimPrefix "/" (.Get "image") }}
+      {{ partial "responsive-image.html" (dict
+        "src" $imgPath
+        "alt" (.Get "title")
+        "sizes" "(max-width: 600px) 100vw, (max-width: 900px) 50vw, 400px"
+        "widths" (slice 400 600 800)
+        "lazy" true
+        "lqip" true
+      ) }}
     </div>
     {{ end }}
-
     <div class="article__inner">
       <div class="article__info">
-        <h3 class="article__title">
-          <a href="{{ .Get "link" }}" class="article__link" style="border-bottom: none; font-weight: 700;">{{ .Get "title" }}</a>
-        </h3>
+        <h3 class="article__title"><a href="{{ .Get "link" }}" class="article__link">{{ .Get "title" }}</a></h3>
         {{ if .Get "description" }}
         <p class="article__excerpt">{{ .Get "description" }}</p>
+        {{ end }}
+        {{ if .Get "date" }}
+        <time class="article__date">{{ .Get "date" }}</time>
         {{ end }}
       </div>
     </div>

--- a/layouts/shortcodes/article_card.html
+++ b/layouts/shortcodes/article_card.html
@@ -15,7 +15,10 @@
     {{ end }}
     <div class="article__inner">
       <div class="article__info">
-        <h3 class="article__title"><a href="{{ .Get "link" }}" class="article__link">{{ .Get "title" }}</a></h3>
+        {{/* Inline reset: this card renders inside tool/prose content, whose
+             `a:not(.button)` rule adds a border-bottom underline and font-weight
+             override. Reset both so the card matches the blog-card titles. */}}
+        <h3 class="article__title"><a href="{{ .Get "link" }}" class="article__link" style="border-bottom: none; font-weight: inherit;">{{ .Get "title" }}</a></h3>
         {{ if .Get "description" }}
         <p class="article__excerpt">{{ .Get "description" }}</p>
         {{ end }}


### PR DESCRIPTION
## Summary
- Redesigned the blog post cards (homepage blog section, `/posts` listing, and the "You may also like" related-posts cards) into a lighter, more editorial style.
- Removed the dark gradient overlays, the 50% grayscale filter, the read-time, and the on-image tag/date overlays — the cover image is now clean and full color.
- New layout: a light bordered card panel with a serif title (terracotta accent rule), a 2-line excerpt, and a quiet date pinned to the bottom.
- Cards on the same row now match height, with dates aligned along the bottom edge.
- Card surface, border, and text map to existing brand CSS variables, so the dark-mode toggle keeps working.
- Refreshed the Blog page intro copy.

Design spec: `docs/specs/2026-06-13-blog-card-redesign-design.md`

## Test Plan
- [x] `hugo --gc --minify` builds with no errors
- [x] Blog cards on `/posts` render full-color with the new layout (light mode)
- [x] Dark mode: card surface/border/text adapt; terracotta accent rule preserved
- [x] Cards in a row are equal height with bottom-aligned dates
- [x] Related-posts ("You may also like") cards match the new style