### PR TITLE
feat(home): redesign "View all" links as CTA buttons with chevron

### DIFF
--- a/assets/sass/3-modules/_sections.scss
+++ b/assets/sass/3-modules/_sections.scss
@@ -25,22 +25,6 @@
     font-weight: 600;
   }
 
-  .section__link {
-    font-family: $heading-font-family;
-    font-size: 22px;
-    font-weight: 500;
-    font-style: italic;
-    text-decoration: underline;
-    text-decoration-color: var(--heading-font-color);
-    text-decoration-thickness: 1px;
-    text-underline-offset: 3px;
-    line-height: 1.3;
-
-    &:hover {
-      text-decoration-color: transparent;
-    }
-  }
-
   @media (max-width: $mobile) {
     margin: 60px 0;
 
@@ -48,8 +32,7 @@
       margin-bottom: 32px;
     }
 
-    .section__title,
-    .section__link {
+    .section__title {
       font-size: 20px;
     }
   }

--- a/layouts/partials/section-blog.html
+++ b/layouts/partials/section-blog.html
@@ -9,7 +9,7 @@
         <div class="section__info">
           <div class="section__head">
             <h2 class="section__title">{{ .Site.Params.blog.blog_title | safeHTML }}</h2>
-            <a class="section__link" href="/posts">View all</a>
+            <a class="button button--cta" href="/posts">View all <i class="fa-solid fa-chevron-right"></i></a>
           </div>
           <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
         </div>

--- a/layouts/partials/section-projects.html
+++ b/layouts/partials/section-projects.html
@@ -12,7 +12,7 @@
             <div class="section__info">
               <div class="section__head">
                 <h2 class="section__title">{{ .Site.Params.projects.completed.projects_title | safeHTML }}</h2>
-                <a class="section__link" href="/projects">View all</a>
+                <a class="button button--cta" href="/projects">View all <i class="fa-solid fa-chevron-right"></i></a>
               </div>
               <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
             </div>
@@ -47,7 +47,7 @@
             <div class="section__info">
               <div class="section__head">
                 <h2 class="section__title">{{ .Site.Params.projects.fundraising.projects_title | safeHTML }}</h2>
-                <a class="section__link" href="/projects">View all</a>
+                <a class="button button--cta" href="/projects">View all <i class="fa-solid fa-chevron-right"></i></a>
               </div>
               <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
             </div>


### PR DESCRIPTION
Redesigns the three homepage **View all** links (blog + completed/fundraising projects) into CTA buttons.

## Changes
- **Style:** italic underlined text → `.button .button--cta`, matching the header **Support** button (coral `--tertiary-color` background, dark text). Note the Support button is coral, not the teal default `.button`, hence `--cta`.
- **Chevron:** added a `fa-chevron-right` icon after the label, mirroring the hero **About ›** button.
- **Cleanup:** removed the now-unused `.section__link` styles from `_sections.scss`.

## Verification
- `hugo` build passes.
- Rendered markup confirmed (1 blog + 2 projects buttons).
- Visually confirmed the button color/chevron match the header Support and hero About buttons.