### PR TITLE
Revamp Biowatch tool page — cards, CTAs, reorg, copy pass

### DIFF
--- a/content/tools/biowatch/index.md
+++ b/content/tools/biowatch/index.md
@@ -7,12 +7,26 @@ icon: /images/logos/biowatch-icon.png
 summary: Open-source desktop app for analyzing camera trap data. Runs 100% locally — your sensitive wildlife data never leaves your computer.
 github_repo: https://github.com/earthtoolsmaker/biowatch
 project: /projects/biowatch-app
+hide_meta_links: true
 date: 2025-05-01
 js:
   - /js/biowatch.js
   - /js/tabs.js
 all_downloads_url: https://github.com/earthtoolsmaker/biowatch/releases/tag/v1.0.11
 ---
+
+# Analyze Camera Trap Data — Privately, On Your Machine
+
+Biowatch is a free, open-source desktop application that lets you analyze, visualize, and explore camera trap datasets entirely offline. Your sensitive wildlife data never gets uploaded to any server — everything runs locally on your computer.
+
+{{< image_carousel id="biowatch-gallery" >}}
+  {{< carousel_image src="./images/overview.png" alt="Biowatch study overview" caption="Overview: every study opens with an interactive map, key metrics, the best captures, and the full species distribution with IUCN status." shadow="false" rounded="false" >}}
+  {{< carousel_image src="./images/explore.png" alt="Biowatch Explore tab" caption="Explore: map camera locations as species pie-charts, abundance, or density heatmaps, with daily-activity and seasonal charts alongside." shadow="false" rounded="false" >}}
+  {{< carousel_image src="./images/media.png" alt="Biowatch media library" caption="Media: browse, filter, and search thousands of camera trap images and videos by species, deployment, and detection." shadow="false" rounded="false" >}}
+  {{< carousel_image src="./images/annotation.png" alt="Reviewing AI detections with bounding boxes" caption="Annotate: step through images, adjust bounding boxes, and correct AI predictions before they become observations." shadow="false" rounded="false" >}}
+  {{< carousel_image src="./images/ai-models.png" alt="On-device AI model settings" caption="On-device AI: download SpeciesNet, MegaDetector, DeepFaune, or Manas and pick the right model for your region from the coverage map." shadow="false" rounded="false" >}}
+  {{< carousel_image src="./images/export.png" alt="Camtrap DP export dialog" caption="Export: publish to GBIF as a Camtrap DP package, or export your media organized into one folder per species." shadow="false" rounded="false" >}}
+{{< /image_carousel >}}
 
 <div class="tool-container-button-cta" id="container-button-download-biowatch">
   <a class="link-no-decoration" href="https://github.com/earthtoolsmaker/biowatch/releases/latest/download/biowatch-setup.exe" id="download-windows">
@@ -32,54 +46,102 @@ all_downloads_url: https://github.com/earthtoolsmaker/biowatch/releases/tag/v1.0
   </a>
 </div>
 
-# Analyze Camera Trap Data — Privately, On Your Machine
-
-Biowatch is a free, open-source desktop application that lets you analyze, visualize, and explore camera trap datasets entirely offline. Your sensitive wildlife data never gets uploaded to any server — everything runs locally on your computer. New to it? The [online manual](https://biowatch.earthtoolsmaker.org/) walks you through every feature, step by step.
-
-{{< image_carousel id="biowatch-gallery" >}}
-  {{< carousel_image src="./images/overview.png" alt="Biowatch study overview" caption="Overview: every study opens with an interactive map, key metrics, the best captures, and the full species distribution with IUCN status." shadow="false" rounded="false" >}}
-  {{< carousel_image src="./images/explore.png" alt="Biowatch Explore tab" caption="Explore: map camera locations as species pie-charts, abundance, or density heatmaps, with daily-activity and seasonal charts alongside." shadow="false" rounded="false" >}}
-  {{< carousel_image src="./images/media.png" alt="Biowatch media library" caption="Media: browse, filter, and search thousands of camera trap images and videos by species, deployment, and detection." shadow="false" rounded="false" >}}
-  {{< carousel_image src="./images/annotation.png" alt="Reviewing AI detections with bounding boxes" caption="Annotate: step through images, adjust bounding boxes, and correct AI predictions before they become observations." shadow="false" rounded="false" >}}
-  {{< carousel_image src="./images/ai-models.png" alt="On-device AI model settings" caption="On-device AI: download SpeciesNet, MegaDetector, DeepFaune, or Manas and pick the right model for your region from the coverage map." shadow="false" rounded="false" >}}
-  {{< carousel_image src="./images/export.png" alt="Camtrap DP export dialog" caption="Export: publish to GBIF as a Camtrap DP package, or export your media organized into one folder per species." shadow="false" rounded="false" >}}
-{{< /image_carousel >}}
+<div class="about-cta" style="margin-bottom: 64px;">
+  <h3 class="about-cta__title">New to Biowatch?</h3>
+  <p class="about-cta__description">The full online manual walks you through every feature — importing data, exploring studies, annotating images, running AI models, and exporting — with step-by-step guides and screenshots.</p>
+  <a href="https://biowatch.earthtoolsmaker.org/" target="_blank" class="link-no-decoration button button--cta">Read the Manual</a>
+</div>
 
 ## Why Biowatch?
 
-- __100% Offline & Private__: Your research data stays on your machine. No cloud uploads, no accounts, no tracking. Perfect for sensitive location data of endangered species.
-- __Open Source__: Inspect the code, contribute improvements, or adapt it for your needs. Built transparently by the conservation community, for the conservation community.
-- __On-Device AI__: Run powerful species identification models directly on your computer — no internet required after setup.
+Three things set it apart:
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">100% offline &amp; private</h3>
+    <p class="support__card-description">Your research data stays on your machine — no cloud uploads, no accounts, no tracking. Built for the sensitive location data of endangered species.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Open source</h3>
+    <p class="support__card-description">Inspect the code, contribute improvements, or adapt it to your needs — built transparently by the conservation community, for the conservation community.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">On-device AI</h3>
+    <p class="support__card-description">Run powerful species-identification models directly on your computer, with no internet required after setup.</p>
+  </div>
+
+</div>
 
 ## Key Features
 
-- __Import from anywhere__: Start from your own image folders, a [Camtrap DP](https://camtrap-dp.tdwg.org/) package, or curated public datasets from [GBIF](https://www.gbif.org/) and [LILA](https://lila.science/) — or try the one-click demo dataset.
-- __On-device species ID__: Detect and identify animals with local AI models — SpeciesNet, MegaDetector, DeepFaune, and Manas — and pick the best fit for your region from a coverage map.
-- __Interactive maps__: See camera locations as species pie-charts, abundance markers, or density heatmaps, and filter everything to an area you draw.
-- __Activity & trends__: Compare species with daily-activity clocks, seasonal timelines, and per-deployment activity charts.
-- __Media management__: Browse, filter, and search thousands of images and videos, review AI detections, and correct bounding boxes.
-- __Standards-based export__: Publish to GBIF as a Camtrap DP package, or export your media organized into one folder per species.
+Everything from raw captures to published data:
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Import from anywhere</h3>
+    <p class="support__card-description">Start from your own image folders, a <a href="https://camtrap-dp.tdwg.org/">Camtrap DP</a> package, or curated public datasets from <a href="https://www.gbif.org/">GBIF</a> and <a href="https://lila.science/">LILA</a> — or try the one-click demo dataset.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">On-device species ID</h3>
+    <p class="support__card-description">Detect and identify animals with local AI models — SpeciesNet, MegaDetector, DeepFaune, and Manas — and pick the best fit for your region from a coverage map.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Interactive maps</h3>
+    <p class="support__card-description">See camera locations as species pie-charts, abundance markers, or density heatmaps, and filter everything to an area you draw.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Activity &amp; trends</h3>
+    <p class="support__card-description">Compare species with daily-activity clocks, seasonal timelines, and per-deployment activity charts.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Media management</h3>
+    <p class="support__card-description">Browse, filter, and search thousands of images and videos, review AI detections, and correct bounding boxes.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Standards-based export</h3>
+    <p class="support__card-description">Publish to GBIF as a Camtrap DP package, or export your media organized into one folder per species.</p>
+  </div>
+
+</div>
+
+## About
+
+Biowatch grew out of a simple conviction: researchers shouldn't have to choose between modern AI tooling and keeping control of sensitive wildlife data.
+
+Whether you're tracking endangered species, studying behavior, or monitoring biodiversity, it turns raw camera-trap captures into clear results — on your own machine, with no cloud, no subscriptions, and no lock-in.
 
 ## Installation
 
 {{< tabs labels="<i class='fa-brands fa-windows' style='color: #0078D6;'></i>::Windows|<i class='fa-brands fa-apple' style='color: #555555;'></i>::macOS|<i class='fa-brands fa-linux' style='color: #000000;'></i>::Linux" id="installation-tabs" >}}
 {{< tab index="0" markdown="true" >}}
-1. Download the installer above
-2. Run `biowatch-setup.exe`
-3. Follow the installation wizard
-4. Launch Biowatch from the Start menu or desktop shortcut
+<a class="link-no-decoration" href="https://github.com/earthtoolsmaker/biowatch/releases/latest/download/biowatch-setup.exe"><button class="button" style="background-color: #0078D6;"><i class="fa-brands fa-windows" style="margin-right: 0.5em;"></i>Download for Windows</button></a>
+
+1. Run `biowatch-setup.exe`
+2. Follow the installation wizard
+3. Launch Biowatch from the Start menu or desktop shortcut
 {{< /tab >}}
 {{< tab index="1" markdown="true" >}}
-1. Download the `.dmg` file above
-2. Open the disk image
-3. Drag Biowatch to your Applications folder
-4. On first launch, right-click the app and select "Open" (required for apps from outside the App Store)
+<a class="link-no-decoration" href="https://github.com/earthtoolsmaker/biowatch/releases/latest/download/biowatch.dmg"><button class="button" style="background-color: #000000;"><i class="fa-brands fa-apple" style="margin-right: 0.5em;"></i>Download for Mac</button></a>
+
+1. Open the `.dmg` disk image
+2. Drag Biowatch to your Applications folder
+3. On first launch, right-click the app and select "Open" (required for apps from outside the App Store)
 {{< /tab >}}
 {{< tab index="2" markdown="true" >}}
+<a class="link-no-decoration" href="https://github.com/earthtoolsmaker/biowatch/releases/latest/download/biowatch.AppImage"><button class="button" style="background-color: #FCC624; color: #000000;"><i class="fa-brands fa-linux" style="margin-right: 0.5em;"></i>Download AppImage</button></a>
+
 **AppImage (recommended):**
-1. Download the `.AppImage` file above
-2. Make it executable: `chmod +x Biowatch.AppImage`
-3. Run it: `./Biowatch.AppImage`
+1. Make it executable: `chmod +x Biowatch.AppImage`
+2. Run it: `./Biowatch.AppImage`
 
 **Debian/Ubuntu:**
 1. Download the `.deb` package from [all releases](https://github.com/earthtoolsmaker/biowatch/releases)
@@ -87,28 +149,16 @@ Biowatch is a free, open-source desktop application that lets you analyze, visua
 {{< /tab >}}
 {{< /tabs >}}
 
-## Documentation
-
-The full [online manual](https://biowatch.earthtoolsmaker.org/) covers everything — importing data, exploring studies, annotating images, running AI models, and exporting — with step-by-step guides and screenshots.
-
-<div style="margin: 1.5em 0;">
-  <a class="link-no-decoration" href="https://biowatch.earthtoolsmaker.org/" target="_blank">
-    <button class="button button--cta"><i class="fa-solid fa-book" style="margin-right: 0.5em;"></i>Read the Manual</button>
-  </a>
+<div class="support__cta-band">
+  <div class="support__cta-band-text">
+    <h3 class="support__cta-band-title">Ready to try it?</h3>
+    <p class="support__cta-band-description">Biowatch is free and open source — and built in the open. Download it for Windows, macOS, or Linux, or help us keep developing it.</p>
+  </div>
+  <div class="support__cta-band-buttons">
+    <a class="link-no-decoration" href="#container-button-download-biowatch"><button class="button">Download Biowatch</button></a>
+    <a class="link-no-decoration" href="/support/"><button class="button button--ghost">Support development</button></a>
+  </div>
 </div>
-
-<br />
-
-<p><iframe src="https://www.youtube.com/embed/Ei9zOd_5Qkc" loading="lazy" frameborder="0" allowfullscreen style="width:100%;height:auto;aspect-ratio:16/9;"></iframe></p>
-<em style="font-size:14px;line-height:1.4em;display:block;">Biowatch video demo and updates</em>
-<br/>
-
-
-## About
-
-Biowatch was developed to help researchers, conservationists, and wildlife enthusiasts analyze camera trap data more effectively — without compromising on data privacy or requiring expensive cloud services.
-
-Whether you're tracking endangered species in remote locations, studying animal behavior, or monitoring biodiversity, Biowatch provides the tools you need to turn your camera trap data into actionable insights while keeping full control of your data.
 
 <script>
 window.addEventListener("load", () => {

--- a/content/tools/biowatch/index.md
+++ b/content/tools/biowatch/index.md
@@ -49,7 +49,7 @@ Biowatch is a free, open-source desktop application that lets you analyze, visua
 <div class="about-cta" style="margin-bottom: 64px;">
   <h3 class="about-cta__title">New to Biowatch?</h3>
   <p class="about-cta__description">The full online manual walks you through every feature — importing data, exploring studies, annotating images, running AI models, and exporting — with step-by-step guides and screenshots.</p>
-  <a href="https://biowatch.earthtoolsmaker.org/" target="_blank" class="link-no-decoration button button--cta">Read the Manual</a>
+  <a href="https://biowatch.earthtoolsmaker.org/" target="_blank" class="link-no-decoration button button--middle">Read the Manual</a>
 </div>
 
 ## Why Biowatch?
@@ -83,7 +83,7 @@ Everything from raw captures to published data:
 
   <div class="support__card">
     <h3 class="support__card-title">Import from anywhere</h3>
-    <p class="support__card-description">Start from your own image folders, a <a href="https://camtrap-dp.tdwg.org/">Camtrap DP</a> package, or curated public datasets from <a href="https://www.gbif.org/">GBIF</a> and <a href="https://lila.science/">LILA</a> — or try the one-click demo dataset.</p>
+    <p class="support__card-description">Start from your own image folders, a <a href="https://camtrap-dp.tdwg.org/" target="_blank" rel="noopener">Camtrap DP</a> package, or curated public datasets from <a href="https://www.gbif.org/" target="_blank" rel="noopener">GBIF</a> and <a href="https://lila.science/" target="_blank" rel="noopener">LILA</a> — or try the one-click demo dataset.</p>
   </div>
 
   <div class="support__card">

--- a/docs/specs/2026-06-13-biowatch-page-revamp-design.md
+++ b/docs/specs/2026-06-13-biowatch-page-revamp-design.md
@@ -2,101 +2,91 @@
 
 **Date:** 2026-06-13
 **Branch:** `worktree-biowatch-page-revamp` (off `main`)
-**File touched:** `content/tools/biowatch/index.md` (only — reuses existing components, no SCSS/template changes)
+**Files touched:**
+- `content/tools/biowatch/index.md`
+- `layouts/tools/single.html` (one guarded block; affects all tool pages but inert unless the flag is set)
 
 ## Goal
 
-Apply the same visual language used on the refreshed Animal reID page: turn the
-bullet sections into Support-style cards, add a strong closing CTA, and drop the
-video. The page is already emoji-free and well structured, so this is a focused pass.
+Apply the visual language used on the refreshed Animal reID page (Support-style
+cards, strong CTAs, no emojis), tighten the copy, and improve the section flow. The
+page was already emoji-free and well structured, so this is a focused pass — but it
+grew over several iterations into a fuller revamp (see Changes).
 
-## Decisions
+## Final section order
 
-- **Why Biowatch?** → 3 simple `.support__card`s in the base `.support__grid` (fills
-  one 3-col row).
-- **Key Features** → 6 simple `.support__card`s in the base `.support__grid` (3×2).
-  Inline links (Camtrap DP, GBIF, LILA) preserved as real `<a>` tags inside the card
-  descriptions.
-- **Carousel kept** as the screenshot showcase (no image cards, no new styling).
-- **Remove the YouTube video** block from Documentation (keep the manual link +
-  "Read the Manual" button).
-- **Closing CTA:** one teal `.support__cta-band` (reused from the Support page) with
-  two buttons — **Download Biowatch** (primary, jumps to the OS-aware download
-  buttons at `#container-button-download-biowatch`) + **Support development** (ghost,
-  → `/support/`). Placed at the very end, after About.
-- **Light consistency:** a one-line intro above each card section.
-- **Emoji:** none (the existing `support-cta` partial's 🌍 is NOT reused; the band is
-  written fresh, emoji-free).
-
-## Changes (all in `content/tools/biowatch/index.md`)
-
-### 1. Why Biowatch? → cards
-
-Intro: "Built around three principles:" then a `.support__grid` of 3 `.support__card`:
-
-- **100% offline & private** — Your research data stays on your machine — no cloud
-  uploads, no accounts, no tracking. Built for the sensitive location data of
-  endangered species.
-- **Open source** — Inspect the code, contribute improvements, or adapt it to your
-  needs — built transparently by the conservation community, for the conservation
-  community.
-- **On-device AI** — Run powerful species-identification models directly on your
-  computer, with no internet required after setup.
-
-### 2. Key Features → cards
-
-Intro: "Everything from raw captures to published data:" then a `.support__grid` of 6
-`.support__card`. Titles / descriptions kept close to the current bullets:
-
-1. **Import from anywhere** — own image folders, a Camtrap DP package, or curated
-   public datasets from GBIF and LILA — or the one-click demo dataset. (links kept)
-2. **On-device species ID** — local AI models (SpeciesNet, MegaDetector, DeepFaune,
-   Manas), with a coverage map to pick the best fit for your region.
-3. **Interactive maps** — camera locations as species pie-charts, abundance markers,
-   or density heatmaps, filtered to an area you draw.
-4. **Activity & trends** — daily-activity clocks, seasonal timelines, and
-   per-deployment activity charts.
-5. **Media management** — browse, filter, and search thousands of images and videos,
-   review AI detections, and correct bounding boxes.
-6. **Standards-based export** — publish to GBIF as a Camtrap DP package, or export
-   media organized into one folder per species.
-
-### 3. Documentation — remove the video
-
-Delete the `<iframe>` YouTube embed, its `<em>` caption, and the surrounding `<br>`.
-Keep the manual paragraph + "Read the Manual" button.
-
-### 4. Closing CTA band
-
-After the About section:
-
-```html
-<div class="support__cta-band">
-  <div class="support__cta-band-text">
-    <h3 class="support__cta-band-title">Ready to try it?</h3>
-    <p class="support__cta-band-description">Biowatch is free and open source — and built in the open. Download it for Windows, macOS, or Linux, or help us keep developing it.</p>
-  </div>
-  <div class="support__cta-band-buttons">
-    <a class="link-no-decoration" href="#container-button-download-biowatch"><button class="button">Download Biowatch</button></a>
-    <a class="link-no-decoration" href="/support/"><button class="button button--ghost">Support development</button></a>
-  </div>
-</div>
 ```
+H1 + intro
+Image carousel (6 app screenshots, kept as the showcase)
+Download buttons (Windows / macOS / Linux — moved here from the top of the page)
+"New to Biowatch?" manual CTA card (.about-cta)
+## Why Biowatch?      → 3 cards
+## Key Features       → 6 cards (3×2)
+## About              (moved up, sits with the narrative sections)
+## Installation       (OS tabs, each with its own download button)
+Closing CTA band (.support__cta-band): Download Biowatch + Support development
+```
+
+## Changes
+
+### Content — `content/tools/biowatch/index.md`
+
+1. **Why Biowatch?** → 3 simple `.support__card`s in the base `.support__grid` (one
+   row). Intro: "Three things set it apart:".
+2. **Key Features** → 6 simple `.support__card`s in the base `.support__grid` (3×2).
+   Intro: "Everything from raw captures to published data:". Inline links (Camtrap
+   DP, GBIF, LILA) preserved as real `<a>` tags.
+3. **Carousel kept** as the screenshot showcase.
+4. **Video removed** from the old Documentation section.
+5. **Download buttons moved** from above the H1 to just below the carousel. The
+   container keeps `id="container-button-download-biowatch"` (the OS-detection
+   `<script>` and the closing band's Download button both reference it).
+6. **In-tab download buttons:** each Installation tab (Windows/macOS/Linux) now leads
+   with its own OS-colored download button; the redundant "download … above" step was
+   dropped.
+7. **Manual card:** the "Read the Manual" button became a full-width `.about-cta` card
+   ("New to Biowatch?", `button--cta`), placed just below the download buttons. The
+   `## Documentation` heading was removed (redundant with the card title).
+8. **About moved up** to between Key Features and Installation, so the page ends on a
+   clean action cluster (Installation → closing CTA).
+9. **Closing CTA band:** one `.support__cta-band` (reused from the Support page) with
+   **Download Biowatch** (jumps to `#container-button-download-biowatch`) +
+   **Support development** (ghost, → `/support/`). Emoji-free (the existing
+   `support-cta` partial's 🌍 is NOT reused).
+10. **Copy pass:** dropped the intro's duplicated manual sentence; rewrote the About
+    paragraphs to be sharper and less redundant ("grew out of a simple conviction…",
+    "no cloud, no subscriptions, and no lock-in"); changed the Why intro from "Built
+    around three principles:" to "Three things set it apart:".
+
+### Template — `layouts/tools/single.html`
+
+11. **Footer meta-links gated.** The auto-generated `<ul>` of meta links (🛠️ Learn
+    more about the project / GitHub / 🚀 All downloads) is now wrapped in
+    `{{ if not .Params.hide_meta_links }} … {{ end }}`. `hide_meta_links: true` is set
+    in biowatch's front matter only; pyronear/salmonvision (which use the same fields)
+    are unaffected.
+
+## Components reused (no SCSS changes)
+
+`.about-cta`, `.support__card`, `.support__grid`, `.support__cta-band` — all top-level
+selectors from the merged reID work / Support page. The tool page now depends on
+`.support__*` styles from `_support.scss` (intentional cross-file reuse).
 
 ## Out of scope
 
-- No SCSS or template changes (reuses `.support__card`, `.support__grid`,
-  `.support__cta-band`, all top-level selectors from the merged reID work / Support
-  page).
-- No change to the top download buttons, the OS-detection `<script>`, the carousel,
-  Installation tabs, or front matter.
+- No SCSS changes.
+- No change to the OS-detection `<script>`, the carousel, or the tab shortcode.
+- Front-matter unchanged except the new `hide_meta_links: true`.
 
 ## Verification
 
-- `hugo` builds with no errors.
+- `hugo` builds with no errors (verified).
+- Section order matches the list above (verified in source + rendered HTML).
 - Why = 3 cards (one row); Key Features = 6 cards (3×2); both stack to 1 col on mobile.
-- Card links (Camtrap DP / GBIF / LILA) resolve.
-- Video iframe gone; manual button remains.
-- Closing band shows both buttons; Download jumps to the top download buttons, Support
-  → `/support/`.
-- Support page itself unaffected.
+- Card links (Camtrap DP / GBIF / LILA) resolve; in-tab download buttons render in all
+  three tabs.
+- Video gone; footer meta-links gone for biowatch; pyronear/salmonvision still show
+  theirs.
+- Closing band shows both buttons; Download jumps to the relocated download buttons,
+  Support → `/support/`.
+- Support page itself unaffected by the `.support__grid`/`--two`/band reuse.

--- a/docs/specs/2026-06-13-biowatch-page-revamp-design.md
+++ b/docs/specs/2026-06-13-biowatch-page-revamp-design.md
@@ -1,0 +1,102 @@
+# Biowatch tool page revamp
+
+**Date:** 2026-06-13
+**Branch:** `worktree-biowatch-page-revamp` (off `main`)
+**File touched:** `content/tools/biowatch/index.md` (only — reuses existing components, no SCSS/template changes)
+
+## Goal
+
+Apply the same visual language used on the refreshed Animal reID page: turn the
+bullet sections into Support-style cards, add a strong closing CTA, and drop the
+video. The page is already emoji-free and well structured, so this is a focused pass.
+
+## Decisions
+
+- **Why Biowatch?** → 3 simple `.support__card`s in the base `.support__grid` (fills
+  one 3-col row).
+- **Key Features** → 6 simple `.support__card`s in the base `.support__grid` (3×2).
+  Inline links (Camtrap DP, GBIF, LILA) preserved as real `<a>` tags inside the card
+  descriptions.
+- **Carousel kept** as the screenshot showcase (no image cards, no new styling).
+- **Remove the YouTube video** block from Documentation (keep the manual link +
+  "Read the Manual" button).
+- **Closing CTA:** one teal `.support__cta-band` (reused from the Support page) with
+  two buttons — **Download Biowatch** (primary, jumps to the OS-aware download
+  buttons at `#container-button-download-biowatch`) + **Support development** (ghost,
+  → `/support/`). Placed at the very end, after About.
+- **Light consistency:** a one-line intro above each card section.
+- **Emoji:** none (the existing `support-cta` partial's 🌍 is NOT reused; the band is
+  written fresh, emoji-free).
+
+## Changes (all in `content/tools/biowatch/index.md`)
+
+### 1. Why Biowatch? → cards
+
+Intro: "Built around three principles:" then a `.support__grid` of 3 `.support__card`:
+
+- **100% offline & private** — Your research data stays on your machine — no cloud
+  uploads, no accounts, no tracking. Built for the sensitive location data of
+  endangered species.
+- **Open source** — Inspect the code, contribute improvements, or adapt it to your
+  needs — built transparently by the conservation community, for the conservation
+  community.
+- **On-device AI** — Run powerful species-identification models directly on your
+  computer, with no internet required after setup.
+
+### 2. Key Features → cards
+
+Intro: "Everything from raw captures to published data:" then a `.support__grid` of 6
+`.support__card`. Titles / descriptions kept close to the current bullets:
+
+1. **Import from anywhere** — own image folders, a Camtrap DP package, or curated
+   public datasets from GBIF and LILA — or the one-click demo dataset. (links kept)
+2. **On-device species ID** — local AI models (SpeciesNet, MegaDetector, DeepFaune,
+   Manas), with a coverage map to pick the best fit for your region.
+3. **Interactive maps** — camera locations as species pie-charts, abundance markers,
+   or density heatmaps, filtered to an area you draw.
+4. **Activity & trends** — daily-activity clocks, seasonal timelines, and
+   per-deployment activity charts.
+5. **Media management** — browse, filter, and search thousands of images and videos,
+   review AI detections, and correct bounding boxes.
+6. **Standards-based export** — publish to GBIF as a Camtrap DP package, or export
+   media organized into one folder per species.
+
+### 3. Documentation — remove the video
+
+Delete the `<iframe>` YouTube embed, its `<em>` caption, and the surrounding `<br>`.
+Keep the manual paragraph + "Read the Manual" button.
+
+### 4. Closing CTA band
+
+After the About section:
+
+```html
+<div class="support__cta-band">
+  <div class="support__cta-band-text">
+    <h3 class="support__cta-band-title">Ready to try it?</h3>
+    <p class="support__cta-band-description">Biowatch is free and open source — and built in the open. Download it for Windows, macOS, or Linux, or help us keep developing it.</p>
+  </div>
+  <div class="support__cta-band-buttons">
+    <a class="link-no-decoration" href="#container-button-download-biowatch"><button class="button">Download Biowatch</button></a>
+    <a class="link-no-decoration" href="/support/"><button class="button button--ghost">Support development</button></a>
+  </div>
+</div>
+```
+
+## Out of scope
+
+- No SCSS or template changes (reuses `.support__card`, `.support__grid`,
+  `.support__cta-band`, all top-level selectors from the merged reID work / Support
+  page).
+- No change to the top download buttons, the OS-detection `<script>`, the carousel,
+  Installation tabs, or front matter.
+
+## Verification
+
+- `hugo` builds with no errors.
+- Why = 3 cards (one row); Key Features = 6 cards (3×2); both stack to 1 col on mobile.
+- Card links (Camtrap DP / GBIF / LILA) resolve.
+- Video iframe gone; manual button remains.
+- Closing band shows both buttons; Download jumps to the top download buttons, Support
+  → `/support/`.
+- Support page itself unaffected.

--- a/layouts/tools/single.html
+++ b/layouts/tools/single.html
@@ -37,12 +37,13 @@
   <div class="tool-content">
     {{ .Content }}
 
+    {{ if not .Params.hide_meta_links }}
     <br/>
     <br/>
     <ul>
       {{ if .Params.project }}
       <li>
-       🛠️  
+       🛠️
         Learn more about the project <a target="_blank" href="{{ .Params.project }}">here</a>.
       </li>
       {{ end }}
@@ -63,6 +64,7 @@
         </li>
       {{ end }}
     </ul>
+    {{ end }}
   </div>
 </div>
 


### PR DESCRIPTION
Revamps the Biowatch tool page to match the visual language of the About/Support pages and the refreshed Animal reID page.

## Final section order
H1 + intro → carousel → download buttons → "New to Biowatch?" manual card → Why Biowatch? → Key Features → About → Installation → closing CTA band.

## Changes
**Content (`content/tools/biowatch/index.md`)**
- **Why Biowatch?** → 3 cards; **Key Features** → 6 cards (3×2), inline links preserved — reusing `.support__card`.
- **Download buttons** moved from above the H1 to just below the carousel.
- **In-tab download buttons:** each Installation tab (Windows/macOS/Linux) leads with its own OS download button; dropped the redundant "download… above" step.
- **"Read the Manual"** → a full-width `.about-cta` card ("New to Biowatch?"), placed just below the download buttons; removed the redundant "Documentation" heading.
- **About moved up** (sits with the narrative sections); the page ends on Installation → closing CTA.
- **Closing `.support__cta-band`:** Download Biowatch (→ relocated download buttons) + Support development (→ `/support/`).
- **Removed** the YouTube video.
- **Copy pass:** tightened the intro (dropped the duplicated manual line), sharpened the About paragraphs, reworded the "Why" intro.

**Template (`layouts/tools/single.html`)**
- Gated the auto-generated footer meta-links (🛠️/🚀 list) behind a `hide_meta_links` flag, set on biowatch only. Pyronear/SalmonVision (same fields) are unaffected.

## Notes
- Design spec: `docs/specs/2026-06-13-biowatch-page-revamp-design.md`.
- No SCSS changes — reuses `.about-cta`, `.support__card`, `.support__grid`, `.support__cta-band`. The page now depends on `.support__*` styles from `_support.scss` (intentional reuse).
- `hugo` build passes; verified rendered output (section order, cards, in-tab downloads, mobile stacking, Support page unaffected) via screenshots.