### PR TITLE
fix(spaces): point trout embed at achouffe/trout-reID

### DIFF
--- a/content/spaces/trout_identification.md
+++ b/content/spaces/trout_identification.md
@@ -6,8 +6,8 @@ github_repo: https://github.com/earthtoolsmaker/trout-reid
 date: 2024-12-08
 hero_image: /images/pages/spaces/trout_identification/hero.jpg
 project: /projects/trout_identification/
-hf_space: earthtoolsmaker-trout-reid
-hf_space_code: https://huggingface.co/spaces/earthtoolsmaker/trout-reID/tree/main
+hf_space: achouffe-trout-reid
+hf_space_code: https://huggingface.co/spaces/achouffe/trout-reID/tree/main
 manual_steps:
   - step_name: Image Selection
     description: Choose an image from the examples provided below, or upload your own data.


### PR DESCRIPTION
## Problem

The Trout Identification space stopped loading on the website. The embed (`earthtoolsmaker-trout-reid.hf.space`) returns **503** because `earthtoolsmaker/trout-reID` is **PAUSED** and can't be restarted — the org's free `cpu-basic` quota is full of running spaces that are all live website embeds.

## Fix

Duplicated the space to **`achouffe/trout-reID`** (which had free quota) and repoint the front matter at the new subdomain. This is the same cross-account offloading pattern already used for the smolt (`Lumax-eco`), bear-detection, and temporal-smoke embeds.

The fresh rebuild also required two dependency fixes in the duplicated space's `requirements.txt` (not in this repo): pin `gradio==5.6.*` to match the README `sdk_version`, and `huggingface_hub<1.0` (gradio 5.6 oauth imports `HfFolder`, removed in hub 1.0).

## Verification

- `achouffe/trout-reID` runtime: **RUNNING**
- `https://achouffe-trout-reid.hf.space` → **200**
- `hugo` builds clean; rendered page embeds the new subdomain

> Note: free spaces auto-pause after 48h of inactivity, so this can recur. Reliable uptime would need paid hardware or a keep-alive ping.