### PR TITLE
fix(tools): show 1M+ salmon tracked stat on tools page

### DIFF
--- a/layouts/tools/list.html
+++ b/layouts/tools/list.html
@@ -49,7 +49,7 @@
           <div class="about-stats__label">fires detected</div>
         </div>
         <div class="about-stats__item">
-          <div class="about-stats__value">1M</div>
+          <div class="about-stats__value">1M+</div>
           <div class="about-stats__label">salmon tracked</div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
The `/tools/` landing page stats block showed `1M` salmon tracked, while the SalmonVision detail page already shows `1M+`. This updates the listing page to match, displaying `1M+`.

## Change
- `layouts/tools/list.html`: `1M` → `1M+` for the "salmon tracked" stat