### PR TITLE
style(testimonials): match card style with other cards

### DIFF
--- a/assets/sass/3-modules/_testimonials.scss
+++ b/assets/sass/3-modules/_testimonials.scss
@@ -36,17 +36,13 @@
 
 .testimonial-content {
   padding: 32px;
-  border-radius: 22px;
-  background: #fff5ed; // footer cream — keeps cards visible on the white section
+  border-radius: 16px;
+  background: var(--background-alt-color);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 6px 26px rgba(0, 0, 0, 0.05);
 
   @media (max-width: $mobile) {
     padding: 20px;
-  }
-}
-
-.dark-mode {
-  .testimonial-content {
-    background: var(--background-alt-color);
   }
 }
 


### PR DESCRIPTION
## What

Aligns the homepage testimonial cards with the shared card style used across the rest of the site (article, tools, and spaces cards).

## Changes

`assets/sass/3-modules/_testimonials.scss` — `.testimonial-content`:

- Background: cream `#fff5ed` → `var(--background-alt-color)`
- Border-radius: `22px` → `16px`
- Added `border: 1px solid var(--border-color)`
- Added `box-shadow: 0 6px 26px rgba(0, 0, 0, 0.05)`
- Removed the now-redundant `.dark-mode .testimonial-content` override (the CSS variable already resolves per theme)

Padding is left at `32px` (content-specific spacing for the avatar/quote layout).

## Notes

The other cards also have a hover lift (`translateY(-8px)`); intentionally left off here since testimonials live in a carousel slider. Easy to add for full parity if wanted.

Verified with `hugo` (exits 0, compiled CSS reflects the new values).