### PR TITLE
fix(about): align Our Partners section title with other section titles

### DIFF
--- a/assets/sass/4-layouts/_about.scss
+++ b/assets/sass/4-layouts/_about.scss
@@ -5,6 +5,7 @@
 .layout-about .services .container-wide,
 .layout-about .team .container-wide,
 .layout-about .about-stats .container-wide,
+.layout-about .about-partners .container-wide,
 .layout-about .about-timeline .container-wide {
   max-width: 1000px;
   margin-left: auto;
@@ -14,6 +15,7 @@
 .layout-about .services .container-wide,
 .layout-about .team .container-wide,
 .layout-about .about-stats .container-wide,
+.layout-about .about-partners .container-wide,
 .layout-about .about-timeline .container-wide {
   padding-left: 0;
   padding-right: 0;


### PR DESCRIPTION
## Problem

On the About page, the section titles ("What We Do", "Work in the Field", "Our Partners", "The Journey", "The Team") should all share the same left edge, but **Our Partners** was indented differently.

All section titles use identical markup (`.section__info > .section__head > .section__title`), so the cause was CSS. The about-page override in `assets/sass/4-layouts/_about.scss` constrains each section's inner `.container-wide` to `max-width: 1000px` with `padding-left/right: 0` — but the selector list omitted the partners section. As a result, "Our Partners" kept the default `.container-wide` (wider `max-width` + horizontal padding) and its title started at a different left edge.

## Fix

Add `.layout-about .about-partners .container-wide` to both selector groups so the partners section matches its siblings.

## Verification

- `hugo` build succeeds; compiled CSS contains the new selector in both rules.
- Screenshot of the static build with a vertical guide confirms all section titles now sit flush at the same left edge.