### PR TITLE
Tools page redesign: shared card style, per-tool tints, stats + CTA

### DIFF
--- a/assets/sass/3-modules/_tools.scss
+++ b/assets/sass/3-modules/_tools.scss
@@ -141,3 +141,18 @@
 .tools-stats {
   margin: 36px 0 44px;
 }
+
+.tools-cta {
+  margin: 8px 0 0;
+}
+
+.tools-cta--bottom {
+  margin: 16px 0 8px;
+}
+
+.tools-cta__buttons {
+  display: flex;
+  gap: 14px;
+  justify-content: center;
+  flex-wrap: wrap;
+}

--- a/assets/sass/3-modules/_tools.scss
+++ b/assets/sass/3-modules/_tools.scss
@@ -1,11 +1,20 @@
 /* tools */
 .tool {
+  display: flex;
+  flex-direction: column;
   margin-bottom: 32px;
 }
 
 .tool__content {
   position: relative;
-  border-radius: 22px;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  padding: 14px;
+  border-radius: 16px;
+  background: var(--background-alt-color);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 6px 26px rgba(0, 0, 0, 0.05);
   will-change: transform;
   transition: transform .3s ease;
 
@@ -15,136 +24,96 @@
     .tool__title a {
       text-decoration-color: var(--primary-color);
     }
-
-    @media (min-width: $tablet + 1) {
-      .tool__image-container {
-        -webkit-filter: grayscale(0%);
-        filter: grayscale(0%);
-      }
-    }
   }
-}
-
-.tool__head {
-  display: block;
-  // padding: 20px;
-  padding: 18px;
-  border-radius: 22px;
-  // background: var(--background-alt-color);
-  background: #ede0d4;
-  transition: transform .3s ease;
 
   @media (max-width: $mobile) {
-    padding: 16px;
+    padding: 12px;
   }
 }
 
-.tool__image-container {
+.tool__image {
   position: relative;
   display: block;
   width: 100%;
-  height: 100%;
-  border-radius: 9px;
+  border-radius: 10px;
   user-select: none;
   transform: translate(0);
   overflow: hidden;
-  box-shadow: 0px 5px 40px rgba(0, 0, 0, 0.1);
-  background-color: var(--background-color);
-
-  @media (min-width: $tablet + 1) {
-    -webkit-filter: grayscale(50%);
-    filter: grayscale(50%);
-    transition: filter 0.3s ease;
-  }
+  background: var(--tool-tint, var(--accent-color));
 
   &::after {
     content: "";
     display: table;
     padding-top: 70%;
   }
+}
 
-  .tool__image-emoji {
-    font-size: 4em;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-  }
+.tool__logo {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 55%;
+  max-width: 250px;
 
-  .tool__image {
-    position: absolute;
-    top: 0;
-    left: 0;
+  img {
+    display: block;
     width: 100%;
-    height: 100%;
-    // background-image: linear-gradient(#e66465, #9198e5);
-    background-image: linear-gradient(#9198e5, #e66465);
-    // background-color: green;
+    height: auto;
+    max-height: 120px;
+    object-fit: contain;
   }
+}
 
-  .tool__icon {
-    height: 100%;
+.tool__logo--chip {
+  width: auto;
+  max-width: 70%;
+  padding: 16px;
+  background: #fdf1d7;
+  border-radius: 16px;
+  box-shadow: 0 2px #00000045;
 
-    img {
-      position: relative;
-      top:50%;
-      left:50%;
-      transform: translateX(-50%) translateY(-50%);
-      vertical-align: middle;
-      display: block;
-      width: 55%;
-      min-height: 50px;
-      max-width: 250px;
-
-    }
+  img {
+    width: 100%;
+    max-width: 200px;
   }
-
-  .tool__icon-container {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 16px;
-    background: #fdf1d7;
-    border-radius: 16px;
-    box-shadow: 0 2px #00000045;
-    max-width: 70%;
-    max-height: 70%;
-
-    img {
-      position: static;
-      transform: none;
-      width: 100%;
-      height: 100%;
-      max-width: 200px;
-      max-height: 200px;
-      object-fit: contain;
-    }
-  }
-
 }
 
 .tool__inner {
-  margin: 20px 20px 0;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  margin: 16px 6px 2px;
   line-height: 1;
 
+  @media (max-width: $mobile) {
+    margin: 14px 4px 2px;
+  }
+}
+
+.tool__info {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+
   .tool__subtitle {
-    display: inline-block;
     margin-bottom: 8px;
-    font-size: 16px;
-    line-height: 1.2;
+    padding-left: 15px;
+    font-size: 12px;
     font-weight: 700;
-    background: var(--text-gradient);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+    color: var(--text-alt-color);
   }
 
   .tool__title {
     margin-bottom: 8px;
-    font-size: 32px;
+    padding-left: 12px;
+    border-left: 3px solid var(--tertiary-color);
+    font-size: 18px;
     line-height: 1.2;
 
     a {
@@ -165,7 +134,7 @@
         right: 0;
         bottom: 0;
         z-index: 1;
-        border-radius: 22px;
+        border-radius: 16px;
       }
     }
   }
@@ -173,27 +142,15 @@
   .tool__excerpt {
     display: -webkit-box;
     margin-bottom: 0;
-    font-size: 16px;
-    line-height: 1.6;
+    font-size: 14.5px;
+    line-height: 1.55;
+    color: var(--text-alt-color);
     overflow-y: hidden;
-    -webkit-line-clamp: 4;
+    -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
-  }
-
-  @media (max-width: $desktop) {
-    margin: 20px 20px 0;
-
-    .tool__title {
-      font-size: 30px;
-    }
-  }
-
-  @media (max-width: $mobile) {
-    margin: 16px 16px 0;
-
-    .tool__title {
-      font-size: 26px;
-    }
   }
 }
 
+.tools-stats {
+  margin: 36px 0 44px;
+}

--- a/assets/sass/3-modules/_tools.scss
+++ b/assets/sass/3-modules/_tools.scss
@@ -20,10 +20,6 @@
 
   &:hover {
     transform: translateY(-8px);
-
-    .tool__title a {
-      text-decoration-color: var(--primary-color);
-    }
   }
 
   @media (max-width: $mobile) {
@@ -117,15 +113,6 @@
     line-height: 1.2;
 
     a {
-      text-decoration: underline;
-      text-decoration-color: transparent;
-      text-decoration-thickness: 2px;
-      text-underline-offset: 3px;
-
-      &:hover {
-        text-decoration-color: var(--primary-color);
-      }
-
       &::after {
         content: "";
         position: absolute;

--- a/content/tools/animal-reid/index.md
+++ b/content/tools/animal-reid/index.md
@@ -4,6 +4,7 @@ weight: 40
 show_title: true
 button_cta: Try Demo
 icon: /images/logos/reid-icon.png
+card_tint: "#ffe8df"
 summary: A modular computer vision framework for individual animal identification using state-of-the-art techniques including metric learning, local feature matching, and spot pattern analysis across multiple species.
 date: 2025-11-24
 js:

--- a/content/tools/biowatch/index.md
+++ b/content/tools/biowatch/index.md
@@ -4,6 +4,7 @@ weight: 30
 show_title: true
 button_cta: Download and Install
 icon: /images/logos/biowatch-icon.png
+card_tint: "#e0efec"
 summary: Open-source desktop app for analyzing camera trap data. Runs 100% locally — your sensitive wildlife data never leaves your computer.
 github_repo: https://github.com/earthtoolsmaker/biowatch
 project: /projects/biowatch-app

--- a/content/tools/pyronear/index.md
+++ b/content/tools/pyronear/index.md
@@ -5,6 +5,7 @@ show_title: false
 button_cta: Visit Pyronear
 icon: /images/logos/pyronear_logo_letters.png
 logo_container: true
+card_tint: "#fce3d8"
 summary: Democratizing open and low-tech solutions for fighting wildfires. An early detection solution that is open source, efficient, automatic, energy-efficient, economical and modular.
 github_repo: https://github.com/earthtoolsmaker/pyronear-mlops
 landing_page_url: https://pyronear.org/en/

--- a/content/tools/salmonvision/index.md
+++ b/content/tools/salmonvision/index.md
@@ -5,6 +5,7 @@ show_title: false
 button_cta: Visit SalmonVision
 icon: /images/logos/salmon-vision-logo.svg
 logo_container: true
+card_tint: "#dceef1"
 summary: Underwater cameras, sonar and drones combined with innovative AI technology to enable precise and automated salmon counting in rivers.
 landing_page_url: https://salmonvision.org
 project: /projects/wild_salmon_migration_monitoring

--- a/docs/specs/2026-06-13-tools-page-redesign-design.md
+++ b/docs/specs/2026-06-13-tools-page-redesign-design.md
@@ -1,0 +1,125 @@
+# Tools page redesign — design
+
+**Date:** 2026-06-13
+**Status:** Approved
+
+## Goal
+
+Restyle the `content/tools/` listing page so its cards match the shared card
+system used by spaces and blog, remove the clashing purple→red gradient behind
+the tool logos, and add a stats band above the grid. Each logo sits on a soft,
+per-tool brand tint.
+
+## Motivation
+
+The tools cards are the last listing on the site using the old visual language:
+a chunky `#ede0d4` head, a 32px title, a `--text-gradient` subtitle, and brand
+logos floated over `linear-gradient(#9198e5, #e66465)` (purple→red). That
+gradient clashes with the site's teal/terracotta palette. Spaces and blog
+already share a clean card system (`.space__*` / `.article__*`): alt-color
+fill, hairline border, soft shadow, 70%-aspect image, small uppercase subtitle,
+18px title with a terracotta left-accent. Tools should join that system.
+
+## Decisions (from brainstorming)
+
+- **Image area:** keep each tool's brand **logo** centered (logos are the
+  tools' identity) — do not generate illustrations or use screenshots.
+- **Backdrop:** replace the gradient with a **per-tool brand tint**.
+- **Page structure:** add a **stats band** above the cards, mirroring spaces.
+
+## Scope
+
+In scope (only these files):
+
+- `layouts/tools/list.html` — rewrite card markup + add stats band.
+- `assets/sass/3-modules/_tools.scss` — replace card styles with the shared
+  card system; remove the now-orphaned `.tool__head` / gradient / icon-over-
+  gradient rules.
+- `content/tools/{animal-reid,biowatch,pyronear,salmonvision}/index.md` — add
+  the new `card_tint` front-matter field.
+
+Out of scope: tool single pages (`layouts/tools/single.html`), spaces, blog,
+the global color scheme, and any unrelated refactoring.
+
+## Design
+
+### 1. Card chrome & typography (match `.space__*` / `.article__*`)
+
+Rewrite the `.tool` article markup to the shared structure:
+
+- `.tool__content` — `position:relative`, flex column, `padding:14px`,
+  `border-radius:16px`, `background:var(--background-alt-color)`,
+  `border:1px solid var(--border-color)`, `box-shadow:0 6px 26px rgba(0,0,0,.05)`,
+  `transition:transform .3s ease`, `:hover { transform:translateY(-8px) }`.
+  Mobile: `padding:12px`.
+- `.tool__image` — the 70%-aspect block (`&::after { padding-top:70% }`),
+  `border-radius:10px`, `overflow:hidden`. This is where the logo +
+  per-tool tint live (see §2).
+- `.tool__inner` / `.tool__info` — flex column, `margin:16px 6px 2px`.
+- `.tool__subtitle` — small uppercase, `font-size:12px`, `font-weight:700`,
+  `letter-spacing:.06em`, `text-transform:uppercase`, `color:var(--text-alt-color)`,
+  `padding-left:15px`. Replaces the old `--text-gradient` subtitle.
+- `.tool__title` — `font-size:18px`, `padding-left:12px`,
+  `border-left:3px solid var(--tertiary-color)`; the `a::after` full-card click
+  overlay with `border-radius:16px`. Replaces the old 32px title.
+- `.tool__excerpt` — `font-size:14.5px`, `line-height:1.55`,
+  `color:var(--text-alt-color)`, `-webkit-line-clamp:3`.
+
+The whole-card link overlay (`a::after`) is preserved so the entire card is
+clickable, as in spaces.
+
+### 2. Per-tool brand tint + logo
+
+The logo image area replaces the gradient with a soft per-tool tint:
+
+- New optional front-matter field **`card_tint`** on each tool's `index.md`,
+  holding a CSS color. The template sets it as an inline custom property
+  (e.g. `style="--tool-tint: {{ .Params.card_tint }}"`) on `.tool__image`, and
+  the SCSS uses `background: var(--tool-tint, <fallback>)`.
+- Fallback when `card_tint` is unset: a neutral brand tint (a pale teal/blush).
+- Tints are light/pastel so the logos read clearly.
+- The existing **cream chip** for `logo_container` tools (Pyronear,
+  SalmonVision) is preserved — those logos keep their rounded panel; other
+  logos (Biowatch, Animal reID) sit directly on the tint.
+
+Proposed default tints (light, on-brand):
+
+| Tool         | `card_tint` direction |
+|--------------|-----------------------|
+| Biowatch     | sage / teal           |
+| Pyronear     | warm terracotta       |
+| SalmonVision | water blue-teal       |
+| Animal reID  | blush                 |
+
+Exact hex values chosen during implementation to stay pastel and legible
+against each logo.
+
+### 3. Stats band
+
+Add an `about-stats`-style section above the card grid, reusing the same markup
+spaces uses (`section about-stats … animate` → `about-stats__grid` →
+`about-stats__item` with `about-stats__value` + `about-stats__label`). A
+`tools-stats` modifier class is added for any spacing tweaks.
+
+**Stats content (values + labels) is deferred — the user will provide the
+copy.** Implementation builds the band structure with placeholder items wired
+up; the user supplies the final figures before merge.
+
+## Cleanup
+
+The rewrite makes these orphaned and they are removed from `_tools.scss`:
+`.tool__head`, `.tool__image-container` (gradient, grayscale filter),
+`.tool__image` gradient background, and the old 32px `.tool__title` /
+`--text-gradient` `.tool__subtitle` rules. The `.tool__icon` /
+`.tool__icon-container` rules for centering the logo (and the cream chip) are
+retained/adapted since logos are still shown.
+
+## Verification
+
+- `hugo` builds clean (no template errors).
+- Tools listing renders 4 cards visually consistent with the spaces grid:
+  same border, shadow, radius, subtitle/title/excerpt treatment.
+- No purple→red gradient remains; each card shows its logo on its brand tint.
+- Stats band renders above the grid.
+- Screenshot the static build (`public/`) per local-preview quirks (restart
+  hugo / build is ground truth) to confirm.

--- a/layouts/partials/tools-cta.html
+++ b/layouts/partials/tools-cta.html
@@ -1,0 +1,11 @@
+<!-- tools support / collaborate CTA -->
+<div class="container">
+  <div class="about-cta tools-cta {{ .class }} animate">
+    <h3 class="about-cta__title">Free and open source — built for conservation</h3>
+    <p class="about-cta__description">Every tool here is free and open source. If they support your conservation work, or you'd like to build something together, we'd love to hear from you.</p>
+    <div class="tools-cta__buttons">
+      <a href="/support/" class="link-no-decoration button button--cta">Support our work</a>
+      <a href="/contact/" class="link-no-decoration button button--ghost">Get in touch</a>
+    </div>
+  </div>
+</div>

--- a/layouts/tools/list.html
+++ b/layouts/tools/list.html
@@ -32,8 +32,6 @@
     </div>
   </div>
 
-  {{ partial "tools-cta.html" (dict "class" "") }}
-
   <!-- begin tools stats -->
   <section class="section about-stats tools-stats animate">
     <div class="container">

--- a/layouts/tools/list.html
+++ b/layouts/tools/list.html
@@ -32,6 +32,8 @@
     </div>
   </div>
 
+  {{ partial "tools-cta.html" (dict "class" "") }}
+
   <!-- begin tools stats -->
   <section class="section about-stats tools-stats animate">
     <div class="container">
@@ -89,6 +91,8 @@
       {{ end }}
     </div>
   </div>
+
+  {{ partial "tools-cta.html" (dict "class" "tools-cta--bottom") }}
 
 </div>
 <!-- end page-wrapper -->

--- a/layouts/tools/list.html
+++ b/layouts/tools/list.html
@@ -32,48 +32,52 @@
     </div>
   </div>
 
+  <!-- begin tools stats -->
+  <!-- STATS COPY IS A PLACEHOLDER — final values/labels to be provided by the user before merge -->
+  <section class="section about-stats tools-stats animate">
+    <div class="container">
+      <div class="about-stats__grid">
+        <div class="about-stats__item">
+          <div class="about-stats__value">{{ len (where .Site.RegularPages "Section" "tools") }}</div>
+          <div class="about-stats__label">tools</div>
+        </div>
+        <div class="about-stats__item">
+          <div class="about-stats__value">100%</div>
+          <div class="about-stats__label">free &amp; open source</div>
+        </div>
+        <div class="about-stats__item">
+          <div class="about-stats__value">local</div>
+          <div class="about-stats__label">runs on your machine</div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- end tools stats -->
+
   <div class="container animate">
     <div class="row">
       {{ range (where .Site.RegularPages "Section" "tools" ) }}
       <article class="tool col col-4 col-w-6 col-t-12">
         <div class="tool__content">
-          <div class="tool__head">
-            <div class="tool__image-container">
-              <div class="tool__image">
-                <div class="tool__icon">
-                  {{ $iconPath := strings.TrimPrefix "/" .Params.icon }}
-                  {{ $icon := resources.Get $iconPath }}
-                  {{ if .Params.logo_container }}
-                  <div class="tool__icon-container">
-                    {{ if $icon }}
-                    <img src="{{ $icon.RelPermalink }}" alt="{{ .Title }} logo" />
-                    {{ else }}
-                    <img src="{{ .Params.icon }}" alt="{{ .Title }} logo" />
-                    {{ end }}
-                  </div>
-                  {{ else }}
-                    {{ if $icon }}
-                    <img src="{{ $icon.RelPermalink }}" alt="{{ .Title }} logo" />
-                    {{ else }}
-                    <img src="{{ .Params.icon }}" alt="{{ .Title }} logo" />
-                    {{ end }}
-                  {{ end }}
-                </div>
-              </div>
-              {{/*<img class="lazy" data-src="{{ .Params.Image | absURL }}" alt="{{ .Params.Title }}">*/}}
+          <div class="tool__image"{{ with .Params.card_tint }} style="--tool-tint: {{ . }}"{{ end }}>
+            <div class="tool__logo{{ if .Params.logo_container }} tool__logo--chip{{ end }}">
+              {{ $iconPath := strings.TrimPrefix "/" .Params.icon }}
+              {{ $icon := resources.Get $iconPath }}
+              {{ if $icon }}
+              <img src="{{ $icon.RelPermalink }}" alt="{{ .Title }} logo" />
+              {{ else }}
+              <img src="{{ .Params.icon }}" alt="{{ .Title }} logo" />
+              {{ end }}
             </div>
           </div>
           <div class="tool__inner">
             <div class="tool__info">
-              {{ if .Params.subtitle }}
-              <div class="tool__subtitle">{{ .Params.subtitle }}</div>
+              {{ with .Params.subtitle }}
+              <div class="tool__subtitle">{{ . }}</div>
               {{ end }}
-              {{ if .Params.title }}
-              {{/*<h3 class="tool__title"><a href="{{ .Params.landing_page_url }}" class="tool__link">{{ .Params.title }}</a></h3>*/}}
-              <h3 class="tool__title"><a href="{{ .RelPermalink }}" class="tool__link">{{ .Params.title }}</a></h3>
-              {{ end }}
-              {{ if .Params.summary }}
-              <p class="tool__excerpt">{{ .Params.summary }}</p>
+              <h3 class="tool__title"><a href="{{ .RelPermalink }}" class="tool__link">{{ .Title }}</a></h3>
+              {{ with .Params.summary }}
+              <p class="tool__excerpt">{{ . }}</p>
               {{ end }}
             </div>
           </div>

--- a/layouts/tools/list.html
+++ b/layouts/tools/list.html
@@ -33,7 +33,6 @@
   </div>
 
   <!-- begin tools stats -->
-  <!-- STATS COPY IS A PLACEHOLDER — final values/labels to be provided by the user before merge -->
   <section class="section about-stats tools-stats animate">
     <div class="container">
       <div class="about-stats__grid">
@@ -46,8 +45,12 @@
           <div class="about-stats__label">free &amp; open source</div>
         </div>
         <div class="about-stats__item">
-          <div class="about-stats__value">local</div>
-          <div class="about-stats__label">runs on your machine</div>
+          <div class="about-stats__value">500+</div>
+          <div class="about-stats__label">fires detected</div>
+        </div>
+        <div class="about-stats__item">
+          <div class="about-stats__value">1M</div>
+          <div class="about-stats__label">salmon tracked</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Restyle the tools listing cards to match the shared spaces/blog card system (alt-color fill, hairline border, soft shadow, 16px radius, hover lift, small uppercase subtitle, 18px title with terracotta left-accent, alt-color excerpt).
- Replace the clashing purple→red logo gradient with a soft **per-tool brand tint** driven by a new optional `card_tint` front-matter field (Biowatch teal, Pyronear terracotta, SalmonVision blue-teal, Animal reID blush). Logos stay centered; Pyronear/SalmonVision keep their cream chip.
- Add a spaces-style stats band above the grid: **4 tools · 100% free & open source · 500+ fires detected · 1M salmon tracked**.
- Add a spaces-style support/collaborate CTA (top + bottom) via a new `tools-cta.html` partial.
- Drop the green title-underline-on-hover so titles match the spaces cards.

Design spec: `docs/specs/2026-06-13-tools-page-redesign-design.md`.

## Test Plan
- [x] `hugo` builds clean (no template/SCSS errors).
- [x] Tools cards render visually consistent with the spaces grid (border, shadow, radius, typography).
- [x] No purple→red gradient remains; each card shows its logo on its brand tint; chips preserved for Pyronear/SalmonVision.
- [x] Stats band and top/bottom CTAs render.
- [ ] Reviewer: confirm copy (stats figures, CTA wording) and tint choices.