### PR TITLE
style(cards): match feature cards to testimonial/project card style

### DIFF
--- a/assets/sass/4-layouts/_support.scss
+++ b/assets/sass/4-layouts/_support.scss
@@ -220,7 +220,9 @@
 .support__card {
   padding: 28px;
   background-color: var(--background-alt-color);
-  border-radius: 22px;
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  box-shadow: 0 6px 26px rgba(0, 0, 0, 0.05);
 
   .support__card-title {
     font-family: $base-font-family;


### PR DESCRIPTION
## What

Restyle the small feature/highlight cards (`.support__card`) to match the testimonial and project/blog card style.

The shared `.support__card` base class now uses the same treatment as `.testimonial-content` and `.article__content`:

- `border: 1px solid var(--border-color)` (warm `#ede0d4` hairline) — added
- `box-shadow: 0 6px 26px rgba(0, 0, 0, 0.05)` soft shadow — added
- `border-radius: 16px` — was `22px`

The background fill (`--background-alt-color`) was already shared, so the cards now read as the same card family across the site.

## Scope

Because `.support__card` is the shared base class, the change propagates to all the small cards in one place: the tools pages (Pyronear, animal-reid, biowatch, salmonvision), all spaces pages, and the support page (whose `.support__way` / `.support__track` variants extend the same base and keep their own hover behavior).

Non-interactive cards intentionally get no hover lift, matching the static testimonial cards.

## Verification

- `hugo` builds cleanly; compiled CSS confirmed to contain the new border/shadow/radius.
- Screenshot of the Pyronear "Why Pyronear" section confirms the bordered, soft-shadow look matching the testimonial/project cards.