### PR TITLE
Fix Pyronear tools page single-frame detector demo

### DIFF
--- a/content/tools/pyronear/index.md
+++ b/content/tools/pyronear/index.md
@@ -91,7 +91,7 @@ Upload a camera image and watch the detector draw boxes around smoke.
 
 The second-stage model watches whole sequences: real wildfires get caught within minutes while clouds, fog, and haze look-alikes are rejected. This is the model that cuts false alarms by 4× in production.
 
-{{< hf_space "achouffe-temporal-smoke-pyronear" "6.18.0" >}}
+<p><iframe src="https://achouffe-temporal-smoke-pyronear.hf.space" loading="lazy" frameborder="0" style="width:100%;height:1000px;border:0;"></iframe></p>
 
 {{< /tab >}}
 {{< /tabs >}}


### PR DESCRIPTION
## Summary

The single-frame detector demo on the Pyronear **tools** page failed to render, while the identical demo on the **spaces** page worked.

**Root cause:** The tools page embeds two HuggingFace gradio spaces that require different runtimes — single-frame `forest-fire-pyronear` (gradio `5.4.0`) and temporal `temporal-smoke-pyronear` (gradio `6.18.0`). The `hf_space` shortcode mounts each via a `<gradio-app>` custom element, which can only be registered **once per document** (`customElements.define`). With two different runtimes loaded, the 6.18.0 loader won registration and the single-frame app (built for 5.4.0) failed to mount.

This is why the spaces page works (only one gradio app) and why `tools/animal-reid` works despite four embeds (all the same 5.4.0 version, deduped to one registration). Pyronear was the only page mixing versions.

**Fix:** Embed the temporal (6.18.0) demo via an isolated `<iframe>` — a separate document with its own gradio runtime. The main page now loads only the 5.4.0 runtime, so the single-frame `<gradio-app>` mounts correctly. The iframe also avoids the hidden-tab zero-height init problem a web component would hit in the inactive tab.

Verified via `hugo` build: `public/tools/pyronear/index.html` now loads a single gradio.js (5.4.0), one `<gradio-app>`, and the temporal demo as an isolated iframe.

## Test Plan
- [ ] On the deploy preview, open `/tools/pyronear/`, scroll to Interactive Demos, confirm the **Single-frame detection** tab renders and runs.
- [ ] Switch to the **Temporal verification** tab and confirm the iframe-embedded demo renders and runs.
- [ ] Adjust the iframe height (currently `1000px`) if it leaves whitespace or clips content.