### PR TITLE
feat(partners): add 'View all' link to homepage partners carousel

### DIFF
--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -153,19 +153,19 @@ document.addEventListener("DOMContentLoaded", function() {
   /* ============================
   // Partners Slider
   ============================ */
-  if (document.querySelector(".about-partners-slider") && document.querySelector("#about-partners-controls")) {
+  if (document.querySelector(".about-partners-slider")) {
     var aboutPartnersSlider = tns({
       container: ".about-partners-slider",
       items: 2,
       slideBy: 1,
       gutter: 24,
       nav: false,
+      controls: false,
       mouseDrag: true,
       autoplay: true,
       autoplayButtonOutput: false,
       autoplayTimeout: 3000,
       speed: 500,
-      controlsContainer: "#about-partners-controls",
       responsive: {
         768: {
           items: 3,

--- a/layouts/partials/section-testimonials.html
+++ b/layouts/partials/section-testimonials.html
@@ -13,14 +13,7 @@
               {{ with .Site.Params.partners.partners_title }}
               <h2 class="section__title">{{ . | safeHTML }}</h2>
               {{ end }}
-              <ul class="controls list-reset" id="about-partners-controls" aria-label="Partners Navigation" tabindex="0">
-                <li class="prev" data-controls="prev" aria-controls="about-partners-slider" tabindex="-1">
-                  <i class="fa-solid fa-arrow-left-long"></i>
-                </li>
-                <li class="next" data-controls="next" aria-controls="about-partners-slider" tabindex="-1">
-                  <i class="fa-solid fa-arrow-right-long"></i>
-                </li>
-              </ul>
+              <a class="button button--cta" href="/partners/">View all <i class="fa-solid fa-chevron-right"></i></a>
             </div>
             {{ with .Site.Params.partners.partners_title }}
             <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>


### PR DESCRIPTION
## What

Adds a **"View all →" button** to the homepage partners carousel, linking to `/partners/`. It replaces the carousel's `←`/`→` arrow controls, matching the existing pattern used by the blog and projects sections.

## Why

`/partners` was previously only reachable from the footer menu. This surfaces it from the homepage where the partner logos already appear.

## Changes

- `layouts/partials/section-testimonials.html` — swap the partners `<ul class="controls">` (arrows) for `<a class="button button--cta" href="/partners/">View all …</a>`.
- `assets/js/common.js` — drop the `#about-partners-controls` dependency from the slider guard, remove `controlsContainer`, and add `controls: false` so the carousel still autoplays/drags without rendering its own arrows.

## Verification

- `hugo --minify` builds clean.
- Homepage renders the `button--cta` link to `/partners/`; old arrow markup removed; `about-partners-slider` carousel still present and autoplaying.