### PR TITLE
feat(contact): add LinkedIn to social channels

### DIFF
--- a/assets/sass/3-modules/_contact.scss
+++ b/assets/sass/3-modules/_contact.scss
@@ -28,12 +28,6 @@
 .contact-channels__item {
   display: inline-flex;
   align-items: center;
-
-  &:not(:last-child)::after {
-    content: "·";
-    margin-left: 16px;
-    color: var(--text-alt-color);
-  }
 }
 
 .page__content a.contact-channels__link:not(.button) {
@@ -49,8 +43,8 @@
 
   i,
   img {
-    font-size: 16px;
-    width: 18px;
+    font-size: 20px;
+    width: 22px;
     text-align: center;
   }
 
@@ -59,8 +53,9 @@
   }
 }
 
-/* Custom tooltip on the social channel links */
-.page__content .contact-channels__link[data-tooltip] {
+/* Custom tooltip on the social channel links (contact page + footer) */
+.contact-channels__link[data-tooltip],
+.social__link[data-tooltip] {
 
   &::before,
   &::after {

--- a/assets/sass/3-modules/_social.scss
+++ b/assets/sass/3-modules/_social.scss
@@ -19,6 +19,7 @@
 }
 
 .social__link {
+  position: relative;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/config.toml
+++ b/config.toml
@@ -138,6 +138,12 @@ pagerSize = 6
     link = "https://huggingface.co/earthtoolsmaker"
     description = "Try our ML models & demos on HuggingFace"
 
+  [[params.social]]
+    icon = "fa-brands fa-linkedin-in"
+    name = "LinkedIn"
+    link = "https://www.linkedin.com/company/earthtoolsmaker/"
+    description = "Connect with us on LinkedIn"
+
   # Other icons can be found at https://fontawesome.com/icons
 
 

--- a/layouts/_default/contact.html
+++ b/layouts/_default/contact.html
@@ -51,7 +51,7 @@
                 {{ else if .icon }}
                 <i class="{{ .icon }}"></i>
                 {{ end }}
-                <span>{{ .name }}</span>
+                <span class="sr-only">{{ .name }}</span>
               </a>
             </li>
             {{ end }}

--- a/layouts/partials/social-links.html
+++ b/layouts/partials/social-links.html
@@ -3,7 +3,7 @@
   {{ range . }}
   <li class="social__item">
     <a class="social__link" href="{{ .link }}" target="_blank" rel="noopener"
-      aria-label="{{ .name }} link">
+      aria-label="{{ .name }} link"{{ with .description }} data-tooltip="{{ . }}"{{ end }}>
       {{ if .icon }}
         <i class="{{ .icon }}"></i>
       {{ end }}


### PR DESCRIPTION
Adds a LinkedIn entry to `params.social` in `config.toml`, which the contact page renders automatically alongside GitHub and HuggingFace.

- Link: https://www.linkedin.com/company/earthtoolsmaker/
- Icon: `fa-brands fa-linkedin-in` (already used by team cards)

Verified with a clean `hugo` build — the link appears in the contact page output.