### PR TITLE
Spaces: align single pages with tools, author content, add partner strips

### DIFF
--- a/assets/sass/3-modules/_hero.scss
+++ b/assets/sass/3-modules/_hero.scss
@@ -37,14 +37,22 @@
   }
 }
 
-/* Illustration heroes (SVG card art): keep the artwork visible, only fade the
-   bottom edge so the banner blends into the page instead of a hard cut. */
+/* Illustration heroes (SVG card art): keep the artwork visible, but veil the top
+   band so the header stays readable over any artwork, and fade the bottom edge so
+   the banner blends into the page instead of a hard cut. The veil uses the page
+   background color, so it works in both light and dark mode. */
 .hero__image--illustration .hero__image__inner::after {
-  background: linear-gradient(
-    180deg,
-    rgba(var(--rgb-image-color), 0) 22%,
-    rgba(var(--rgb-image-color), 1) 100%
-  );
+  background:
+    linear-gradient(
+      180deg,
+      rgba(var(--rgb-image-color), 0.78) 0,
+      rgba(var(--rgb-image-color), 0) 160px
+    ),
+    linear-gradient(
+      180deg,
+      rgba(var(--rgb-image-color), 0) 22%,
+      rgba(var(--rgb-image-color), 1) 100%
+    );
 }
 
 .hero__inner {

--- a/assets/sass/4-layouts/_space.scss
+++ b/assets/sass/4-layouts/_space.scss
@@ -192,6 +192,55 @@
   }
 }
 
+/* Partner logo strip (sourced from the linked project's clients) */
+.space-partners {
+  margin: 56px 0;
+  text-align: center;
+
+  .space-partners__label {
+    margin-bottom: 20px;
+    font-size: 13px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-alt-color);
+  }
+
+  .space-partners__logos {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 24px 44px;
+  }
+
+  .space-partners__item {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .space-partners__logo {
+    max-height: 52px;
+    max-width: 170px;
+    width: auto;
+    object-fit: contain;
+    opacity: 0.8;
+    transition: opacity .2s ease;
+  }
+
+  .space-partners__item:hover .space-partners__logo {
+    opacity: 1;
+  }
+}
+
+// Partner logos are links inside .space-content — drop the content link underline
+.space-content .space-partners__item {
+  border-bottom: none;
+
+  &:hover {
+    border-bottom: none;
+  }
+}
+
 /* Sidebar */
 .sidebar {
   height: 100%;

--- a/assets/sass/4-layouts/_space.scss
+++ b/assets/sass/4-layouts/_space.scss
@@ -210,34 +210,40 @@
     flex-wrap: wrap;
     justify-content: center;
     align-items: center;
-    gap: 24px 44px;
+    gap: 28px 56px;
   }
 
   .space-partners__item {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
+    height: 48px;
   }
 
   .space-partners__logo {
-    max-height: 52px;
-    max-width: 170px;
-    width: auto;
+    height: 44px;            // fixed height keeps the strip uniform and forces
+    width: auto;             // SVGs with only a viewBox (no intrinsic size) to render
+    max-width: 210px;
     object-fit: contain;
-    opacity: 0.8;
-    transition: opacity .2s ease;
+    opacity: 0.75;
+    filter: grayscale(100%);
+    transition: opacity .25s ease, filter .25s ease;
   }
 
   .space-partners__item:hover .space-partners__logo {
     opacity: 1;
+    filter: grayscale(0%);
   }
 }
 
-// Partner logos are links inside .space-content — drop the content link underline
-.space-content .space-partners__item {
-  border-bottom: none;
+// Partner logos are links inside .space-content — kill the content link underline
+// (needs the element selector to outweigh `.space-content a:not(.button)`).
+.space-content a.space-partners__item {
+  border: none;
+  font-weight: inherit;
 
   &:hover {
-    border-bottom: none;
+    border: none;
   }
 }
 

--- a/assets/sass/4-layouts/_space.scss
+++ b/assets/sass/4-layouts/_space.scss
@@ -119,6 +119,55 @@
     margin-bottom: 2em;
   }
 
+  .space-manual__list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(165px, 1fr));
+    gap: 32px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+
+    @media (max-width: $tablet) {
+      gap: 32px;
+    }
+
+    @media (max-width: $mobile) {
+      grid-template-columns: 1fr;
+      gap: 24px;
+    }
+  }
+
+  .space-manual__item {
+    padding-left: 20px;
+    border-left: 2px solid var(--border-color);
+  }
+
+  .space-manual__number {
+    display: block;
+    margin-bottom: 14px;
+    font-size: 21px;
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: 0.04em;
+    color: var(--tertiary-color);
+  }
+
+  .space-manual__step-title {
+    font-family: $base-font-family;
+    font-size: 18px;
+    line-height: 1.2;
+    font-weight: 700;
+    margin-bottom: 10px;
+    color: var(--heading-font-color);
+  }
+
+  .space-manual__step-description {
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--text-color);
+    margin: 0;
+  }
+
   .space-content__hf_space {
     margin-top: 1.8em;
     margin-bottom: 2.6em;

--- a/assets/sass/4-layouts/_space.scss
+++ b/assets/sass/4-layouts/_space.scss
@@ -16,7 +16,7 @@
 // .hf-space__gradio styles moved to 3-modules/_gradio-reset.scss
 
 .space-info {
-  margin-bottom: 25px;
+  margin-bottom: 56px;
   text-align: center;
   line-height: 1;
 

--- a/content/spaces/bear_identification.md
+++ b/content/spaces/bear_identification.md
@@ -17,4 +17,70 @@ manual_steps:
     description: The system will segment bear faces from the images and compare them against our database of bear faces from British Columbia. It then identifies the individual bear with the highest probability match.
 ---
 
+## Overview
 
+Bear Identification uses facial recognition to tell individual bears apart from ordinary photos — no collars, tags, or handling required. Developed in collaboration with the [BearID Project](https://bearresearch.org/), the system segments a bear's face from an image and compares it against a catalog of known individuals from British Columbia, returning the closest match.
+
+Because a bear's facial features stay recognizable over time, the same animal can be re-identified across seasons and camera trap locations — turning everyday wildlife photos into long-term population data.
+
+## Key Features
+
+What powers the identification:
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Face detection &amp; segmentation</h3>
+    <p class="support__card-description">Isolates the bear's face from a busy background so matching focuses on the features that actually distinguish one animal from another.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Metric-learning embeddings</h3>
+    <p class="support__card-description">Turns each face into a compact signature that captures the subtle traits separating individuals — the approach proven in our British Columbia work.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Catalog matching</h3>
+    <p class="support__card-description">Compares the query face against a database of known bears and ranks the most likely individuals by probability.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Confidence-ranked results</h3>
+    <p class="support__card-description">Surfaces the highest-probability match first, so reviewers can confirm an identity at a glance instead of scanning the whole catalog.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Fully non-invasive</h3>
+    <p class="support__card-description">Works from camera-trap and field photographs, with no tagging, collaring, or handling of the animals.</p>
+  </div>
+
+</div>
+
+## Use Cases
+
+Where it supports bear conservation:
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Population monitoring</h3>
+    <p class="support__card-description">Estimate how many distinct individuals use an area from camera-trap surveys, and track how that changes over time without physical capture.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Tracking individuals over time</h3>
+    <p class="support__card-description">Follow specific bears across seasons and camera locations to study survival, movement, and behavior.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Scalable field research</h3>
+    <p class="support__card-description">Automate identification that would otherwise take experts many hours of manual photo comparison, freeing time for analysis and fieldwork.</p>
+  </div>
+
+</div>
+
+<div class="about-cta">
+  <h3 class="about-cta__title">Learn more about the project</h3>
+  <p class="about-cta__description">See the full bear identification project and our collaboration with the BearID Project — the field context and research behind this system.</p>
+  <a href="/projects/bear_identification/" class="link-no-decoration button button--middle">View the project</a>
+</div>

--- a/content/spaces/bear_identification.md
+++ b/content/spaces/bear_identification.md
@@ -79,6 +79,8 @@ Where it supports bear conservation:
 
 </div>
 
+{{< space_partners >}}
+
 <div class="about-cta">
   <h3 class="about-cta__title">Learn more about the project</h3>
   <p class="about-cta__description">See the full bear identification project and our collaboration with the BearID Project — the field context and research behind this system.</p>

--- a/content/spaces/coral_reef_health_monitoring.md
+++ b/content/spaces/coral_reef_health_monitoring.md
@@ -72,6 +72,8 @@ From a single benthic image to quantified reef cover:
 
 </div>
 
+{{< space_partners >}}
+
 <div class="about-cta">
   <h3 class="about-cta__title">Learn more about the project</h3>
   <p class="about-cta__description">See the full coral reef health monitoring project and our collaboration with ReefSupport — the pipeline and research behind this tool.</p>

--- a/content/spaces/coral_reef_health_monitoring.md
+++ b/content/spaces/coral_reef_health_monitoring.md
@@ -17,4 +17,65 @@ manual_steps:
     description: The system will generate bounding boxes and segmentation masks for the detected coral species, each accompanied by a corresponding probability score.
 ---
 
+## Overview
+
+Coral Reef Health Monitoring brings computer vision to benthic (seabed) imagery, detecting and segmenting corals so reef surveys can be analyzed in a fraction of the time. Built in collaboration with [ReefSupport](https://reef.support/), it turns the photos and video collected on research dives into measurable data on what lives on the reef — and how that changes over time.
+
+Marine biologists spend a large share of their time manually processing dive footage. By automating the segmentation step, this tool removes the reporting bottleneck and helps quantify the long-term growth or decline of coral cover within marine protected areas.
+
+## How It Works
+
+From a single benthic image to quantified reef cover:
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Benthic image input</h3>
+    <p class="support__card-description">Works with the imagery already gathered on research dives — pick an example or upload your own seabed photo.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Detection &amp; segmentation</h3>
+    <p class="support__card-description">Draws bounding boxes and pixel-level segmentation masks around each coral, isolating it from sand, water, and other substrate.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Probability scores</h3>
+    <p class="support__card-description">Every detection comes with a confidence score, so analysts can prioritize review and keep only reliable results.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Coral-cover quantification</h3>
+    <p class="support__card-description">Segmentation masks translate into measurable coral cover — the foundation for tracking reef change survey after survey.</p>
+  </div>
+
+</div>
+
+## Why Reef Monitoring Matters
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Biodiversity hotspots</h3>
+    <p class="support__card-description">Reefs shelter roughly a quarter of all marine species on under 1% of the ocean floor — monitoring their health protects an outsized share of ocean life.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Faster reporting</h3>
+    <p class="support__card-description">Automating image analysis clears the reporting backlog, so conservation guidance can reach the field while it still makes a difference.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Tracking change in MPAs</h3>
+    <p class="support__card-description">Consistent, repeatable cover estimates reveal whether protected reefs are recovering or declining over the long term.</p>
+  </div>
+
+</div>
+
+<div class="about-cta">
+  <h3 class="about-cta__title">Learn more about the project</h3>
+  <p class="about-cta__description">See the full coral reef health monitoring project and our collaboration with ReefSupport — the pipeline and research behind this tool.</p>
+  <a href="/projects/coral_reef_health_monitoring/" class="link-no-decoration button button--middle">View the project</a>
+</div>
+
 

--- a/content/spaces/early_forest_fire_detection.md
+++ b/content/spaces/early_forest_fire_detection.md
@@ -17,3 +17,64 @@ manual_steps:
     description: The system will generate bounding boxes on the detected fire smokes with an associated probability.
 ---
 
+## Overview
+
+Early Forest Fire Detection analyzes camera imagery to spot the first wisps of wildfire smoke and flag them fast. It is the detection model behind [Pyronear](https://pyronear.org/), whose network of high-resolution cameras watches forested regions around the clock from elevated vantage points — turning a panoramic view of the landscape into an early warning the moment smoke appears.
+
+When the model spots smoke, it draws a bounding box with an associated probability. In the field, that detection becomes an alert routed to a supervision platform connected to the fire department, so responders can act while a fire is still small.
+
+## How Detection Works
+
+From a camera frame to an actionable alert:
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Always-on cameras</h3>
+    <p class="support__card-description">High-resolution cameras at elevated vantage points give panoramic coverage of the forest, day and night.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Real-time analysis</h3>
+    <p class="support__card-description">The model runs on a compact, low-power microcomputer at the camera, so detection happens on-site without heavy infrastructure.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Smoke localization</h3>
+    <p class="support__card-description">Detected smoke is marked with a bounding box and a probability, pinpointing where in the frame the threat is emerging.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Fast alerting</h3>
+    <p class="support__card-description">Detections feed a supervision platform connected to the fire department, turning a sighting into a response within minutes.</p>
+  </div>
+
+</div>
+
+## Why Early Detection Matters
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Biodiversity</h3>
+    <p class="support__card-description">Wildfires can wipe out habitats and the species that depend on them — catching fires early limits the damage.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Carbon storage</h3>
+    <p class="support__card-description">Forests lock away carbon. Every fire prevented or contained keeps that carbon out of the atmosphere.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Communities &amp; responders</h3>
+    <p class="support__card-description">Earlier warnings mean smaller fires, safer firefighting, and more time to protect the people living near forests.</p>
+  </div>
+
+</div>
+
+<div class="about-cta">
+  <h3 class="about-cta__title">Learn more about the project</h3>
+  <p class="about-cta__description">See the full early forest fire detection project and our work with Pyronear — the end-to-end system from camera to fire department.</p>
+  <a href="/projects/early_forest_fire_detection/" class="link-no-decoration button button--middle">View the project</a>
+</div>
+

--- a/content/spaces/early_forest_fire_detection.md
+++ b/content/spaces/early_forest_fire_detection.md
@@ -72,6 +72,8 @@ From a camera frame to an actionable alert:
 
 </div>
 
+{{< space_partners >}}
+
 <div class="about-cta">
   <h3 class="about-cta__title">Learn more about the project</h3>
   <p class="about-cta__description">See the full early forest fire detection project and our work with Pyronear — the end-to-end system from camera to fire department.</p>

--- a/content/spaces/forest_elephant_rumble_detection.md
+++ b/content/spaces/forest_elephant_rumble_detection.md
@@ -75,6 +75,8 @@ From raw audio to a localized rumble log:
 
 </div>
 
+{{< space_partners >}}
+
 <div class="about-cta">
   <h3 class="about-cta__title">Learn more about the project</h3>
   <p class="about-cta__description">See the full passive acoustic monitoring project and our work with the Elephant Listening Project and the Cornell Lab.</p>

--- a/content/spaces/forest_elephant_rumble_detection.md
+++ b/content/spaces/forest_elephant_rumble_detection.md
@@ -19,3 +19,64 @@ manual_steps:
   - step_name: Export the data
     description: A CSV file will be created, containing a comprehensive analysis of the audio file, including the localization of the detected elephant rumbles.
 ---
+
+## Overview
+
+Forest Elephant Rumbles Detection listens to the soundscape of Central Africa's rainforests and picks out elephant rumbles — the low-frequency calls that travel far through dense forest where the animals themselves are almost impossible to see. Developed with the [Elephant Listening Project](https://elephantlisteningproject.org/) at the Cornell Lab's K. Lisa Yang Center for Conservation Bioacoustics, it turns long audio recordings into structured data on when and where elephants called.
+
+Forest elephants have declined by more than 60% in a decade, and a critical obstacle to protecting them is simply not knowing where they are over time. Passive acoustic monitoring offers a way to close that data gap at the scale of an entire forest.
+
+## How It Works
+
+From raw audio to a localized rumble log:
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Audio input</h3>
+    <p class="support__card-description">Works with recordings from the forest soundscape — choose an example clip or upload your own audio.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Infrasound spectrograms</h3>
+    <p class="support__card-description">Generates spectrograms in the infrasound range, making the low-frequency rumbles visible to the model and to you.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Rumble detection</h3>
+    <p class="support__card-description">The model detects and classifies elephant rumbles against the background noise of the forest.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">CSV export</h3>
+    <p class="support__card-description">Produces a CSV with a full analysis of the recording, including the time localization of each detected rumble — ready for downstream research.</p>
+  </div>
+
+</div>
+
+## Why Acoustic Monitoring Matters
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Population insight</h3>
+    <p class="support__card-description">Sound carries where cameras can't see, giving researchers a way to track presence and activity across vast, dense forest.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Anti-poaching</h3>
+    <p class="support__card-description">Knowing where and when elephants are active helps prioritize patrols and protection in the areas that need it most.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Reducing conflict</h3>
+    <p class="support__card-description">Better data on elephant movement supports efforts to anticipate and mitigate human–elephant conflict.</p>
+  </div>
+
+</div>
+
+<div class="about-cta">
+  <h3 class="about-cta__title">Learn more about the project</h3>
+  <p class="about-cta__description">See the full passive acoustic monitoring project and our work with the Elephant Listening Project and the Cornell Lab.</p>
+  <a href="/projects/elephants_passive_acoustic_monitoring/" class="link-no-decoration button button--middle">View the project</a>
+</div>

--- a/content/spaces/human_wildlife_bear_conflict.md
+++ b/content/spaces/human_wildlife_bear_conflict.md
@@ -8,6 +8,13 @@ hero_image: /images/projects/human_wildlife_conflict_bear/cover.png
 project: /projects/human_wildlife_bear_conflict/
 hf_space: achouffe-bear-detection
 hf_space_code: https://huggingface.co/spaces/earthtoolsmaker/bear-detection/tree/main
+clients:
+  - name: HackThePlanet
+    link: https://www.hack-the-planet.io
+    logo: /images/clients/hacktheplanet/logo.png
+  - name: Foundation Conservation Carpathia
+    link: https://www.carpathia.org/
+    logo: /images/clients/carpathia/logo.svg
 manual_steps:
   - step_name: Image Selection
     description: Choose an image from the examples provided below, or upload your own data.
@@ -71,6 +78,8 @@ From a camera-trap frame to a deterrent that fires only when needed:
   </div>
 
 </div>
+
+{{< space_partners >}}
 
 <div class="about-cta">
   <h3 class="about-cta__title">Learn more about the project</h3>

--- a/content/spaces/human_wildlife_bear_conflict.md
+++ b/content/spaces/human_wildlife_bear_conflict.md
@@ -17,5 +17,66 @@ manual_steps:
     description: The system is capable of detecting bears in camera trap images, even at night. Once a bear is identified, the bear deterrent system can be activated, offering a cost-effective solution for mitigating human-wildlife conflicts.
 ---
 
+## Overview
+
+This Bear Detector helps people and bears share the same landscape. Near farms in Romania, bears wandering close to crops and livestock can lead to losses — and, too often, to retaliation against the animals. The system detects bears in camera-trap images, even at night, and can trigger a deterrent the moment one approaches, keeping bears at a safe distance without harm.
+
+It's a low-cost, automated way to defuse human–wildlife conflict at the source: instead of a person watching a feed around the clock, the camera does the watching and acts only when a bear actually appears.
+
+## How It Works
+
+From a camera-trap frame to a deterrent that fires only when needed:
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Camera-trap input</h3>
+    <p class="support__card-description">Runs on the same camera-trap images already used for wildlife monitoring near farms — pick an example or upload your own.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Day &amp; night detection</h3>
+    <p class="support__card-description">Reliably detects bears in daylight and in night-time imagery, when conflicts are most likely to happen.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Deterrent trigger</h3>
+    <p class="support__card-description">When a bear is identified, the system can activate a deterrent automatically — encouraging the animal to move on before any harm is done.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Cost-effective</h3>
+    <p class="support__card-description">Automating detection removes the need for constant human watch, making round-the-clock protection affordable for small farms.</p>
+  </div>
+
+</div>
+
+## Why Coexistence Matters
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Protect livelihoods</h3>
+    <p class="support__card-description">Keeping bears away from crops and livestock reduces the losses that put pressure on rural communities.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Protect bears</h3>
+    <p class="support__card-description">Preventing conflict in the first place means fewer bears are harmed in retaliation — a win for the population.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">A non-lethal solution</h3>
+    <p class="support__card-description">Deterrence, not removal: people and predators can share the landscape without either side paying the price.</p>
+  </div>
+
+</div>
+
+<div class="about-cta">
+  <h3 class="about-cta__title">Learn more about the project</h3>
+  <p class="about-cta__description">See the full human–wildlife bear conflict project — the field context and the deterrent system behind this detector.</p>
+  <a href="/projects/human_wildlife_bear_conflict/" class="link-no-decoration button button--middle">View the project</a>
+</div>
+
 
 

--- a/content/spaces/seal_identification.md
+++ b/content/spaces/seal_identification.md
@@ -18,7 +18,7 @@ manual_steps:
 
 ## Overview
 
-Seal Identification lets researchers track individual seals over time without tagging or any invasive procedure. By reading the unique whisker patterns, facial markings, and head shape of each animal, the model builds a distinctive "fingerprint" that stays stable across seasons and years. Developed with [Wageningen Marine Research](https://www.wur.nl/en/research-results/research-institutes/marine-research.htm), it supports the grey and harbour seal colonies of the Wadden Sea — a UNESCO World Heritage Site.
+Seal Identification lets researchers track individual seals over time without tagging or any invasive procedure. By reading the unique whisker patterns, facial markings, and head shape of each animal, the model builds a distinctive "fingerprint" that stays stable across seasons and years. Developed with [Wageningen Marine Research](https://www.wur.nl/en/Research-Results/Research-Institutes/marine-research.htm), it supports the grey and harbour seal colonies of the Wadden Sea — a UNESCO World Heritage Site.
 
 ## Key Features
 

--- a/content/spaces/seal_identification.md
+++ b/content/spaces/seal_identification.md
@@ -18,26 +18,70 @@ manual_steps:
 
 ## Overview
 
-The Seal Identification system enables researchers to track individual seals over time without physical tagging or invasive procedures. By analyzing unique whisker patterns, facial markings, and head shape characteristics, the model creates distinctive "fingerprints" for each seal that remain stable across seasons and years.
+Seal Identification lets researchers track individual seals over time without tagging or any invasive procedure. By reading the unique whisker patterns, facial markings, and head shape of each animal, the model builds a distinctive "fingerprint" that stays stable across seasons and years. Developed with [Wageningen Marine Research](https://www.wur.nl/en/research-results/research-institutes/marine-research.htm), it supports the grey and harbour seal colonies of the Wadden Sea — a UNESCO World Heritage Site.
 
-This technology supports critical conservation research by revealing:
-- Individual movement patterns between haul-out sites
-- Site fidelity and habitat preferences
-- Long-term survival rates
-- Reproductive success of individual females
-- Social structure within seal colonies
+## Key Features
+
+What the re-identification system brings:
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Whisker &amp; face fingerprints</h3>
+    <p class="support__card-description">Combines whisker patterns, facial markings, and head shape into a signature unique to each individual.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Top-k matching</h3>
+    <p class="support__card-description">Searches a database of known seals and returns the most similar individuals for review, not just a single guess.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Confidence scores</h3>
+    <p class="support__card-description">Each match comes with a confidence score, so a high-confidence hit signals the same seal seen again across sightings.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Non-invasive, across seasons</h3>
+    <p class="support__card-description">Identification from photographs alone means individuals can be followed year after year without ever handling them.</p>
+  </div>
+
+</div>
 
 ## Use Cases
 
-- **Long-Term Population Studies**: Track individual seals across multiple survey years to estimate survival rates and population dynamics. By re-identifying individuals annually, researchers can build complete life histories without invasive tagging.
-- **Movement Ecology**: Map how individual seals move between different haul-out sites within the Wadden Sea. Understanding connectivity between colonies informs conservation planning and marine protected area design.
-- **Reproductive Monitoring**: Identify individual females and track their reproductive success over time. This provides insights into breeding frequency, pup survival, and factors affecting population growth.
-- **Behavioral Research**: Link individual identification with behavioral observations to study personality, social networks, and learning behaviors within seal colonies.
+Where it supports seal conservation:
 
-## Applications Beyond the Wadden Sea
+<div class="support__grid">
 
-While developed for Wadden Sea seal monitoring, this re-identification approach is transferable to other seal populations and marine mammal species worldwide. The same computer vision techniques can enable non-invasive individual tracking in diverse conservation contexts, from Arctic ice seals to Antarctic fur seals.
+  <div class="support__card">
+    <h3 class="support__card-title">Long-term population studies</h3>
+    <p class="support__card-description">Re-identify individuals across survey years to estimate survival rates and build complete life histories without invasive tagging.</p>
+  </div>
 
-## Learn More
+  <div class="support__card">
+    <h3 class="support__card-title">Movement ecology</h3>
+    <p class="support__card-description">Map how seals move between haul-out sites across the Wadden Sea, informing conservation planning and protected-area design.</p>
+  </div>
 
-For complete details on the broader Wadden Sea seal monitoring project, including the multi-classifier detection system and web application for researchers, visit the [project page]({{< ref "/projects/wadden_sea_seal_monitoring" >}}).
+  <div class="support__card">
+    <h3 class="support__card-title">Reproductive monitoring</h3>
+    <p class="support__card-description">Track individual females and their reproductive success to understand breeding frequency, pup survival, and population growth.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Behavioral research</h3>
+    <p class="support__card-description">Link identities to observations to study social networks, site fidelity, and behavior within colonies.</p>
+  </div>
+
+</div>
+
+## Beyond the Wadden Sea
+
+Though built for the Wadden Sea, the same re-identification approach transfers to other seal populations and marine mammals worldwide — from Arctic ice seals to Antarctic fur seals — wherever non-invasive individual tracking can support conservation.
+
+<div class="about-cta">
+  <h3 class="about-cta__title">Learn more about the project</h3>
+  <p class="about-cta__description">See the full Wadden Sea seal monitoring project and our work with Wageningen Marine Research — including the detection system and researcher web app.</p>
+  <a href="/projects/wadden_sea_seal_monitoring/" class="link-no-decoration button button--middle">View the project</a>
+</div>

--- a/content/spaces/seal_identification.md
+++ b/content/spaces/seal_identification.md
@@ -80,6 +80,8 @@ Where it supports seal conservation:
 
 Though built for the Wadden Sea, the same re-identification approach transfers to other seal populations and marine mammals worldwide — from Arctic ice seals to Antarctic fur seals — wherever non-invasive individual tracking can support conservation.
 
+{{< space_partners >}}
+
 <div class="about-cta">
   <h3 class="about-cta__title">Learn more about the project</h3>
   <p class="about-cta__description">See the full Wadden Sea seal monitoring project and our work with Wageningen Marine Research — including the detection system and researcher web app.</p>

--- a/content/spaces/smolt_sonar_monitoring.md
+++ b/content/spaces/smolt_sonar_monitoring.md
@@ -14,3 +14,64 @@ manual_steps:
   - step_name: Visualize the results
     description: The system will generate an annotated video with bounding boxes around detected smolt, track their movement, and count individuals by migration direction.
 ---
+
+## Overview
+
+Smolt Sonar Monitoring detects, tracks, and counts juvenile salmon as they migrate downstream — straight from ARIS sonar footage. Developed with [BC Hydro](https://www.bchydro.com/) and [Lumax AI](https://lumax.ai/), it was built around sonar collected at Jansen Lake on Vancouver Island, British Columbia.
+
+Sonar is essential here because smolt migrate in turbid water, at night, and in dense bursts where optical cameras fail. ARIS produces video-like acoustic images that make small fish visible in those conditions — but reviewing that footage by hand is slow and error-prone. This tool automates the count.
+
+## How It Works
+
+From a sonar clip to a directional count:
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Sonar video input</h3>
+    <p class="support__card-description">Works directly on ARIS acoustic imagery — choose a preprocessed example sequence or upload your own sonar footage.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Smolt detection</h3>
+    <p class="support__card-description">Deep-learning object detection finds individual smolt in noisy acoustic frames and marks each with a bounding box.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Movement tracking</h3>
+    <p class="support__card-description">A tracker follows each fish across frames, so the same smolt isn't counted twice as it passes through the sonar beam.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Directional counting</h3>
+    <p class="support__card-description">Counts individuals by migration direction, separating genuine downstream migrants from fish drifting the other way.</p>
+  </div>
+
+</div>
+
+## Why Count Smolt
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Population trends</h3>
+    <p class="support__card-description">Smolt counts over multiple years reveal whether a salmon population is growing, stable, or heading toward collapse.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Dam impact</h3>
+    <p class="support__card-description">Counts above and below infrastructure quantify how dams and turbines affect downstream fish survival.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Compliance &amp; management</h3>
+    <p class="support__card-description">Consistent, auditable counts feed regulatory reporting and decisions on dam operations and habitat restoration.</p>
+  </div>
+
+</div>
+
+<div class="about-cta">
+  <h3 class="about-cta__title">Learn more about the project</h3>
+  <p class="about-cta__description">See the full smolt sonar monitoring project and our work with BC Hydro and Lumax AI — the ARIS pipeline behind this tool.</p>
+  <a href="/projects/monitoring_smolt_salmon_migration_with_sonar/" class="link-no-decoration button button--middle">View the project</a>
+</div>

--- a/content/spaces/smolt_sonar_monitoring.md
+++ b/content/spaces/smolt_sonar_monitoring.md
@@ -70,6 +70,8 @@ From a sonar clip to a directional count:
 
 </div>
 
+{{< space_partners >}}
+
 <div class="about-cta">
   <h3 class="about-cta__title">Learn more about the project</h3>
   <p class="about-cta__description">See the full smolt sonar monitoring project and our work with BC Hydro and Lumax AI — the ARIS pipeline behind this tool.</p>

--- a/content/spaces/snowleopard_identification.md
+++ b/content/spaces/snowleopard_identification.md
@@ -78,6 +78,8 @@ Where the system supports conservation work:
 
 </div>
 
+{{< space_partners >}}
+
 <div class="about-cta">
   <h3 class="about-cta__title">Learn more about the project</h3>
   <p class="about-cta__description">See the full snow leopard monitoring project and our partnership with OSI Panthera — the field context behind this identification system.</p>

--- a/content/spaces/snowleopard_identification.md
+++ b/content/spaces/snowleopard_identification.md
@@ -18,29 +18,68 @@ manual_steps:
 
 ## Overview
 
-The Snow Leopard Identification system enables researchers and conservationists to track individual snow leopards across Central Asia's mountain ranges without invasive tagging. By analyzing the unique rosette patterns on each animal's coat, the system creates distinctive visual fingerprints that remain stable throughout the animal's life.
+The Snow Leopard Identification system lets researchers and conservationists track individual snow leopards across Central Asia's mountain ranges without invasive tagging. By analyzing the unique rosette patterns on each animal's coat, it builds distinctive visual fingerprints that stay stable throughout the animal's life.
 
-Snow leopards are notoriously difficult to study due to their remote, high-altitude habitats spanning rugged terrain across 12 countries. This technology transforms camera trap images into actionable conservation data, supporting:
-
-- Individual identification across survey seasons
-- Population size estimation in remote regions
-- Movement tracking between territories
-- Long-term survival monitoring
+Snow leopards are notoriously hard to study — their remote, high-altitude habitats span rugged terrain across 12 countries. This technology turns camera trap images into actionable conservation data, supporting individual identification across survey seasons, population estimation in remote regions, movement tracking between territories, and long-term survival monitoring.
 
 ## Key Features
 
-- **Multi-Body-Part Matching**: Works with images of head, left flank, right flank, tail, and other body regions
-- **Location Filtering**: Filter catalog searches by geographic region
-- **Multiple Feature Extractors**: Choose between SIFT, SuperPoint, DISK, or ALIKED for optimal matching
-- **Confidence Scoring**: Four-level confidence system (🔵 Excellent, 🟢 Good, 🟡 Fair, 🔴 Uncertain)
-- **Visual Verification**: Side-by-side comparison views with matched keypoint visualization
+What the identification system brings to the field:
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Multi-body-part matching</h3>
+    <p class="support__card-description">Works with images of head, left flank, right flank, tail, and other body regions — so you can identify an individual from whatever the camera captured.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Location filtering</h3>
+    <p class="support__card-description">Narrow catalog searches by geographic region to speed up matching and cut down false candidates.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Multiple feature extractors</h3>
+    <p class="support__card-description">Choose between SIFT, SuperPoint, DISK, or ALIKED to get the best matching performance for your imagery.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Confidence scoring</h3>
+    <p class="support__card-description">A four-level confidence system — 🔵 Excellent, 🟢 Good, 🟡 Fair, 🔴 Uncertain — makes every match easy to triage.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Visual verification</h3>
+    <p class="support__card-description">Side-by-side comparison views with matched keypoint visualization let you confirm each identification by eye.</p>
+  </div>
+
+</div>
 
 ## Use Cases
 
-- **Population Monitoring**: Estimate population sizes in protected areas by identifying unique individuals from camera trap surveys. Track how populations change over time without physical capture.
-- **Movement Ecology**: Understand how individual snow leopards move across landscapes by matching sightings at different camera trap locations. Map territory boundaries and corridor usage.
-- **Conservation Planning**: Identify key individuals and breeding populations to prioritize protection efforts. Monitor the effectiveness of conservation interventions.
+Where the system supports conservation work:
 
-## Learn More
+<div class="support__grid">
 
-For complete details on the snow leopard monitoring project and partnership with OSI Panthera, visit the [project page]({{< ref "/projects/snow_leopard_monitoring" >}}).
+  <div class="support__card">
+    <h3 class="support__card-title">Population monitoring</h3>
+    <p class="support__card-description">Estimate population sizes in protected areas by identifying unique individuals from camera trap surveys, and track how populations change over time without physical capture.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Movement ecology</h3>
+    <p class="support__card-description">Match sightings at different camera trap locations to understand how individuals move across landscapes, mapping territory boundaries and corridor usage.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Conservation planning</h3>
+    <p class="support__card-description">Identify key individuals and breeding populations to prioritize protection efforts, and monitor the effectiveness of conservation interventions.</p>
+  </div>
+
+</div>
+
+<div class="about-cta">
+  <h3 class="about-cta__title">Learn more about the project</h3>
+  <p class="about-cta__description">See the full snow leopard monitoring project and our partnership with OSI Panthera — the field context behind this identification system.</p>
+  <a href="/projects/snow_leopard_monitoring/" class="link-no-decoration button button--middle">View the project</a>
+</div>

--- a/content/spaces/temporal_smoke_verification.md
+++ b/content/spaces/temporal_smoke_verification.md
@@ -74,6 +74,8 @@ From a flagged candidate to a verdict you can see:
 
 </div>
 
+{{< space_partners >}}
+
 <div class="about-cta">
   <h3 class="about-cta__title">Learn more about the project</h3>
   <p class="about-cta__description">See the wider early forest fire detection project and Pyronear's work — the detection system this verification step builds on.</p>

--- a/content/spaces/temporal_smoke_verification.md
+++ b/content/spaces/temporal_smoke_verification.md
@@ -18,3 +18,64 @@ manual_steps:
   - step_name: Run the model live (optional)
     description: Re-run the full pipeline from scratch on the Space's hardware to verify the precomputed results.
 ---
+
+## Overview
+
+Temporal Smoke Verification tackles the hardest part of automated wildfire detection: telling real smoke from things that merely look like it. A single frame of drifting cloud, morning haze, or fog can fool a detector. This model watches a candidate over a sequence of frames instead — because genuine wildfire smoke *behaves* in ways a cloud doesn't.
+
+Built on Pyronear's [temporal model](https://github.com/pyronear/temporal-model), it complements early detection by adding a second, time-aware opinion that filters out false alarms before they reach a responder.
+
+## How It Works
+
+From a flagged candidate to a verdict you can see:
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Tracked candidates</h3>
+    <p class="support__card-description">Each potential smoke is tracked across the sequence as a "tube" — a candidate followed frame by frame rather than judged in isolation.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Verdict over time</h3>
+    <p class="support__card-description">The classifier weighs how the candidate evolves and labels each tube — orange for judged smoke, gray for rejected look-alikes.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">See what it sees</h3>
+    <p class="support__card-description">Stabilized crops of each tube are laid out over time, holding the background still so the only thing moving is the candidate itself.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Verify it live</h3>
+    <p class="support__card-description">Re-run the full pipeline from scratch on the Space's hardware to confirm the precomputed results for yourself.</p>
+  </div>
+
+</div>
+
+## Why Temporal Verification
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Fewer false alarms</h3>
+    <p class="support__card-description">Clouds, haze, and fog are the classic triggers of false positives — watching over time filters them out.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Trust in alerts</h3>
+    <p class="support__card-description">Every false alarm erodes confidence and wastes responder time. Cleaner alerts keep people acting on the ones that matter.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">A second opinion</h3>
+    <p class="support__card-description">It layers on top of frame-by-frame detection, adding temporal context without slowing the first warning.</p>
+  </div>
+
+</div>
+
+<div class="about-cta">
+  <h3 class="about-cta__title">Learn more about the project</h3>
+  <p class="about-cta__description">See the wider early forest fire detection project and Pyronear's work — the detection system this verification step builds on.</p>
+  <a href="/projects/early_forest_fire_detection/" class="link-no-decoration button button--middle">View the project</a>
+</div>

--- a/content/spaces/trout_identification.md
+++ b/content/spaces/trout_identification.md
@@ -72,6 +72,8 @@ From a photo to a confident match:
 
 </div>
 
+{{< space_partners >}}
+
 <div class="about-cta">
   <h3 class="about-cta__title">Learn more about the project</h3>
   <p class="about-cta__description">See the full trout identification project and our work with Lumax AI on the Elk River — the research behind this tool.</p>

--- a/content/spaces/trout_identification.md
+++ b/content/spaces/trout_identification.md
@@ -16,3 +16,64 @@ manual_steps:
   - step_name: Visualize the results
     description: The system will standardize the fish images and compare them to our database of trout from British Columbia. It then identifies the individual fish that has the highest probability of matching. If no match is found, the fish is classified as a new entry.
 ---
+
+## Overview
+
+Trout Identification reads the spot patterns on a trout the way a fingerprint scanner reads a thumb. Each fish carries a unique, stable arrangement of black spots that stays consistent throughout its life — so a clear photo is enough to recognize the same individual again. Developed with [Lumax AI](https://lumax.ai/), the system was built around Westslope Cutthroat Trout monitored in the Elk River, British Columbia.
+
+It compares a new image against a catalog of known fish and returns the most likely match — or flags the trout as a new entry when it hasn't been seen before. No tagging, no handling, no stress on the animal.
+
+## How It Works
+
+From a photo to a confident match:
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Image input</h3>
+    <p class="support__card-description">Works from ordinary trout photographs — choose an example or upload your own image of the fish.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Standardization</h3>
+    <p class="support__card-description">Aligns and standardizes the fish so spot patterns can be compared consistently, regardless of how the photo was taken.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Spot-pattern matching</h3>
+    <p class="support__card-description">Matches the unique spot arrangement against a catalog of known trout and ranks the most likely individual.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">New-entry detection</h3>
+    <p class="support__card-description">When no confident match exists, the fish is logged as a new individual — growing the catalog over time.</p>
+  </div>
+
+</div>
+
+## Why It Matters
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">An indicator species</h3>
+    <p class="support__card-description">Westslope Cutthroat Trout need cold, clean water, so their numbers are a sensitive gauge of freshwater ecosystem health.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Non-invasive</h3>
+    <p class="support__card-description">Identification from natural markings means no tags or handling — monitoring that doesn't disturb the fish.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Population tracking</h3>
+    <p class="support__card-description">Re-identifying individuals over time supports survival estimates, movement studies, and long-term population monitoring.</p>
+  </div>
+
+</div>
+
+<div class="about-cta">
+  <h3 class="about-cta__title">Learn more about the project</h3>
+  <p class="about-cta__description">See the full trout identification project and our work with Lumax AI on the Elk River — the research behind this tool.</p>
+  <a href="/projects/trout_identification/" class="link-no-decoration button button--middle">View the project</a>
+</div>

--- a/content/spaces/wild_salmon_migration_monitoring.md
+++ b/content/spaces/wild_salmon_migration_monitoring.md
@@ -17,3 +17,64 @@ manual_steps:
     description: The system will generate an annotated video with bouding boxes around salmons and will count the number of individuals.
 ---
 
+## Overview
+
+Wild Salmon Migration Monitoring counts and classifies salmon straight from underwater camera streams as they return upriver to spawn. It's the model behind [SalmonVision](https://salmonvision.org/), built with the [Pacific Salmon Foundation](https://psf.ca/), the [Wild Salmon Center](https://wildsalmoncenter.org/), [Lumax AI](https://lumax.ai/), and [Simon Fraser University](https://sfu.ca/) to monitor a wide range of salmon species across British Columbia.
+
+Knowing how many salmon make it back is essential for management — escapement targets exist to ensure enough fish pass through, and populations face mounting pressure from fisheries, dams, and a changing climate. Automating the count turns continuous underwater video into reliable numbers without hours of manual review.
+
+## How It Works
+
+From an underwater clip to a counted run:
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Video input</h3>
+    <p class="support__card-description">Works on underwater camera footage of the river — choose an example clip or upload your own video.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Detection</h3>
+    <p class="support__card-description">Locates each salmon in the stream and marks it with a bounding box, even in busy, low-visibility water.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Tracking &amp; counting</h3>
+    <p class="support__card-description">Follows fish across frames and tallies individuals, producing an annotated video and a count you can trust.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Built for many species</h3>
+    <p class="support__card-description">Designed to monitor a range of salmon species returning to their natal streams, not just one.</p>
+  </div>
+
+</div>
+
+## Why It Matters
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Meeting escapement targets</h3>
+    <p class="support__card-description">Accurate counts confirm whether enough salmon are passing through to satisfy conservation regulations.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Pressure on populations</h3>
+    <p class="support__card-description">Fisheries, dams, and habitat change all threaten salmon runs — monitoring is the first step to managing them.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Ecosystem &amp; culture</h3>
+    <p class="support__card-description">Wild salmon are woven into BC's ecology, economy, and culture, carrying nutrients from ocean to stream as they return.</p>
+  </div>
+
+</div>
+
+<div class="about-cta">
+  <h3 class="about-cta__title">Learn more about the project</h3>
+  <p class="about-cta__description">See the full wild salmon migration monitoring project and the SalmonVision partnership behind this tool.</p>
+  <a href="/projects/wild_salmon_migration_monitoring/" class="link-no-decoration button button--middle">View the project</a>
+</div>
+

--- a/content/spaces/wild_salmon_migration_monitoring.md
+++ b/content/spaces/wild_salmon_migration_monitoring.md
@@ -72,6 +72,8 @@ From an underwater clip to a counted run:
 
 </div>
 
+{{< space_partners >}}
+
 <div class="about-cta">
   <h3 class="about-cta__title">Learn more about the project</h3>
   <p class="about-cta__description">See the full wild salmon migration monitoring project and the SalmonVision partnership behind this tool.</p>

--- a/content/spaces/wild_salmon_migration_monitoring.md
+++ b/content/spaces/wild_salmon_migration_monitoring.md
@@ -14,7 +14,7 @@ manual_steps:
   - step_name: Run the ML model
     description: Click the 'Submit' button to initiate the machine learning model.
   - step_name: Visualize the results
-    description: The system will generate an annotated video with bouding boxes around salmons and will count the number of individuals.
+    description: The system will generate an annotated video with bounding boxes around salmons and will count the number of individuals.
 ---
 
 ## Overview

--- a/docs/specs/2026-06-13-spaces-single-page-tools-alignment-design.md
+++ b/docs/specs/2026-06-13-spaces-single-page-tools-alignment-design.md
@@ -1,0 +1,93 @@
+# Spaces Single Page — Alignment with Tools Page — Design
+
+**Date:** 2026-06-13
+**Status:** Approved (brainstorm) — ready for implementation plan
+
+## Overview
+
+Bring the individual space pages (`layouts/spaces/single.html`) up to the visual
+standard of the recently redesigned tools page (`layouts/tools/single.html`). The
+spaces single page is the older design: it links out via an emoji `<ul>`, uses a
+heavy emoji "Manual" heading, and ends with a prev/next navigation block padded with
+~16 empty `<div>`s. The tools page is clean: centered title, content, then a tidy
+"Resources" footer.
+
+Scope is the **single** space page only. This is unrelated to the in-progress spaces
+**listing** card refresh (`2026-06-13-spaces-page-refresh-design.md`).
+
+## Approach
+
+Inline replication (not a shared partial). All template changes are scoped to
+`layouts/spaces/single.html`, plus one small SCSS tweak in `_space.scss`. The tools
+page is **not** modified, so the just-shipped tools redesign is not regressed. The
+footer markup/styles mirror the tools `tool-resources` block exactly, under a
+`space-resources` class.
+
+## Changes
+
+### 1. Resources footer (core change)
+
+Replace the emoji `<ul>` (🛠️ project / GitHub / 🤗 hosted) with the tools-page
+"Resources" footer: a centered uppercase "RESOURCES" label and inline links separated
+by `·`, built dynamically from whichever params exist:
+
+| Param | Icon | Label |
+|---|---|---|
+| `project` | `fa-solid fa-circle-info` | Project overview |
+| `github_repo` | `fa-brands fa-github` | Source code |
+| `hf_space_code` | `fa-solid fa-arrow-up-right-from-square` | Hosted on Hugging Face |
+
+Render only the rows whose param exists (same `slice`/`append` pattern as tools).
+Same inline styles as `tool-resources` for exact visual parity, under class
+`space-resources`.
+
+### 2. Reorder content
+
+Match the tools page, where Resources is always last. New order inside
+`.space-content`:
+
+```
+manual steps  →  Gradio embed  →  .Content  →  Resources footer
+```
+
+Today the link list sits mid-page, before `.Content`.
+
+### 3. Restrained "Manual" heading
+
+`🧑🏾‍🏫 Manual 📖` → `📖 Manual` — one emoji per heading, per the house style
+(About/Support are the reference).
+
+### 4. Separator
+
+Remove the `<hr class="space-separator">` between the info block and content, to match
+the tools page (which has no separator). The centered title+summary block keeps its own
+bottom margin.
+
+### 5. Remove prev/next navigation
+
+Delete the entire `.space__navigation` block (the prev/next "Next Space" markup with
+the empty `<div>`s). The spaces listing/gallery is how users move between spaces, and
+the tools page has no such nav.
+
+## Kept as-is
+
+- Gradio embed (`hf_space`) — the core function of a space page.
+- Manual steps list (`manual_steps`).
+- Hero image logic (`card_image` illustration / `hero_image` fallback).
+- Centered title + summary (`space-info`).
+
+## Dead code (flagged, not removed)
+
+Removing the nav block leaves `.space__nav`, `.space__navigation`, `.space-separator`,
+and related rules in `assets/sass/4-layouts/_space.scss` unused. Per the user's
+"don't delete pre-existing dead code unless asked" rule, these are left in place and
+flagged here. Prune on request.
+
+## Verification / Success Criteria
+
+- `hugo` builds cleanly (static build is ground truth, not the dev server).
+- A representative space (`bear_identification`) renders with: new dot-separated
+  Resources footer, correct order (manual → embed → content → resources), `📖 Manual`
+  heading, no `<hr>`, no prev/next nav block.
+- Footer visually matches a tool page's Resources footer (screenshot comparison).
+- No regression on the tools page (untouched).

--- a/layouts/shortcodes/space_partners.html
+++ b/layouts/shortcodes/space_partners.html
@@ -4,10 +4,13 @@
   partner data lives in one place. Optional title override: {{< space_partners title="Built with" >}}
 */}}
 {{ $title := .Get "title" | default "In partnership with" }}
-{{ $clients := slice }}
-{{ with .Page.Params.project }}
-  {{ with site.GetPage . }}
-    {{ $clients = .Params.clients | default slice }}
+{{/* Prefer the page's own clients; otherwise source them from the linked project. */}}
+{{ $clients := .Page.Params.clients | default slice }}
+{{ if not $clients }}
+  {{ with .Page.Params.project }}
+    {{ with site.GetPage . }}
+      {{ $clients = .Params.clients | default slice }}
+    {{ end }}
   {{ end }}
 {{ end }}
 {{ if $clients }}

--- a/layouts/shortcodes/space_partners.html
+++ b/layouts/shortcodes/space_partners.html
@@ -1,0 +1,35 @@
+{{/*
+  space_partners — static partner logo strip for a space page.
+  Sources partners from the page's linked project (.Params.project) so the
+  partner data lives in one place. Optional title override: {{< space_partners title="Built with" >}}
+*/}}
+{{ $title := .Get "title" | default "In partnership with" }}
+{{ $clients := slice }}
+{{ with .Page.Params.project }}
+  {{ with site.GetPage . }}
+    {{ $clients = .Params.clients | default slice }}
+  {{ end }}
+{{ end }}
+{{ if $clients }}
+<div class="space-partners">
+  <div class="space-partners__label">{{ $title }}</div>
+  <div class="space-partners__logos">
+    {{ range $partner := $clients }}
+    {{ $img := "" }}
+    {{ with $partner.logo }}
+      {{ $imgPath := strings.TrimPrefix "/" . }}
+      {{/* Prefer a dark-text variant (for white-on-transparent logos) when one exists */}}
+      {{ $img = or (resources.Get (replace $imgPath "logo.png" "logo_dark.png")) (resources.Get $imgPath) }}
+      {{ if and $img (not (strings.HasSuffix $imgPath ".svg")) (gt $img.Width 380) }}
+        {{ $img = $img.Resize "380x" }}
+      {{ end }}
+    {{ end }}
+    {{ with $img }}
+    <a class="space-partners__item" href="{{ $partner.link }}" target="_blank" rel="noopener noreferrer" title="{{ $partner.name }}">
+      <img class="space-partners__logo" src="{{ .RelPermalink }}" alt="{{ $partner.name }}" loading="lazy">
+    </a>
+    {{ end }}
+    {{ end }}
+  </div>
+</div>
+{{ end }}

--- a/layouts/spaces/single.html
+++ b/layouts/spaces/single.html
@@ -87,53 +87,6 @@
     </div>
     {{ end }}
 
-    {{ if or .NextInSection .PrevInSection }}
-    <div class="space__navigation">
-
-      {{ if .PrevInSection }}
-      <div class="prev">
-        <a href="{{ .PrevInSection.Permalink }}" class="prev__image">
-          {{ partial "space-image.html" (dict "path" .PrevInSection.Params.card_image "alt" .PrevInSection.Title "class" "space__nav__next_img") }}
-        </a>
-        <div class="prev__box">
-          <span class="space__nav space__nav__prev">Prev Space</span>
-          <h4 class="space__nav__title"><a href="{{ .PrevInSection.Permalink }}">{{ .PrevInSection.Title }}</a></h4>
-        </div>
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-      </div>
-      {{ end }}
-
-      {{ if .NextInSection }}
-      <div class="next">
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-        <div class="next__box">
-          <span class="space__nav space__nav__next">Next Space</span>
-          <h4 class="space__nav__title"><a href="{{ .NextInSection.Permalink }}">{{ .NextInSection.Title }}</a></h4>
-        </div>
-        <a href="{{ .NextInSection.Permalink }}" class="next__image">
-          {{ partial "space-image.html" (dict "path" .NextInSection.Params.card_image "alt" .NextInSection.Title "class" "space__nav__next_img") }}
-        </a>
-        {{/*{{ end }}*/}}
-      </div>
-      {{ end }}
-
-    </div>
-    {{ end }}
-
   </div>
 </div>
 

--- a/layouts/spaces/single.html
+++ b/layouts/spaces/single.html
@@ -43,9 +43,13 @@
     {{ if .Params.manual_steps }}
     <div class="space-content__manual">
       <b class="space-content__manual-title">📖 Manual</b>
-      <ol class="space-content__manual_steps_list">
-        {{ range $manual_steps }}
-          <li class="space-content__manual_step_item"><b>{{ .step_name }}:</b> {{ .description }}</li>
+      <ol class="space-manual__list">
+        {{ range $index, $step := $manual_steps }}
+          <li class="space-manual__item">
+            <span class="space-manual__number" aria-hidden="true">{{ printf "%02d" (add $index 1) }}</span>
+            <h4 class="space-manual__step-title">{{ $step.step_name }}</h4>
+            <p class="space-manual__step-description">{{ $step.description }}</p>
+          </li>
         {{ end }}
       </ol>
     </div>

--- a/layouts/spaces/single.html
+++ b/layouts/spaces/single.html
@@ -68,26 +68,25 @@
       ></gradio-app>
     </div>
     {{ end }}
-    <ul>
-      {{ if .Params.project }}
-      <li>
-       🛠️  
-        Learn more about the project <a target="_blank" href="{{ .Params.project }}">here</a>.
-      </li>
-      {{ end }}
-      {{ if .Params.github_repo }}
-      <li>
-        <i class="fa-brands fa-github"></i>
-        The code is available <a target="_blank" href="{{ .Params.github_repo }}">here</a>.
-      </li>
-      {{ end }}
-      {{ if .Params.hf_space_code }}
-        <li>
-          🤗 The application is hosted <a target="_blank" href="{{ .Params.hf_space_code }}">here</a>.
-        </li>
-      {{ end }}
-    </ul>
     {{ .Content }}
+
+    {{ $resources := slice }}
+    {{ with .Params.project }}{{ $resources = $resources | append (dict "icon" "fa-solid fa-circle-info" "label" "Project overview" "url" .) }}{{ end }}
+    {{ with .Params.github_repo }}{{ $resources = $resources | append (dict "icon" "fa-brands fa-github" "label" "Source code" "url" .) }}{{ end }}
+    {{ with .Params.hf_space_code }}{{ $resources = $resources | append (dict "icon" "fa-solid fa-arrow-up-right-from-square" "label" "Hosted on Hugging Face" "url" .) }}{{ end }}
+    {{ if $resources }}
+    <div class="space-resources" style="margin-top:48px;padding-top:24px;border-top:1px solid var(--border-color);text-align:center;">
+      <div style="font-size:13px;letter-spacing:0.08em;text-transform:uppercase;color:var(--text-alt-color);margin-bottom:14px;">Resources</div>
+      <div style="display:flex;flex-wrap:wrap;justify-content:center;align-items:center;gap:8px 18px;">
+        {{ range $i, $r := $resources }}
+        {{ if gt $i 0 }}<span aria-hidden="true" style="color:var(--border-color);">·</span>{{ end }}
+        <a class="link-no-decoration" target="_blank" rel="noopener" href="{{ $r.url }}" style="display:inline-flex;align-items:center;gap:0.45em;font-size:15px;color:var(--text-alt-color);">
+          <i class="{{ $r.icon }}"></i>{{ $r.label }}
+        </a>
+        {{ end }}
+      </div>
+    </div>
+    {{ end }}
 
     {{ if or .NextInSection .PrevInSection }}
     <div class="space__navigation">

--- a/layouts/spaces/single.html
+++ b/layouts/spaces/single.html
@@ -37,13 +37,12 @@
     <div class="space-info__summary">{{ .Params.summary }}</div>
     {{ end }}
   </div>
-  <hr class="space-separator">
 
   <div class="space-content">
     {{ $manual_steps := .Params.manual_steps }}
     {{ if .Params.manual_steps }}
     <div class="space-content__manual">
-      <b class="space-content__manual-title">🧑🏾‍🏫 Manual  📖</b>
+      <b class="space-content__manual-title">📖 Manual</b>
       <ol class="space-content__manual_steps_list">
         {{ range $manual_steps }}
           <li class="space-content__manual_step_item"><b>{{ .step_name }}:</b> {{ .description }}</li>

--- a/layouts/spaces/single.html
+++ b/layouts/spaces/single.html
@@ -42,7 +42,7 @@
     {{ $manual_steps := .Params.manual_steps }}
     {{ if .Params.manual_steps }}
     <div class="space-content__manual">
-      <b class="space-content__manual-title">📖 Manual</b>
+      <b class="space-content__manual-title">Manual</b>
       <ol class="space-manual__list">
         {{ range $index, $step := $manual_steps }}
           <li class="space-manual__item">


### PR DESCRIPTION
## Summary

Overhauls the individual **space** pages to match the polished tools-page standard, authors real content for them, and adds a partner-logo strip.

### Layout & template (`layouts/spaces/single.html`, `_space.scss`)
- Replaced the emoji `<ul>` link list with the tools-style **Resources** footer (dot-separated links).
- Reordered content (manual → embed → content → resources); removed the `<hr>` separator and the prev/next nav block.
- Manual steps now render as a numbered **`01 / 02 / 03`** grid matching the About page style; dropped the emoji from the "Manual" heading.
- Added breathing room between the summary and the content.

### Header readability (`_hero.scss`)
- Illustration heroes now get a soft top **veil** so the header stays legible over any hero art (works in light *and* dark mode). Scoped to space pages only.

### Content (all 11 spaces)
- Authored tool-style content — Overview + feature-card grids + use cases + a project CTA — grounded in each linked project (partners, methods, locations). Sections tailored per subject.

### Partner strips (`space_partners` shortcode)
- New `space_partners` shortcode renders a static, grayscale logo strip sourced from the linked project's `clients` (or the page's own). Added to every partner-bearing space. Bear-conflict uses HackThePlanet + Foundation Conservation Carpathia.

## Test plan
- [x] `hugo` builds cleanly (verified locally; 11 space pages render).
- [x] Spot-check space pages: Resources footer, numbered manual, header legibility over dark/light heroes, partner strips (single + multi-logo), CTAs.
- [x] Confirm tools page is unchanged.