### PR TITLE
feat(projects): partner orgs stat over salmon in /projects band

### DIFF
--- a/docs/specs/2026-06-13-project-cards-match-blog-cards-design.md
+++ b/docs/specs/2026-06-13-project-cards-match-blog-cards-design.md
@@ -92,7 +92,7 @@ gained the same support/collaborate framing that `spaces/` received on
   (`projects-cta--bottom`).
 - **Stats band** — reuses the `.about-stats` component inside a `.container` (so
   it lines up with the cards, unlike the about page's `.container-wide`). Four
-  tailored stats: live project count, `1M+` salmon tracked, `9+` species
+  tailored stats: live project count, `19` partner organizations, `9+` species
   monitored, `100%` open source.
 - **`_projects.scss` re-created** — now holds only the projects-page spacing
   modifiers (`.projects-cta`, `.projects-cta--bottom`, `.projects-cta__buttons`,

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -44,8 +44,8 @@
           <div class="about-stats__label">conservation projects</div>
         </div>
         <div class="about-stats__item">
-          <div class="about-stats__value">1M+</div>
-          <div class="about-stats__label">salmon tracked</div>
+          <div class="about-stats__value">19</div>
+          <div class="about-stats__label">partner organizations</div>
         </div>
         <div class="about-stats__item">
           <div class="about-stats__value">9+</div>


### PR DESCRIPTION
Follow-up to #51 (merged). That PR shipped the `/projects` stats band with **"1M+ salmon tracked"**; this swaps it for **"19 partner organizations"** per request.

Single change — the stats band's second item:

| Before | After |
|--------|-------|
| 1M+ salmon tracked | 19 partner organizations |

Full band: `{N} conservation projects · 19 partner organizations · 9+ species monitored · 100% open source`.

Branched fresh off current `main` so the diff is only the stat swap (the spec note is updated to match) — no risk to the "View all" link work that landed after #51.

## Verification
- `hugo` builds clean; `/projects` output shows "partner organizations", salmon gone.