### PR TITLE
Refresh Animal reID tool page — CTA cards, reorg, card sections, tab fixes

### DIFF
--- a/assets/sass/3-modules/_tabs.scss
+++ b/assets/sass/3-modules/_tabs.scss
@@ -9,6 +9,13 @@
   gap: 32px;
   border-bottom: 1px solid var(--border-color);
   margin-bottom: 24px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   @media (max-width: $tablet) {
     gap: 16px;
@@ -21,6 +28,8 @@
 
 .tabs__tab {
   position: relative;
+  flex: 0 0 auto;
+  white-space: nowrap;
   padding: 12px 24px;
   font-size: 18px;
   font-weight: 700;
@@ -37,7 +46,7 @@
     position: absolute;
     left: 0;
     right: 0;
-    bottom: -1px;
+    bottom: 0;
     height: 3px;
     background-color: transparent;
     transition: $global-transition;
@@ -47,7 +56,7 @@
     color: var(--heading-font-color);
 
     &::after {
-      background-color: var(--primary-color);
+      background-color: var(--secondary-color);
     }
   }
 
@@ -57,35 +66,16 @@
     &::after {
       background-color: var(--secondary-color);
     }
-
-    &:hover::after {
-      background-color: var(--secondary-color);
-    }
   }
 
   @media (max-width: $tablet) {
-    padding: 8px 12px;
-    font-size: 24px;
-  }
-
-  @media (max-width: $mobile) {
-    padding: 8px 12px;
-    font-size: 24px;
+    padding: 10px 16px;
+    font-size: 16px;
   }
 }
 
 .tabs__tab-icon {
   margin-right: 8px;
-
-  @media (max-width: $tablet) {
-    margin-right: 0;
-  }
-}
-
-.tabs__tab-text {
-  @media (max-width: $tablet) {
-    display: none;
-  }
 }
 
 .tabs__panels {

--- a/assets/sass/4-layouts/_support.scss
+++ b/assets/sass/4-layouts/_support.scss
@@ -208,6 +208,15 @@
   }
 }
 
+/* Two-up variant (e.g. the two reID technique cards) */
+.support__grid--two {
+  grid-template-columns: repeat(2, 1fr);
+
+  @media (max-width: $mobile) {
+    grid-template-columns: 1fr;
+  }
+}
+
 .support__card {
   padding: 28px;
   background-color: var(--background-alt-color);

--- a/content/tools/animal-reid/index.md
+++ b/content/tools/animal-reid/index.md
@@ -11,19 +11,11 @@ js:
   - /js/tabs.js
 ---
 
-<div class="tool-container-button-cta">
-  <a class="link-no-decoration" href="#demos" >
-    <button class="button tool-button-cta">
-      Try Interactive Demos
-    </button>
-  </a>
-</div>
-
 # Individual Animal Identification Across Species
 
-Animal reID is a modular framework that enables precise identification of individual animals using computer vision. Built on years of conservation technology research, our approach adapts to different species by employing the most appropriate identification technique—whether that's facial recognition, spot pattern matching, or local feature analysis.
+Animal reID is a modular computer vision framework for identifying individual animals. It adapts to each species by choosing the right technique — facial recognition, spot-pattern matching, or local feature analysis.
 
-From monitoring bear populations in British Columbia to tracking individual trout in river systems, and extending to snow leopards in Central Asia and seals in coastal waters, Animal reID provides researchers with powerful, non-invasive tools for wildlife monitoring and conservation.
+From bears in British Columbia and trout in river systems to snow leopards in Central Asia and seals in coastal waters, it gives researchers non-invasive tools for wildlife monitoring and conservation.
 
 {{< image_carousel id="animal-reid-gallery" >}}
   {{< carousel_image src="./images/animal_reid_leopard_1.png" alt="Snow Leopard Identification" caption="Local feature matching identifies individual snow leopards by analyzing their unique spot patterns across camera trap images." >}}
@@ -32,25 +24,52 @@ From monitoring bear populations in British Columbia to tracking individual trou
   {{< carousel_image src="./images/animal_reid_trout_1.png" alt="Trout Identification" caption="LightGLUE local feature matching identifies individual trout by analyzing their unique spot patterns along the body." >}}
 {{< /image_carousel >}}
 
-## Key Features
-
-- 🧬 **Multi-Species Support**: Proven techniques for bears, trout, seals, and snow leopards, with extensibility for other species
-- 🎯 **Modular Architecture**: Choose from metric learning, local feature matching, or hybrid approaches based on your species and data
-- 🔬 **Research-Grade Accuracy**: Built on peer-reviewed techniques including Instance Segmentation + Metric Learning and LightGLUE local feature matching
-- 🌍 **Conservation Focused**: Designed for real-world field applications with non-invasive monitoring capabilities
-- 📊 **Database Integration**: Compare new observations against historical databases to track population dynamics over time
+<div class="about-cta">
+  <h3 class="about-cta__title">See it in action</h3>
+  <p class="about-cta__description">Upload a photo to the live demos and watch Animal reID pick out the individual — bear, trout, seal, or snow leopard.</p>
+  <a href="#demos" class="link-no-decoration button button--middle">Try the demos</a>
+</div>
 
 <br/>
+<br/>
 
-## Conservation Impact
+## Why Animal reID
 
-Animal reID technology enables researchers to:
+Animal reID combines proven techniques into one adaptable system for individual identification.
 
-- **Monitor population dynamics** without invasive tagging or marking
-- **Track individual animals** across seasons and years to understand behavior, migration, and survival
-- **Assess conservation effectiveness** by quantifying population trends with individual-level precision
-- **Reduce field costs** by automating identification from camera trap and observation images
-- **Scale monitoring efforts** to cover larger geographic areas with existing observation networks
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">One framework, many species</h3>
+    <p class="support__card-description">Proven on bears, trout, seals, and snow leopards, and extensible to new species.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">The right technique for your data</h3>
+    <p class="support__card-description">Metric learning, local feature matching, or a hybrid, matched to your species and imagery.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Non-invasive by design</h3>
+    <p class="support__card-description">Identify individuals from camera-trap and observation images, with no tagging or marking.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Population trends over time</h3>
+    <p class="support__card-description">Match new sightings against historical databases to track survival, movement, and behavior.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Built to scale in the field</h3>
+    <p class="support__card-description">Automate identification to cut field costs and cover larger areas with existing networks.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Research-grade and open source</h3>
+    <p class="support__card-description">Built on peer-reviewed methods, with open-source implementations you can run and adapt.</p>
+  </div>
+
+</div>
 
 <br/>
 <br/>
@@ -59,7 +78,7 @@ Animal reID technology enables researchers to:
 
 Experience Animal reID in action with our live demonstrations. These systems are currently monitoring real wildlife populations.
 
-{{< tabs labels="🐻 Bear |🐠 Trout |🦭 Seal |🐆 Snow Leopard" id="animal-reid-demos" >}}
+{{< tabs labels="::Bear|::Trout|::Seal|::Snow Leopard" id="animal-reid-demos" >}}
 {{< tab index="0" >}}
 
 Upload bear photographs and watch as the system segments facial features and matches them against our database of known individuals from British Columbia.
@@ -93,54 +112,47 @@ Upload snow leopard photographs and watch as the system analyzes unique coat pat
 <br/>
 <br/>
 
-## Resources & Documentation
+## How It Works
 
-{{< tabs labels="🚀 Try |🔬 Techniques|📁 Projects|📖 Guides" id="resources-tabs" >}}
-{{< tab index="0" >}}
+Animal reID matches the identification technique to the species. Two approaches cover most cases:
 
-<p class="tabs__intro">Experience Animal reID systems in action through our interactive demonstration spaces. Each space provides hands-on access to production-grade identification models.</p>
+<div class="support__grid support__grid--two">
 
-<div class="container">
-  <div class="row">
-
-{{< space_card title="Bear Identification" link="/spaces/bear_identification/" emoji="🐻" summary="A computer vision system utilizes facial recognition technology to analyze bear photographs and identify individual bears. This innovative system aims to monitor the population size of bears in British Columbia over time, ultimately supporting and enhancing conservation efforts in the region." >}}
-
-{{< space_card title="Trout Identification" link="/spaces/trout_identification/" emoji="🐠" summary="A computer vision system analyzes the spot patterns of trout to identify individual fish. This innovative, non-invasive approach aims to monitor trout populations in British Columbia over time, ultimately supporting and enhancing conservation efforts in the region." >}}
-
-{{< space_card title="Seal Identification" link="/spaces/seal_identification/" emoji="🦭" summary="Non-invasive seal re-identification using computer vision to track individual animals across seasons through unique whisker patterns and facial features in the Wadden Sea." >}}
-
-{{< space_card title="Snow Leopard Identification" link="/spaces/snowleopard_identification/" emoji="🐆" summary="Computer vision system for identifying individual snow leopards using feature matching and machine learning, supporting conservation efforts in Central Asia." >}}
-
+  <div class="support__card support__track">
+    <span class="support__track-label">Facial recognition</span>
+    <h3 class="support__card-title">Metric Learning</h3>
+    <p class="support__card-description">Used successfully for bear identification, this approach combines instance segmentation to isolate animal faces with deep metric learning to create unique embeddings for each individual. The system learns to recognize subtle facial features and marking patterns that distinguish one animal from another.</p>
+    <div class="support__track-proof">Applications: bears, primates, big cats, and other species with distinctive facial characteristics.</div>
+    <ul class="support__track-offers">
+      <li>Highly accurate for species with distinctive facial features</li>
+      <li>Robust to pose variations and lighting conditions</li>
+      <li>Proven in production for British Columbia bear monitoring</li>
+    </ul>
   </div>
+
+  <div class="support__card support__track">
+    <span class="support__track-label">Spot patterns</span>
+    <h3 class="support__card-title">Local Feature Matching</h3>
+    <p class="support__card-description">Pioneered in our trout identification work, this technique uses advanced local feature matching (LightGLUE) to analyze unique spot patterns on fish bodies. The system standardizes fish orientations and matches keypoint patterns against a reference database.</p>
+    <div class="support__track-proof">Applications: trout, leopards, cheetahs, whale sharks, and other spot-patterned species.</div>
+    <ul class="support__track-offers">
+      <li>Non-invasive identification from natural markings</li>
+      <li>Works with partial views and occlusions</li>
+      <li>Effective for species with complex, unique pattern distributions</li>
+    </ul>
+  </div>
+
 </div>
 
-{{< /tab >}}
-{{< tab index="1" markdown="true" >}}
+<br/>
+<br/>
 
-### Metric Learning for Facial Recognition
+## Resources & Documentation
 
-Used successfully for **bear identification**, this approach combines instance segmentation to isolate animal faces with deep metric learning to create unique embeddings for each individual. The system learns to recognize subtle facial features and marking patterns that distinguish one animal from another.
+Explore the open-source projects and technical guides behind Animal reID.
 
-**Key advantages:**
-- Highly accurate for species with distinctive facial features
-- Robust to pose variations and lighting conditions
-- Proven in production for British Columbia bear monitoring
-
-**Applications**: Bears, primates, big cats, and other species with distinctive facial characteristics
-
-### Local Feature Matching for Spot Patterns
-
-Pioneered in our **trout identification** work, this technique uses advanced local feature matching (LightGLUE) to analyze unique spot patterns on fish bodies. The system standardizes fish orientations and matches keypoint patterns against a reference database.
-
-**Key advantages:**
-- Non-invasive identification from natural markings
-- Works with partial views and occlusions
-- Effective for species with complex, unique pattern distributions
-
-**Applications**: Trout, leopards, cheetahs, whale sharks, and other spot-patterned species
-
-{{< /tab >}}
-{{< tab index="2" >}}
+{{< tabs labels="::Projects|::Guides" id="resources-tabs" >}}
+{{< tab index="0" >}}
 
 <p class="tabs__intro">Each implementation is open-source with detailed documentation:</p>
 
@@ -159,7 +171,7 @@ Pioneered in our **trout identification** work, this technique uses advanced loc
 </div>
 
 {{< /tab >}}
-{{< tab index="3" >}}
+{{< tab index="1" >}}
 
 <p class="tabs__intro">In-depth technical guides covering the design and implementation of animal identification systems:</p>
 
@@ -180,13 +192,8 @@ Pioneered in our **trout identification** work, this technique uses advanced loc
 {{< /tab >}}
 {{< /tabs >}}
 
-<br/>
-
-## Get Started
-
-Interested in applying Animal reID to your conservation project? We offer consultation on selecting the right identification approach, custom development for new species, and collaborative research opportunities.
-
-<br/>
-<div style="text-align: center;">
-  <a href="/contact/" class="button">Get in Touch</a>
+<div class="about-cta">
+  <h3 class="about-cta__title">Have a species to identify?</h3>
+  <p class="about-cta__description">Tell us about your animals and your image data — we'll give you an honest read on which identification approach fits and what it would take.</p>
+  <a href="/contact/" class="link-no-decoration button button--middle">Start a project</a>
 </div>

--- a/docs/specs/2026-06-13-animal-reid-page-refresh-design.md
+++ b/docs/specs/2026-06-13-animal-reid-page-refresh-design.md
@@ -1,0 +1,90 @@
+# Animal reID page refresh — layout & copy
+
+**Date:** 2026-06-13
+**Branch:** `worktree-animal-reid-page-refresh` (off `main`)
+**File touched:** `content/tools/animal-reid/index.md` (only)
+
+## Goal
+
+Improve the layout and copy of the Animal reID tool page. The main weakness is the
+closing section — a bare `## Get Started` heading, a verbose paragraph, and a small
+"Get in Touch" button. Replace it with the site's existing `.about-cta` card (the
+light bordered CTA used on the About page's "What We Do" section), and do a light,
+targeted copy pass. No section reordering.
+
+## Decisions
+
+- **CTA style:** Light bordered card — the `.about-cta` component (Image #1 reference),
+  single button → `/contact/`.
+- **Scope:** CTA + targeted copy/layout polish. Surgical, single file.
+- **No CSS changes.** `.about-cta` is a top-level selector in
+  `assets/sass/4-layouts/_about.scss` (not nested under an `.about` parent), so its
+  styles already apply globally. Reusing the markup needs zero SCSS edits. The class
+  remains shared with the About page; the SCSS is untouched, so both stay in sync.
+- The page's `index.md` already uses raw HTML for its buttons, so inlining the
+  `.about-cta` markup matches the existing file style (no new partial/shortcode —
+  YAGNI).
+
+## Changes
+
+### 1. Replace the closing section
+
+**Remove** (current end of page):
+
+```markdown
+## Get Started
+
+Interested in applying Animal reID to your conservation project? We offer consultation on selecting the right identification approach, custom development for new species, and collaborative research opportunities.
+
+<br/>
+<div style="text-align: center;">
+  <a href="/contact/" class="button">Get in Touch</a>
+</div>
+```
+
+**Replace with** the `.about-cta` card:
+
+```html
+<div class="about-cta">
+  <h3 class="about-cta__title">Have a species to identify?</h3>
+  <p class="about-cta__description">Tell us about your animals and your image data — we'll give you an honest read on which identification approach fits and what it would take.</p>
+  <a href="/contact/" class="link-no-decoration button button--middle">Start a project</a>
+</div>
+```
+
+The `## Get Started` H2 is dropped — it would be redundant directly above the card's
+own title. The card's built-in `margin-top: 48px` provides the spacing, so the
+trailing `<br/>` pair before this section can be removed.
+
+### 2. Targeted copy polish (no reordering)
+
+Tighten the two intro paragraphs under the H1, cutting redundancy while keeping the
+species range. Proposed:
+
+> Animal reID is a modular computer vision framework for identifying individual
+> animals. It adapts to each species by choosing the right technique — facial
+> recognition, spot-pattern matching, or local feature analysis.
+>
+> From bears in British Columbia and trout in river systems to snow leopards in
+> Central Asia and seals in coastal waters, it gives researchers non-invasive tools
+> for wildlife monitoring and conservation.
+
+Any other flabby phrasing found during implementation gets a light touch only —
+Key Features, Conservation Impact, demos tabs, and resources tabs keep their
+structure and content.
+
+### Out of scope
+
+- No SCSS changes.
+- No section reordering or merging.
+- No changes to the top "Try Interactive Demos" button, the image carousel, the
+  `hf_space` demo embeds, or the resources/techniques/projects/guides tabs.
+- No changes to front matter.
+
+## Verification
+
+- `hugo` builds with no errors.
+- Rendered page shows the `.about-cta` card as the closer, styled identically to the
+  About page's CTA (bordered, centered, single button), with the button linking to
+  `/contact/`.
+- Intro reads cleaner; no content lost.

--- a/docs/specs/2026-06-13-animal-reid-page-refresh-design.md
+++ b/docs/specs/2026-06-13-animal-reid-page-refresh-design.md
@@ -2,7 +2,10 @@
 
 **Date:** 2026-06-13
 **Branch:** `worktree-animal-reid-page-refresh` (off `main`)
-**File touched:** `content/tools/animal-reid/index.md` (only)
+**Files touched:** `content/tools/animal-reid/index.md`; `layouts/shortcodes/tabs.html` (one-line guard, Phase 2)
+
+> Phase 1 (CTA card + intro polish) is implemented. Phase 2 (layout/organization +
+> emoji removal) is described in its own section at the bottom of this doc.
 
 ## Goal
 
@@ -73,7 +76,7 @@ Any other flabby phrasing found during implementation gets a light touch only �
 Key Features, Conservation Impact, demos tabs, and resources tabs keep their
 structure and content.
 
-### Out of scope
+### Out of scope (Phase 1 — superseded by Phase 2 below)
 
 - No SCSS changes.
 - No section reordering or merging.
@@ -81,10 +84,101 @@ structure and content.
   `hf_space` demo embeds, or the resources/techniques/projects/guides tabs.
 - No changes to front matter.
 
-## Verification
+## Verification (Phase 1)
 
 - `hugo` builds with no errors.
 - Rendered page shows the `.about-cta` card as the closer, styled identically to the
   About page's CTA (bordered, centered, single button), with the button linking to
   `/contact/`.
 - Intro reads cleaner; no content lost.
+
+---
+
+# Phase 2 — Layout, organization & emoji removal
+
+## Decisions
+
+- **Structure: story-led.** Final section order:
+  1. Hero "Try Interactive Demos" button (unchanged)
+  2. H1 + intro (Phase 1)
+  3. Image carousel (unchanged)
+  4. `## Why Animal reID` — Key Features + Conservation Impact **merged into one list**
+  5. `## Interactive Demos` (`{#demos}` anchor kept) — same four `hf_space` embeds
+  6. `## How It Works` — the Techniques content promoted out of the Resources tabs
+  7. `## Resources & Documentation` — now only **Projects + Guides** tabs
+  8. `.about-cta` card (Phase 1)
+- **Copy: restructure + merge.** Fold the two bullet lists into capability+impact
+  bullets; dedupe the redundant "Try" tab; rewrite section intros to fit the flow.
+- **Emoji: none anywhere.** Stricter than About/Support. No heading emojis, no
+  per-bullet emojis, no tab-label emojis, no `space_card` emoji (the cards live in
+  the removed "Try" tab anyway).
+- **Headings: plain markdown** `##` (no squiggle SVG, no template change for headings).
+
+## Changes
+
+### 1. `tabs` shortcode guard — `layouts/shortcodes/tabs.html`
+
+Render the icon `<span>` only when an icon is present, so emoji-free labels don't
+leave an 8px dangling gap:
+
+```go-html-template
+{{ if $icon }}<span class="tabs__tab-icon">{{ $icon | safeHTML }}</span>{{ end }}
+```
+
+Backward-compatible: biowatch (the only other `tabs` user) passes non-empty FA icons
+via the `icon::text` form, so its spans still render. Emoji-free labels use the
+`::Label` form (empty icon → span omitted).
+
+### 2. Merge Key Features + Conservation Impact → `## Why Animal reID`
+
+Replace both sections with one. Proposed body (no emojis):
+
+> Animal reID combines proven techniques into one adaptable system for individual
+> identification:
+>
+> - **One framework, many species** — proven on bears, trout, seals, and snow
+>   leopards, and extensible to new species.
+> - **The right technique for your data** — metric learning, local feature matching,
+>   or a hybrid, matched to your species and imagery.
+> - **Non-invasive by design** — identify individuals from camera-trap and
+>   observation images, with no tagging or marking.
+> - **Population trends over time** — match new sightings against historical
+>   databases to track survival, movement, and behavior.
+> - **Built to scale in the field** — automate identification to cut field costs and
+>   cover larger areas with existing networks.
+
+### 3. Promote Techniques → `## How It Works`
+
+Lift the existing "Techniques" tab content (Metric Learning for Facial Recognition +
+Local Feature Matching for Spot Patterns) out of the Resources tabs into a top-level
+`## How It Works` section, placed after the demos. Copy intact.
+
+### 4. Trim Resources tabs → Projects + Guides
+
+- Remove the "Try" tab (re-linked the same demo spaces — duplication).
+- Remove the "Techniques" tab (promoted to How It Works).
+- Keep Projects + Guides; emoji-free labels `labels="::Projects|::Guides"`.
+- Renumber surviving panels to `index="0"` (Projects) and `index="1"` (Guides) so
+  tab buttons (indexed by label order) match panels.
+
+### 5. Strip remaining emojis
+
+- Demo tab labels → `labels="::Bear|::Trout|::Seal|::Snow Leopard"`.
+- No emojis in any heading or bullet.
+
+## Out of scope (Phase 2)
+
+- No SCSS changes.
+- No changes to the hero button, carousel, the four `hf_space` embeds, the CTA card,
+  or front matter.
+- No changes to the Projects/Guides card content (only their tab labels/indexes).
+
+## Verification (Phase 2)
+
+- `hugo` builds with no errors.
+- Section order matches the list above; only one bullet list (no Features/Impact
+  duplication).
+- Resources block shows exactly two tabs (Projects, Guides) and they switch correctly
+  in the built HTML (tab `data-tab` indexes align with panel `data-panel`).
+- Biowatch tabs still render their FA icons (shortcode change is backward-compatible).
+- `grep` of the rendered `index.html` finds no emoji characters in the page body.

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -19,7 +19,7 @@
             aria-selected="{{ if eq $index 0 }}true{{ else }}false{{ end }}"
             aria-controls="{{ $id }}-panel-{{ $index }}"
             data-tab="{{ $index }}">
-      <span class="tabs__tab-icon">{{ $icon | safeHTML }}</span>
+      {{ if $icon }}<span class="tabs__tab-icon">{{ $icon | safeHTML }}</span>{{ end }}
       <span class="tabs__tab-text">{{ $text }}</span>
     </button>
     {{- end }}


### PR DESCRIPTION
Refreshes the Animal reID tool page to match the visual language of the About/Support pages.

## Changes

**CTAs (now `.about-cta` cards, matching the site pattern)**
- Top "Try Interactive Demos" button → "See it in action" card (jumps to `#demos`), placed after the gallery.
- Weak "Get Started / Get in Touch" closer → "Have a species to identify?" card (→ `/contact/`).

**Layout & content (story-led reorg)**
- Section order: Why → Interactive Demos → How It Works → Resources.
- Merged the old "Key Features" + "Conservation Impact" bullet lists.
- Removed the duplicate "Try" tab in Resources (it re-linked the same demo spaces).
- Promoted the "Techniques" tab content into a top-level "How It Works" section.
- Uniform section spacing with a parallel one-line intro under every heading.

**Cards (reusing the Support-page card styles)**
- How It Works → 2 cards (new `.support__grid--two` modifier).
- Why Animal reID → 6 cards (3×3) on the base `.support__grid`.

**Emoji**
- Removed all emojis (headings, bullets, tab labels, space_card params) per the About/Support convention.

**Tab component (`_tabs.scss` + `tabs.html`)**
- Labels now show on mobile (were `display:none`), mobile font 24px→16px, nav is horizontally scrollable, hover/active underline unified to the teal `--secondary-color`.
- The icon `<span>` renders only when an icon is present — backward-compatible with biowatch's Font Awesome icon tabs.

## Notes
- Design spec: `docs/specs/2026-06-13-animal-reid-page-refresh-design.md`.
- The tool page now reuses `.support__*` classes from `_support.scss` (intentional reuse; a future change to those Support styles will also affect this page).
- `hugo` build passes; verified rendered output (tab switching, mobile tabs, cards, Support page unaffected) via screenshots.