### PR TITLE
style(footer): match footer color to project card colors

### DIFF
--- a/assets/sass/3-modules/_footer.scss
+++ b/assets/sass/3-modules/_footer.scss
@@ -1,8 +1,7 @@
 /* Footer */
 .footer {
-  border-top: 1px solid #ede0d4;
-  // background: #ede0d4;
-  background: #fff5ed;
+  border-top: 1px solid var(--border-color);
+  background: var(--background-alt-color);
 
   .footer__inner {
     padding: 40px 0;


### PR DESCRIPTION
## What

Make the footer background/border match the project cards by pointing them at the same CSS variables the cards use.

\`\`\`scss
.footer {
  border-top: 1px solid var(--border-color);   // was: 1px solid #ede0d4
  background: var(--background-alt-color);       // was: #fff5ed
}
\`\`\`

## Effect

- **Light mode:** footer background `#fff5ed` (cream) → `#fbf6f6`, the exact value `.article__content` cards use. Border-top unchanged (`--border-color` is `#ede0d4` in light mode).
- **Dark mode:** the footer was hardcoded to stay cream `#fff5ed`; it now becomes `#1a1a1f` to match the cards, with a dark border.

## Status

Draft — not yet convinced this is the right look. Open question: should the footer truly be identical to the cards, or just *harmonize* with them? Alternatives if `#fbf6f6` feels off:
- Keep the warm cream `#fff5ed` but apply it to the cards instead (warm everywhere).
- Use a slightly darker shade for the footer to set it apart as a distinct region.