### PR TITLE
Revamp individual project pages (editorial single-column)

### DIFF
--- a/assets/sass/3-modules/_header.scss
+++ b/assets/sass/3-modules/_header.scss
@@ -295,26 +295,22 @@
       font-size: 16px;
       line-height: 1.6;
 
+      // Dropdown items use a clean colour change. The top-level nav's
+      // floating dot (::before) reads as a stray mark in a vertical list,
+      // so it's removed here in favour of a hover/active colour.
+      &::before { content: none; }
+      &::after { content: none; }
+
       &:hover {
-        &::after {
-          opacity: .3;
-        }
+        color: var(--secondary-color);
+      }
+
+      &.active-link {
+        color: var(--primary-color);
       }
 
       &:last-child {
         margin-bottom: 0;
-      }
-
-      &.active-link {
-        &::before {
-          opacity: 1;
-          visibility: visible;
-          background-color: var(--primary-color);
-        }
-      }
-
-      &::before {
-        top: 0;
       }
     }
   }

--- a/assets/sass/3-modules/_header.scss
+++ b/assets/sass/3-modules/_header.scss
@@ -296,10 +296,14 @@
       line-height: 1.6;
 
       // Dropdown items use a clean colour change. The top-level nav's
-      // floating dot (::before) reads as a stray mark in a vertical list,
-      // so it's removed here in favour of a hover/active colour.
-      &::before { content: none; }
-      &::after { content: none; }
+      // floating dot (::before) reads as a stray mark in the desktop
+      // floating dropdown, so it's removed there in favour of a hover/
+      // active colour. Gated to desktop so the inline mobile menu — which
+      // shares this selector — keeps its dot indicator.
+      @media (min-width: $desktop + 1) {
+        &::before { content: none; }
+        &::after { content: none; }
+      }
 
       &:hover {
         color: var(--secondary-color);

--- a/assets/sass/4-layouts/_project-single.scss
+++ b/assets/sass/4-layouts/_project-single.scss
@@ -48,3 +48,59 @@
     .project-hero__stat-value { font-size: 30px; }
   }
 }
+
+// --- Facts bar (under hero, aligned to the reading column) ---
+.project-facts {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px 22px;
+  max-width: 780px;
+  margin: -28px auto 8px;          // pull up into the hero's bottom margin
+  padding: 16px 0;
+  border-bottom: 1px solid var(--border-color);
+
+  &__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45em;
+    font-size: 15px;
+    color: var(--text-alt-color);
+
+    img { height: 18px; width: auto; }
+    i { font-size: 18px; }
+
+    &:hover { color: var(--secondary-color); }
+  }
+
+  &__tools {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  &__chip {
+    font-size: 12px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: var(--background-alt-color);
+    border: 1px solid var(--border-color);
+    color: var(--text-color);
+  }
+
+  &__date {
+    margin-left: auto;
+    font-size: 14px;
+    color: var(--text-alt-color);
+  }
+
+  @media (max-width: $tablet) {
+    padding-left: $base-spacing-unit;
+    padding-right: $base-spacing-unit;
+  }
+
+  @media (max-width: $mobile) {
+    margin-top: 8px;
+    &__date { margin-left: 0; }
+  }
+}

--- a/assets/sass/4-layouts/_project-single.scss
+++ b/assets/sass/4-layouts/_project-single.scss
@@ -1,0 +1,8 @@
+/* Individual Project Page
+   Editorial single-column layout. Reuses .about-hero, .support__cta-band,
+   .post__content, .article, .section__info from other layouts; only
+   project-specific pieces live here. */
+
+.project-single {
+  // sections filled in by later tasks
+}

--- a/assets/sass/4-layouts/_project-single.scss
+++ b/assets/sass/4-layouts/_project-single.scss
@@ -88,10 +88,23 @@
     color: var(--text-color);
   }
 
-  &__date {
+  &__live {
     margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
     font-size: 14px;
+    font-weight: 600;
     color: var(--text-alt-color);
+  }
+
+  &__live-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #3fb950;
+    box-shadow: 0 0 0 0 rgba(63, 185, 80, 0.5);
+    animation: project-facts-live-pulse 2s infinite;
   }
 
   @media (max-width: $tablet) {
@@ -101,8 +114,14 @@
 
   @media (max-width: $mobile) {
     margin-top: 8px;
-    &__date { margin-left: 0; }
+    &__live { margin-left: 0; }
   }
+}
+
+@keyframes project-facts-live-pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(63, 185, 80, 0.5); }
+  70%  { box-shadow: 0 0 0 7px rgba(63, 185, 80, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(63, 185, 80, 0); }
 }
 
 // --- Reading column (typography inherited from .post__content) ---
@@ -123,8 +142,6 @@
   margin-top: 64px;
 }
 
-// --- Related / next sections: tighten the gap between the two
-//     adjacent card sections (each is a .section with 80px margins) ---
-.project-next {
-  margin-top: 0;
-}
+// The related-reading and next-project blocks keep the site's standard
+// .section rhythm (80px), so there's comfortable, consistent spacing
+// before "Next project" whether or not a related section precedes it.

--- a/assets/sass/4-layouts/_project-single.scss
+++ b/assets/sass/4-layouts/_project-single.scss
@@ -159,3 +159,16 @@
     .partner-logo-container { height: 44px; }
   }
 }
+
+// --- CTA band: keep the reused band, just give it breathing room
+//     consistent with the surrounding sections ---
+.project-single .support__cta-band,
+.container > .support__cta-band {
+  margin-top: 64px;
+}
+
+// --- Related / next sections: tighten the gap between the two
+//     adjacent card sections (each is a .section with 80px margins) ---
+.project-next {
+  margin-top: 0;
+}

--- a/assets/sass/4-layouts/_project-single.scss
+++ b/assets/sass/4-layouts/_project-single.scss
@@ -112,53 +112,9 @@
   padding: 40px $base-spacing-unit 8px;
 }
 
-// --- Partner strip (grayscale logos, like the spaces/partner pages) ---
-.project-partners {
-  &__grid {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
-    gap: 24px 44px;
-  }
-
-  .partner-logo-container {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    height: 60px;
-    background: transparent;
-    border: none;
-
-    .partner-logo {
-      max-height: 100%;
-      max-width: 160px;
-      width: auto;
-      object-fit: contain;
-      filter: grayscale(100%);
-      opacity: 0.7;
-      transition: all 0.3s ease;
-    }
-
-    &:hover {
-      transform: translateY(-4px);
-      .partner-logo { filter: grayscale(0%); opacity: 1; }
-    }
-
-    // white-on-transparent logos need inverting to read on the light bg
-    &.partner-bg-inverted .partner-logo {
-      filter: grayscale(100%) invert(40%);
-    }
-    &.partner-bg-inverted:hover .partner-logo {
-      filter: grayscale(0%) invert(0%);
-    }
-  }
-
-  @media (max-width: $mobile) {
-    &__grid { gap: 20px 28px; }
-    .partner-logo-container { height: 44px; }
-  }
-}
+// Partner strip reuses the spaces pages' .space-partners treatment
+// ("In partnership with" label + uniform 44px grayscale logos); no extra
+// rules needed here.
 
 // --- CTA band: keep the reused band, just give it breathing room
 //     consistent with the surrounding sections ---

--- a/assets/sass/4-layouts/_project-single.scss
+++ b/assets/sass/4-layouts/_project-single.scss
@@ -104,3 +104,58 @@
     &__date { margin-left: 0; }
   }
 }
+
+// --- Reading column (typography inherited from .post__content) ---
+.project-single__body {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 40px $base-spacing-unit 8px;
+}
+
+// --- Partner strip (grayscale logos, like the spaces/partner pages) ---
+.project-partners {
+  &__grid {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 24px 44px;
+  }
+
+  .partner-logo-container {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 60px;
+    background: transparent;
+    border: none;
+
+    .partner-logo {
+      max-height: 100%;
+      max-width: 160px;
+      width: auto;
+      object-fit: contain;
+      filter: grayscale(100%);
+      opacity: 0.7;
+      transition: all 0.3s ease;
+    }
+
+    &:hover {
+      transform: translateY(-4px);
+      .partner-logo { filter: grayscale(0%); opacity: 1; }
+    }
+
+    // white-on-transparent logos need inverting to read on the light bg
+    &.partner-bg-inverted .partner-logo {
+      filter: grayscale(100%) invert(40%);
+    }
+    &.partner-bg-inverted:hover .partner-logo {
+      filter: grayscale(0%) invert(0%);
+    }
+  }
+
+  @media (max-width: $mobile) {
+    &__grid { gap: 20px 28px; }
+    .partner-logo-container { height: 44px; }
+  }
+}

--- a/assets/sass/4-layouts/_project-single.scss
+++ b/assets/sass/4-layouts/_project-single.scss
@@ -129,23 +129,28 @@
   padding-right: $base-spacing-unit;
 }
 
-// Article-block vertical rhythm (facts bar → article spacing).
+// Article-block vertical rhythm (facts bar → article spacing). No bottom
+// padding so the gap below the article is set solely by the next block's
+// top margin (keeps the stacked-CTA spacing consistent — see below).
 .project-single__body {
-  padding-bottom: 8px;
+  padding-bottom: 0;
 
   .post__content {
     padding-top: 40px;        // space between the facts bar and the article
   }
 }
 
-// Partner strip reuses the spaces pages' .space-partners treatment
-// ("In partnership with" label + uniform 44px grayscale logos); no extra
-// rules needed here.
+// --- Consistent vertical rhythm for the stacked blocks below the article:
+//     demo CTA card → "Want a system" band → partner strip all sit one
+//     $project-cta-gap apart. Each block owns only its TOP gap (bottom
+//     margins are zeroed) so the spacing can't compound. ---
+$project-cta-gap: 56px;
 
-// --- CTA band: keep the reused band, just give it breathing room
-//     consistent with the surrounding sections ---
+// .space-partners ships margin: 56px 0; matches the gap, so the band only
+// needs its top gap and a zeroed bottom.
 .project-single__col > .support__cta-band {
-  margin-top: 64px;
+  margin-top: $project-cta-gap;
+  margin-bottom: 0;
 }
 
 // The related-reading and next-project blocks keep the site's standard
@@ -154,7 +159,8 @@
 
 // --- Inline demo CTA (from the demo_cta shortcode): reuses the .about-cta
 //     card; replaces the old embedded HF widget with a link to the ML Space
-//     page. Only the in-content margin differs from .about-cta. ---
+//     page. Top gap from the article, no bottom margin (the band below
+//     owns the gap). ---
 .about-cta.demo-cta {
-  margin: 40px 0;
+  margin: $project-cta-gap 0 0;
 }

--- a/assets/sass/4-layouts/_project-single.scss
+++ b/assets/sass/4-layouts/_project-single.scss
@@ -3,6 +3,9 @@
    .post__content, .article, .section__info from other layouts; only
    project-specific pieces live here. */
 
+// "Live" status accent — no sitewide green exists, so it's defined here.
+$project-live-color: #3fb950;
+
 // --- Hero (extends .about-hero) ---
 .project-hero {
   &.project-hero--gradient {
@@ -30,14 +33,16 @@
   }
 
   .project-hero__stat-value {
+    display: block;
     font-family: $heading-font-family;
     font-weight: 700;
     font-size: 40px;
     line-height: 1;
-    color: #fff;
+    color: var(--white);
   }
 
   .project-hero__stat-label {
+    display: block;
     margin: 8px 0 0;
     font-size: 14px;
     color: rgba(255, 255, 255, 0.8);
@@ -102,8 +107,8 @@
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background: #3fb950;
-    box-shadow: 0 0 0 0 rgba(63, 185, 80, 0.5);
+    background: $project-live-color;
+    box-shadow: 0 0 0 0 rgba($project-live-color, 0.5);
     animation: project-facts-live-pulse 2s infinite;
   }
 
@@ -114,9 +119,9 @@
 }
 
 @keyframes project-facts-live-pulse {
-  0%   { box-shadow: 0 0 0 0 rgba(63, 185, 80, 0.5); }
-  70%  { box-shadow: 0 0 0 7px rgba(63, 185, 80, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(63, 185, 80, 0); }
+  0%   { box-shadow: 0 0 0 0 rgba($project-live-color, 0.5); }
+  70%  { box-shadow: 0 0 0 7px rgba($project-live-color, 0); }
+  100% { box-shadow: 0 0 0 0 rgba($project-live-color, 0); }
 }
 
 // --- Shared content column. Everything below the full-bleed hero (facts

--- a/assets/sass/4-layouts/_project-single.scss
+++ b/assets/sass/4-layouts/_project-single.scss
@@ -49,14 +49,14 @@
   }
 }
 
-// --- Facts bar (under hero, aligned to the reading column) ---
+// --- Facts bar — fills the shared .project-single__body column so its
+//     width and underline line up exactly with the article text below ---
 .project-facts {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 12px 22px;
-  max-width: 780px;
-  margin: -28px auto 8px;          // pull up into the hero's bottom margin
+  margin: -28px 0 0;               // pull up into the hero's bottom margin
   padding: 16px 0;
   border-bottom: 1px solid var(--border-color);
 
@@ -107,11 +107,6 @@
     animation: project-facts-live-pulse 2s infinite;
   }
 
-  @media (max-width: $tablet) {
-    padding-left: $base-spacing-unit;
-    padding-right: $base-spacing-unit;
-  }
-
   @media (max-width: $mobile) {
     margin-top: 8px;
     &__live { margin-left: 0; }
@@ -124,11 +119,23 @@
   100% { box-shadow: 0 0 0 0 rgba(63, 185, 80, 0); }
 }
 
-// --- Reading column (typography inherited from .post__content) ---
-.project-single__body {
+// --- Shared content column. Everything below the full-bleed hero (facts
+//     bar, article, CTA band, partner strip) uses this so their widths and
+//     gutters line up at every breakpoint — including mobile. ---
+.project-single__col {
   max-width: 780px;
   margin: 0 auto;
-  padding: 40px $base-spacing-unit 8px;
+  padding-left: $base-spacing-unit;
+  padding-right: $base-spacing-unit;
+}
+
+// Article-block vertical rhythm (facts bar → article spacing).
+.project-single__body {
+  padding-bottom: 8px;
+
+  .post__content {
+    padding-top: 40px;        // space between the facts bar and the article
+  }
 }
 
 // Partner strip reuses the spaces pages' .space-partners treatment
@@ -137,11 +144,17 @@
 
 // --- CTA band: keep the reused band, just give it breathing room
 //     consistent with the surrounding sections ---
-.project-single .support__cta-band,
-.container > .support__cta-band {
+.project-single__col > .support__cta-band {
   margin-top: 64px;
 }
 
 // The related-reading and next-project blocks keep the site's standard
 // .section rhythm (80px), so there's comfortable, consistent spacing
 // before "Next project" whether or not a related section precedes it.
+
+// --- Inline demo CTA (from the demo_cta shortcode): reuses the .about-cta
+//     card; replaces the old embedded HF widget with a link to the ML Space
+//     page. Only the in-content margin differs from .about-cta. ---
+.about-cta.demo-cta {
+  margin: 40px 0;
+}

--- a/assets/sass/4-layouts/_project-single.scss
+++ b/assets/sass/4-layouts/_project-single.scss
@@ -3,6 +3,48 @@
    .post__content, .article, .section__info from other layouts; only
    project-specific pieces live here. */
 
-.project-single {
-  // sections filled in by later tasks
+// --- Hero (extends .about-hero) ---
+.project-hero {
+  &.project-hero--gradient {
+    background: linear-gradient(120deg, var(--secondary-color), var(--primary-color));
+  }
+
+  .project-hero__kicker {
+    margin-bottom: 14px;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.85);
+  }
+
+  .project-hero__stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 36px;
+    margin: 28px 0 0;
+  }
+
+  .project-hero__stat {
+    margin: 0;
+  }
+
+  .project-hero__stat-value {
+    font-family: $heading-font-family;
+    font-weight: 700;
+    font-size: 40px;
+    line-height: 1;
+    color: #fff;
+  }
+
+  .project-hero__stat-label {
+    margin: 8px 0 0;
+    font-size: 14px;
+    color: rgba(255, 255, 255, 0.8);
+  }
+
+  @media (max-width: $mobile) {
+    .project-hero__stats { gap: 24px; }
+    .project-hero__stat-value { font-size: 30px; }
+  }
 }

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -131,6 +131,7 @@
 @import '4-layouts/post';
 /* >>>>>>>>>>>>>> :: 4.2-Project <<<<<<<<<<<<<<< */
 @import '4-layouts/project';
+@import '4-layouts/project-single';
 /* >>>>>>>>>>>>>> :: 4.3-Tags Page <<<<<<<<<<<<<<< */
 @import '4-layouts/tags-page';
 /* >>>>>>>>>>>>>> :: 4.4-Space <<<<<<<<<<<<<<< */

--- a/content/projects/bear_identification.md
+++ b/content/projects/bear_identification.md
@@ -13,7 +13,7 @@ github_repo: https://github.com/earthtoolsmaker/bear-conservation
 space: /spaces/bear_identification/
 tools:
   - Computer Vision
-  - Maching Learning
+  - Machine Learning
 status: completed
 date: 2024-04-03
 pinned: false
@@ -227,6 +227,6 @@ conservation. The development of open-source tools in this project signifies a
 valuable contribution, not only facilitating adaptability to various species
 but also holding potential to enhance conservation endeavors on a global scale.
 
-One can try out the model from the [ML Space]({{< ref "/spaces/bear_identification" >}}) or directly from the snippet below:
+One can try out the model from the [ML Space]({{< ref "/spaces/bear_identification" >}}) or right here:
 
-{{< hf_space "earthtoolsmaker-bear-face-recognition" >}}
+{{< demo_cta >}}

--- a/content/projects/bear_identification.md
+++ b/content/projects/bear_identification.md
@@ -227,6 +227,6 @@ conservation. The development of open-source tools in this project signifies a
 valuable contribution, not only facilitating adaptability to various species
 but also holding potential to enhance conservation endeavors on a global scale.
 
-One can try out the model from the [ML Space]({{< ref "/spaces/bear_identification" >}}) or right here:
+One can try out the model from the [ML Space]({{< ref "/spaces/bear_identification" >}}).
 
 {{< demo_cta >}}

--- a/content/projects/biowatch-app.md
+++ b/content/projects/biowatch-app.md
@@ -1,6 +1,11 @@
 ---
 title: "Biowatch: Camera Trap Data, Visualized"
 summary: A free, open-source desktop application for visualizing camera trap data to support conservation efforts.
+tools:
+  - Computer Vision
+  - Machine Learning
+  - Camera Traps
+  - Interactive Map
 clients:
   - name: OSI Panthera
     link: https://www.osi-panthera.org/

--- a/content/projects/carpathian-bear-deterrence.md
+++ b/content/projects/carpathian-bear-deterrence.md
@@ -257,6 +257,6 @@ diverse species.
 </span>
 <br/>
 
-One can try out the model from the [ML Space]({{< ref "/spaces/human_wildlife_bear_conflict" >}}) or directly from the snippet below:
+One can try out the model from the [ML Space]({{< ref "/spaces/human_wildlife_bear_conflict" >}}) or right here:
 
-{{< hf_space "achouffe-bear-detection" >}}
+{{< demo_cta >}}

--- a/content/projects/carpathian-bear-deterrence.md
+++ b/content/projects/carpathian-bear-deterrence.md
@@ -257,6 +257,6 @@ diverse species.
 </span>
 <br/>
 
-One can try out the model from the [ML Space]({{< ref "/spaces/human_wildlife_bear_conflict" >}}) or right here:
+One can try out the model from the [ML Space]({{< ref "/spaces/human_wildlife_bear_conflict" >}}).
 
 {{< demo_cta >}}

--- a/content/projects/coral_reef_health_monitoring.md
+++ b/content/projects/coral_reef_health_monitoring.md
@@ -209,6 +209,6 @@ health and dynamics.
 ![Benthic Analysis System](/images/projects/coral_reef_segmentation/coral_ai.gif)
 *Gallery / Benthic Imagery Analysis System by <a href="https://reef.support">Reef Support</a>*
 
-One can try out the model from the [ML Space]({{< ref "/spaces/coral_reef_health_monitoring" >}}) or directly from the snippet below:
+One can try out the model from the [ML Space]({{< ref "/spaces/coral_reef_health_monitoring" >}}) or right here:
 
-{{< hf_space "earthtoolsmaker-coral-segmentation-reef-support" >}}
+{{< demo_cta >}}

--- a/content/projects/coral_reef_health_monitoring.md
+++ b/content/projects/coral_reef_health_monitoring.md
@@ -209,6 +209,6 @@ health and dynamics.
 ![Benthic Analysis System](/images/projects/coral_reef_segmentation/coral_ai.gif)
 *Gallery / Benthic Imagery Analysis System by <a href="https://reef.support">Reef Support</a>*
 
-One can try out the model from the [ML Space]({{< ref "/spaces/coral_reef_health_monitoring" >}}) or right here:
+One can try out the model from the [ML Space]({{< ref "/spaces/coral_reef_health_monitoring" >}}).
 
 {{< demo_cta >}}

--- a/content/projects/early_forest_fire_detection.md
+++ b/content/projects/early_forest_fire_detection.md
@@ -201,6 +201,6 @@ greatly improving our capacity to protect forests that are increasingly
 threatened by the impacts of global warming.
 
 One can try out the model from the [ML Space]({{< ref
-"/spaces/early_forest_fire_detection" >}}) or right here:
+"/spaces/early_forest_fire_detection" >}}).
 
 {{< demo_cta >}}

--- a/content/projects/early_forest_fire_detection.md
+++ b/content/projects/early_forest_fire_detection.md
@@ -201,6 +201,6 @@ greatly improving our capacity to protect forests that are increasingly
 threatened by the impacts of global warming.
 
 One can try out the model from the [ML Space]({{< ref
-"/spaces/early_forest_fire_detection" >}}) or directly from the snippet below:
+"/spaces/early_forest_fire_detection" >}}) or right here:
 
-{{< hf_space "earthtoolsmaker-forest-fire-pyronear" >}}
+{{< demo_cta >}}

--- a/content/projects/elephants_passive_acoustic_monitoring.md
+++ b/content/projects/elephants_passive_acoustic_monitoring.md
@@ -287,6 +287,6 @@ in anti-poaching efforts, informs habitat management, supports research,
 engages local communities, and offers a cost-effective, scalable solution for
 conservation efforts.
 
-One can try out the model from the [ML Space]({{< ref "/spaces/forest_elephant_rumble_detection" >}}) or directly from the snippet below:
+One can try out the model from the [ML Space]({{< ref "/spaces/forest_elephant_rumble_detection" >}}) or right here:
 
-{{< hf_space "earthtoolsmaker-forest-elephant-rumbles-detection" >}}
+{{< demo_cta >}}

--- a/content/projects/elephants_passive_acoustic_monitoring.md
+++ b/content/projects/elephants_passive_acoustic_monitoring.md
@@ -287,6 +287,6 @@ in anti-poaching efforts, informs habitat management, supports research,
 engages local communities, and offers a cost-effective, scalable solution for
 conservation efforts.
 
-One can try out the model from the [ML Space]({{< ref "/spaces/forest_elephant_rumble_detection" >}}) or right here:
+One can try out the model from the [ML Space]({{< ref "/spaces/forest_elephant_rumble_detection" >}}).
 
 {{< demo_cta >}}

--- a/content/projects/monitoring_smolt_salmon_migration_with_sonar.md
+++ b/content/projects/monitoring_smolt_salmon_migration_with_sonar.md
@@ -130,7 +130,7 @@ Rather than spanning the trigger segment across the entire sonar range, this pro
 
 Experience the smolt detection and counting model in action. Upload preprocessed sonar footage or use the provided examples to see automated detection and tracking:
 
-{{< hf_space "Lumax-eco-sonar-smolt" >}}
+{{< demo_cta >}}
 
 ## Conclusion
 

--- a/content/projects/trout_identification.md
+++ b/content/projects/trout_identification.md
@@ -188,6 +188,6 @@ ensuring the long-term survival of trout species and the health of the
 environments they inhabit.
 
 One can try out the model from the [ML Space]({{< ref
-"/spaces/trout_identification" >}}) or right here:
+"/spaces/trout_identification" >}}).
 
 {{< demo_cta >}}

--- a/content/projects/trout_identification.md
+++ b/content/projects/trout_identification.md
@@ -188,6 +188,6 @@ ensuring the long-term survival of trout species and the health of the
 environments they inhabit.
 
 One can try out the model from the [ML Space]({{< ref
-"/spaces/trout_identification" >}}) or directly from the snippet below:
+"/spaces/trout_identification" >}}) or right here:
 
-{{< hf_space "earthtoolsmaker-trout-reid" >}}
+{{< demo_cta >}}

--- a/content/projects/wadden_sea_seal_monitoring.md
+++ b/content/projects/wadden_sea_seal_monitoring.md
@@ -172,4 +172,4 @@ By combining cutting-edge computer vision with ecological expertise, this projec
 
 Experience the re-identification model in action through our interactive demonstration. Upload images of seal faces to see how the system extracts unique features and matches individuals:
 
-{{< hf_space "earthtoolsmaker-seal-reid" >}}
+{{< demo_cta >}}

--- a/content/projects/wild_salmon_migration_monitoring.md
+++ b/content/projects/wild_salmon_migration_monitoring.md
@@ -259,6 +259,6 @@ identifying and addressing threats, and engaging stakeholders in conservation
 efforts.
 
 One can try out the model from the [ML Space]({{< ref
-"/spaces/wild_salmon_migration_monitoring" >}}) or directly from the snippet below:
+"/spaces/wild_salmon_migration_monitoring" >}}) or right here:
 
-{{< hf_space "earthtoolsmaker-salmon-vision" >}}
+{{< demo_cta >}}

--- a/content/projects/wild_salmon_migration_monitoring.md
+++ b/content/projects/wild_salmon_migration_monitoring.md
@@ -259,6 +259,6 @@ identifying and addressing threats, and engaging stakeholders in conservation
 efforts.
 
 One can try out the model from the [ML Space]({{< ref
-"/spaces/wild_salmon_migration_monitoring" >}}) or right here:
+"/spaces/wild_salmon_migration_monitoring" >}}).
 
 {{< demo_cta >}}

--- a/content/projects/wild_salmon_migration_monitoring.md
+++ b/content/projects/wild_salmon_migration_monitoring.md
@@ -1,6 +1,14 @@
 ---
 title: Wild Salmon Migration Monitoring
 summary: The project monitors wild salmon migration to ensure the number passing through meets state regulations, addressing threats from human activities like fisheries and dams.
+tagline: Automated, multi-sensor counting that keeps Pacific salmon runs within regulation.
+stats:
+  - value: "7"
+    label: salmon species recognized
+  - value: "3"
+    label: sensing modalities
+  - value: "24/7"
+    label: automated counting
 github_repo: https://github.com/Salmon-Computer-Vision/salmon-computer-vision/tree/master
 space: /spaces/wild_salmon_migration_monitoring/
 clients:

--- a/docs/specs/2026-06-14-project-pages-revamp-design.md
+++ b/docs/specs/2026-06-14-project-pages-revamp-design.md
@@ -1,0 +1,114 @@
+# Project Pages Revamp — Design
+
+**Date:** 2026-06-14
+**Status:** Approved
+**Scope:** Individual project pages (`content/projects/*`), rendered by `layouts/projects/single.html`. Brings them in line with the redesigned post/about/support pages (Newsreader headings, teal/coral palette, rounded cards, section dividers, CTA bands).
+
+## Goal
+
+Fully revamp the individual project page from the current two-column "content + tan sidebar widget" layout into an **editorial single-column** layout that matches the rest of the redesigned site. Wrap the existing long-form article body in modern, mostly auto-derived sections (hero, facts bar, partner strip, CTA band, related/next cards) so existing project markdown needs no edits.
+
+Only `layouts/projects/single.html` and its new styling change. Project markdown bodies are left untouched. Two **optional** front-matter fields are introduced but never required.
+
+## Decisions (validated via visual brainstorming)
+
+- **Layout:** Direction A — editorial single-column (chosen over a refined two-column-with-sidebar). Long articles with wide images/tables read best in one centered column, matching the post page.
+- **Sections around the body:** all four auto-derived sections in scope — facts bar, partner strip, status-aware CTA band, related + next-project cards.
+- **New optional front matter:** `tagline` and `stats`, both render-only-when-present.
+- The old sidebar widgets are retired from this template (not deleted).
+
+## Page structure (top → bottom)
+
+### 1. Hero
+
+Full-bleed cover image (`.Params.image`) with a dark gradient overlay for legibility, reusing the about/support `about-hero` overlay pattern. Overlay (constrained to `container-wide`) contains:
+
+- **Kicker** — uppercase, letter-spaced, dot-separated: status label (`completed` → "Completed", `fundraising` → "Seeking funding") + primary tool (first of `tools`).
+- **Title** — `.Title` in Newsreader.
+- **Tagline** — `tagline` front-matter, falling back to `summary`.
+- **Stats row** (only if `stats` present) — 1–3 large value/label pairs.
+- **Fallback:** if a project has no `image`, the hero uses the teal gradient (`--secondary-color` → `--primary-color`) with no `<img>`.
+
+### 2. Facts bar
+
+Slim strip directly under the hero, rendering only the pieces that exist:
+
+- **Action links** — GitHub (`github_repo`) and ML Space (`space`) using the same icons as the current `widget-project-meta` (`fa-brands fa-github`, `images/social/hf.svg`).
+- **Tool chips** — `tools` as small rounded chips.
+- **Date** — `.Date.Format "2 January, 2006"` in muted text.
+
+### 3. Reading column
+
+`.Content` rendered untouched in a centered single column (~780px, matching the post page) with the same typographic rhythm as `_post.scss` (heading spacing, links, blockquotes/`<cite>`, code, lists, tables, images, iframes/`hf_space` embeds). The existing markdown bodies are **not** edited. The current in-content fundraising `support-cta` partial is removed from the body here (replaced by the CTA band, section 5).
+
+### 4. Partner strip
+
+Uniform grayscale logo row built from `clients` (same treatment as the spaces/partner pages — grayscale, no link underline, uniform SVG/img sizing, `partner-bg-inverted` honored). Preceded by a `section__info` heading + squiggle. Skipped entirely when there are no `clients`.
+
+### 5. CTA band
+
+Dark-teal `support__cta-band` before the footer, status-aware:
+
+- `completed` → "Want a system like this?" → **Talk to us** (`/contact/`) + ghost **See our work** (`/projects/`).
+- `fundraising` → "Help fund this project" → **Sponsor this project** / **Talk to us** (`/contact/`).
+
+Reuses the `.support__cta-band` / `.button--ghost` styles verbatim.
+
+### 6. Related reading
+
+`related_posts` rendered as the modern `.article` cards, under a `section__info` heading. Reuses the existing article-card markup/styles (respecting the shared `.article__*` constraint — no edits to shared classes; wrapper-scoped overrides only if needed). Skipped when `related_posts` is empty.
+
+### 7. Next project
+
+`PrevInSection` rendered as a single project/`.article` card (modernizing the current `.project__nav` block), under a `section__info` heading. Skipped when there is no `PrevInSection` (last project in section).
+
+## New optional front matter
+
+Both optional; render-only-when-present; zero forced content edits.
+
+```yaml
+tagline: One punchy line for the hero.   # falls back to `summary`
+stats:                                   # 1–3 entries; hero stats row
+  - value: "1M+"
+    label: salmon tracked
+  - value: "7"
+    label: species recognized
+```
+
+## Files touched
+
+- `layouts/projects/single.html` — rewritten as the Direction A composition above.
+- `assets/sass/4-layouts/_project-single.scss` — **new** partial: hero overlay variant, facts bar, reading-column typography, partner strip, section spacing. Registered in the SASS manifest (`assets/sass/main.scss` or equivalent).
+- Possibly small new partials under `layouts/partials/` for the hero / facts bar / next-project card if it keeps `single.html` readable (decided during implementation).
+- No changes to project markdown content. `tagline`/`stats` added to project files later, ad hoc.
+
+## Reuse (no changes to these)
+
+- `responsive-image.html`, `project-card.html`, the `.article` card styles.
+- `about-hero` overlay CSS, `support__cta-band`, `button--ghost`, the `section__info` heading + squiggle SVG.
+- Partner-strip grayscale treatment from the spaces/partner pages.
+
+## Retired (left in place, not deleted)
+
+- `layouts/partials/sidebar-widgets/widget-project-meta.html`
+- `layouts/partials/sidebar-widgets/widget-recent-projects-and-related-posts.html`
+
+These become unused by `projects/single.html`. Implementation will grep for other references and report; they are not removed as part of this change.
+
+## Edge cases
+
+No `image` → gradient hero · no `github_repo`/`space` → hide those links · no `tools` → no chips/kicker tool · no `clients` → no partner strip · no `stats`/`tagline` → fall back/skip · no `related_posts` → skip · last project → no next-project card.
+
+## Non-goals
+
+- No changes to the projects **list** page (`layouts/projects/list.html`), homepage project section, or `project-card.html`.
+- No required front-matter changes; no edits to existing project markdown bodies.
+- No deletion of the retired sidebar widgets.
+- No global style changes — all new CSS scoped to the project-single layout.
+
+## Verification
+
+- `hugo` builds with no errors/warnings (static build is ground truth — local `hugo server` can serve stale pages).
+- Screenshot-check representative projects: **wild_salmon_migration_monitoring** (partners + space + github + related post, `completed`), **carpathian-bear-deterrence** (`fundraising` → CTA variant), **snow_leopard_monitoring**, and one with no related posts / minimal metadata to confirm graceful degradation.
+- Confirm hero, facts bar, partner strip, CTA band, and cards all render and degrade correctly; confirm reading-column typography on tables, blockquotes, and embeds.
+- Snap chromium screenshots use `$HOME` paths + a virtual-time-budget.

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -46,17 +46,15 @@
     <a class="project-facts__link" target="_blank" rel="noopener" href="{{ . }}"><i class="fa-brands fa-github"></i> Source code</a>
     {{ end }}
     {{ with .Params.space }}
-    <a class="project-facts__link" href="{{ . }}">
-      {{ $hf := resources.Get "images/social/hf.svg" }}{{ if $hf }}<img src="{{ $hf.RelPermalink }}" alt="">{{ end }} ML Space demo
-    </a>
+    <a class="project-facts__link" href="{{ . }}"><i class="fa-solid fa-circle-play"></i> Try the demo</a>
     {{ end }}
     {{ with .Params.tools }}
     <span class="project-facts__tools">
       {{ range . }}<span class="project-facts__chip">{{ . }}</span>{{ end }}
     </span>
     {{ end }}
-    {{ if not .Date.IsZero }}
-    <time class="project-facts__date" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "2 January, 2006" }}</time>
+    {{ if eq .Params.status "completed" }}
+    <span class="project-facts__live"><span class="project-facts__live-dot" aria-hidden="true"></span>Live</span>
     {{ end }}
   </div>
 </div>
@@ -68,34 +66,7 @@
   </div>
 </div>
 
-{{/* ---------- 4. PARTNER STRIP (same treatment as the spaces pages) ---------- */}}
-{{ with .Params.clients }}
-<div class="container">
-  <div class="space-partners">
-    <div class="space-partners__label">In partnership with</div>
-    <div class="space-partners__logos">
-      {{ range $partner := . }}
-      {{ $img := "" }}
-      {{ with $partner.logo }}
-        {{ $imgPath := strings.TrimPrefix "/" . }}
-        {{/* Prefer a dark-text variant (for white-on-transparent logos) when one exists */}}
-        {{ $img = or (resources.Get (replace $imgPath "logo.png" "logo_dark.png")) (resources.Get $imgPath) }}
-        {{ if and $img (not (strings.HasSuffix $imgPath ".svg")) (gt $img.Width 380) }}
-          {{ $img = $img.Resize "380x" }}
-        {{ end }}
-      {{ end }}
-      {{ with $img }}
-      <a class="space-partners__item" href="{{ $partner.link }}" target="_blank" rel="noopener noreferrer" title="{{ $partner.name }}">
-        <img class="space-partners__logo" src="{{ .RelPermalink }}" alt="{{ $partner.name }}" loading="lazy">
-      </a>
-      {{ end }}
-      {{ end }}
-    </div>
-  </div>
-</div>
-{{ end }}
-
-{{/* ---------- 5. CTA BAND (status-aware) ---------- */}}
+{{/* ---------- 4. CTA BAND (status-aware) ---------- */}}
 <div class="container">
   {{ if eq .Params.status "fundraising" }}
   <div class="support__cta-band">
@@ -121,6 +92,33 @@
   </div>
   {{ end }}
 </div>
+
+{{/* ---------- 5. PARTNER STRIP (same treatment as the spaces pages) ---------- */}}
+{{ with .Params.clients }}
+<div class="container">
+  <div class="space-partners">
+    <div class="space-partners__label">In partnership with</div>
+    <div class="space-partners__logos">
+      {{ range $partner := . }}
+      {{ $img := "" }}
+      {{ with $partner.logo }}
+        {{ $imgPath := strings.TrimPrefix "/" . }}
+        {{/* Prefer a dark-text variant (for white-on-transparent logos) when one exists */}}
+        {{ $img = or (resources.Get (replace $imgPath "logo.png" "logo_dark.png")) (resources.Get $imgPath) }}
+        {{ if and $img (not (strings.HasSuffix $imgPath ".svg")) (gt $img.Width 380) }}
+          {{ $img = $img.Resize "380x" }}
+        {{ end }}
+      {{ end }}
+      {{ with $img }}
+      <a class="space-partners__item" href="{{ $partner.link }}" target="_blank" rel="noopener noreferrer" title="{{ $partner.name }}">
+        <img class="space-partners__logo" src="{{ .RelPermalink }}" alt="{{ $partner.name }}" loading="lazy">
+      </a>
+      {{ end }}
+      {{ end }}
+    </div>
+  </div>
+</div>
+{{ end }}
 
 {{/* ---------- 6. RELATED READING ---------- */}}
 {{ if .Params.related_posts }}

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -68,23 +68,31 @@
   </div>
 </div>
 
-{{/* ---------- 4. PARTNER STRIP ---------- */}}
+{{/* ---------- 4. PARTNER STRIP (same treatment as the spaces pages) ---------- */}}
 {{ with .Params.clients }}
-<section class="section project-partners">
-  <div class="container"><div class="row"><div class="col col-12"><div class="container__inner">
-    <div class="section__info">
-      <div class="section__head"><h2 class="section__title">Partners</h2></div>
-      <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
-    </div>
-    <div class="project-partners__grid">
-      {{ range . }}
-      <a class="partner-logo-container{{ with .bg }} partner-bg-{{ . }}{{ end }}" href="{{ .link }}" target="_blank" rel="noopener" title="{{ .name }}">
-        {{ $imgPath := strings.TrimPrefix "/" .logo }}{{ $img := resources.Get $imgPath }}{{ if $img }}<img class="partner-logo" src="{{ $img.RelPermalink }}" alt="{{ .name }}" loading="lazy">{{ end }}
+<div class="container">
+  <div class="space-partners">
+    <div class="space-partners__label">In partnership with</div>
+    <div class="space-partners__logos">
+      {{ range $partner := . }}
+      {{ $img := "" }}
+      {{ with $partner.logo }}
+        {{ $imgPath := strings.TrimPrefix "/" . }}
+        {{/* Prefer a dark-text variant (for white-on-transparent logos) when one exists */}}
+        {{ $img = or (resources.Get (replace $imgPath "logo.png" "logo_dark.png")) (resources.Get $imgPath) }}
+        {{ if and $img (not (strings.HasSuffix $imgPath ".svg")) (gt $img.Width 380) }}
+          {{ $img = $img.Resize "380x" }}
+        {{ end }}
+      {{ end }}
+      {{ with $img }}
+      <a class="space-partners__item" href="{{ $partner.link }}" target="_blank" rel="noopener noreferrer" title="{{ $partner.name }}">
+        <img class="space-partners__logo" src="{{ .RelPermalink }}" alt="{{ $partner.name }}" loading="lazy">
       </a>
       {{ end }}
+      {{ end }}
     </div>
-  </div></div></div></div>
-</section>
+  </div>
+</div>
 {{ end }}
 
 {{/* ---------- 5. CTA BAND (status-aware) ---------- */}}

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -25,14 +25,14 @@
       {{ $tagline := .Params.tagline | default .Params.summary }}
       {{ with $tagline }}<p class="about-hero__description">{{ . }}</p>{{ end }}
       {{ with .Params.stats }}
-      <dl class="project-hero__stats">
+      <div class="project-hero__stats">
         {{ range . }}
         <div class="project-hero__stat">
-          <dt class="project-hero__stat-value">{{ .value }}</dt>
-          <dd class="project-hero__stat-label">{{ .label }}</dd>
+          <span class="project-hero__stat-value">{{ .value }}</span>
+          <span class="project-hero__stat-label">{{ .label }}</span>
         </div>
         {{ end }}
-      </dl>
+      </div>
       {{ end }}
     </div>
   </div>
@@ -43,7 +43,7 @@
 <div class="project-single__col project-single__body">
   <div class="project-facts">
     {{ with .Params.github_repo }}
-    <a class="project-facts__link" target="_blank" rel="noopener" href="{{ . }}"><i class="fa-brands fa-github"></i> Source code</a>
+    <a class="project-facts__link" target="_blank" rel="noopener noreferrer" href="{{ . }}"><i class="fa-brands fa-github"></i> Source code</a>
     {{ end }}
     {{ with .Params.space }}
     <a class="project-facts__link" href="{{ . }}"><i class="fa-solid fa-circle-play"></i> Try the demo</a>

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -1,72 +1,151 @@
 {{ define "main" }}
 
-<div class="container">
-
-  <div class="project-info">
-    {{ if .Params.subtitle }}
-    <p class="project-info__subtitle">{{ .Params.subtitle }}</p>
-    {{ end }}
-    {{ if .Title }}
-    <h1 class="project-info__title">{{ .Title }}</h1>
-    {{ end }}
-  </div>
-
+{{/* ---------- 1. HERO ---------- */}}
+{{ $statusLabel := "" }}
+{{ if eq .Params.status "completed" }}{{ $statusLabel = "Completed" }}{{ else if eq .Params.status "fundraising" }}{{ $statusLabel = "Seeking funding" }}{{ end }}
+{{ $kicker := slice }}
+{{ with $statusLabel }}{{ $kicker = $kicker | append . }}{{ end }}
+{{ with .Params.tools }}{{ $kicker = $kicker | append (index . 0) }}{{ end }}
+<div class="about-hero project-hero{{ if not .Params.image }} project-hero--gradient{{ end }}">
   {{ if .Params.image }}
-  <div class="project-info-image">
-    {{ $imgPath := strings.TrimPrefix "/" .Params.image }}
-    {{ partial "responsive-image.html" (dict
-      "src" $imgPath
-      "alt" .Title
-      "class" "project-cover"
-      "sizes" "(max-width: 900px) 100vw, 900px"
-      "widths" (slice 600 900 1200)
-      "lazy" true
-      "lqip" true
-    ) }}
-  </div>
+  {{ $imgPath := strings.TrimPrefix "/" .Params.image }}
+  {{ partial "responsive-image.html" (dict
+    "src" $imgPath
+    "alt" .Title
+    "sizes" "100vw"
+    "widths" (slice 600 900 1200 1500)
+    "lazy" false
+    "fetchpriority" "high"
+    "lqip" false
+  ) }}
   {{ end }}
-
-  <div class="row">
-    <div class="project-left col col-7 col-d-12">
-      <div class="project-content">
-        {{ .Content }}
-        {{ if eq .Params.status "fundraising" }}
-        {{ partial "support-cta.html" . }}
-        {{ end }}
-        {{ if .PrevInSection }}
-        <div class="project__nav">
-          <div class="project__prev">
-            <div class="project__box">
-              <span class="project__nav-info">Next Project</span>
-              <h2 class="project__nav-title">
-                <a href="{{ .PrevInSection.Permalink }}" class="project__nav-link">{{ .PrevInSection.Title }}</a>
-              </h2>
-            </div>
-          </div>
-          <a class="project__nav-image" href="{{ .PrevInSection.Permalink }}">
-            {{ $imgPath := strings.TrimPrefix "/" .PrevInSection.Params.Image }}
-            {{ partial "responsive-image.html" (dict
-              "src" $imgPath
-              "alt" .PrevInSection.Title
-              "sizes" "(max-width: 600px) 100vw, (max-width: 900px) 100vw, 900px"
-              "widths" (slice 600 900 1200)
-              "lazy" true
-              "lqip" true
-            ) }}
-          </a>
+  <div class="about-hero__overlay">
+    <div class="container-wide">
+      {{ if $kicker }}<p class="project-hero__kicker">{{ delimit $kicker " · " }}</p>{{ end }}
+      <h1 class="about-hero__title">{{ .Title }}</h1>
+      {{ $tagline := .Params.tagline | default .Params.summary }}
+      {{ with $tagline }}<p class="about-hero__description">{{ . }}</p>{{ end }}
+      {{ with .Params.stats }}
+      <dl class="project-hero__stats">
+        {{ range . }}
+        <div class="project-hero__stat">
+          <dt class="project-hero__stat-value">{{ .value }}</dt>
+          <dd class="project-hero__stat-label">{{ .label }}</dd>
         </div>
         {{ end }}
-      </div>
-    </div>
-
-    <div class="project-right col col-5 col-d-12">
-      <aside class="sidebar">
-        {{ partial "sidebar-widgets/widget-project-meta" . }}
-        {{ partial "sidebar-widgets/widget-recent-projects-and-related-posts" . }}
-      </aside>
+      </dl>
+      {{ end }}
     </div>
   </div>
-
 </div>
+
+{{/* ---------- 2. FACTS BAR ---------- */}}
+<div class="container">
+  <div class="project-facts">
+    {{ with .Params.github_repo }}
+    <a class="project-facts__link" target="_blank" rel="noopener" href="{{ . }}"><i class="fa-brands fa-github"></i> Source code</a>
+    {{ end }}
+    {{ with .Params.space }}
+    <a class="project-facts__link" href="{{ . }}">
+      {{ $hf := resources.Get "images/social/hf.svg" }}{{ if $hf }}<img src="{{ $hf.RelPermalink }}" alt="">{{ end }} ML Space demo
+    </a>
+    {{ end }}
+    {{ with .Params.tools }}
+    <span class="project-facts__tools">
+      {{ range . }}<span class="project-facts__chip">{{ . }}</span>{{ end }}
+    </span>
+    {{ end }}
+    {{ if not .Date.IsZero }}
+    <time class="project-facts__date" datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "2 January, 2006" }}</time>
+    {{ end }}
+  </div>
+</div>
+
+{{/* ---------- 3. READING COLUMN ---------- */}}
+<div class="project-single__body">
+  <div class="post__content">
+    {{ .Content }}
+  </div>
+</div>
+
+{{/* ---------- 4. PARTNER STRIP ---------- */}}
+{{ with .Params.clients }}
+<section class="section project-partners">
+  <div class="container"><div class="row"><div class="col col-12"><div class="container__inner">
+    <div class="section__info">
+      <div class="section__head"><h2 class="section__title">Partners</h2></div>
+      <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
+    </div>
+    <div class="project-partners__grid">
+      {{ range . }}
+      <a class="partner-logo-container{{ with .bg }} partner-bg-{{ . }}{{ end }}" href="{{ .link }}" target="_blank" rel="noopener" title="{{ .name }}">
+        {{ $imgPath := strings.TrimPrefix "/" .logo }}{{ $img := resources.Get $imgPath }}{{ if $img }}<img class="partner-logo" src="{{ $img.RelPermalink }}" alt="{{ .name }}" loading="lazy">{{ end }}
+      </a>
+      {{ end }}
+    </div>
+  </div></div></div></div>
+</section>
+{{ end }}
+
+{{/* ---------- 5. CTA BAND (status-aware) ---------- */}}
+<div class="container">
+  {{ if eq .Params.status "fundraising" }}
+  <div class="support__cta-band">
+    <div class="support__cta-band-text">
+      <h3 class="support__cta-band-title">Help fund this project</h3>
+      <p class="support__cta-band-description">Tell us this is the work you want to back — we'll share the full scope, the budget, and what your support unlocks.</p>
+    </div>
+    <div class="support__cta-band-buttons">
+      <a class="link-no-decoration" href="/contact/"><button class="button">Sponsor this project</button></a>
+      <a class="link-no-decoration" href="/contact/"><button class="button button--ghost">Talk to us</button></a>
+    </div>
+  </div>
+  {{ else }}
+  <div class="support__cta-band">
+    <div class="support__cta-band-text">
+      <h3 class="support__cta-band-title">Want a system like this?</h3>
+      <p class="support__cta-band-description">We build conservation technology with partners in the field. Tell us what you're monitoring and we'll tell you what's possible.</p>
+    </div>
+    <div class="support__cta-band-buttons">
+      <a class="link-no-decoration" href="/contact/"><button class="button">Talk to us</button></a>
+      <a class="link-no-decoration" href="/projects/"><button class="button button--ghost">See our work</button></a>
+    </div>
+  </div>
+  {{ end }}
+</div>
+
+{{/* ---------- 6. RELATED READING ---------- */}}
+{{ if .Params.related_posts }}
+<section class="section project-related">
+  <div class="container"><div class="row"><div class="col col-12"><div class="container__inner">
+    <div class="section__info">
+      <div class="section__head"><h2 class="section__title">Related reading</h2></div>
+      <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
+    </div>
+    <div class="row">
+      {{ range .Params.related_posts }}
+        {{ with site.GetPage "posts" . }}
+          {{ partial "article.html" . }}
+        {{ end }}
+      {{ end }}
+    </div>
+  </div></div></div></div>
+</section>
+{{ end }}
+
+{{/* ---------- 7. NEXT PROJECT ---------- */}}
+{{ with .PrevInSection }}
+<section class="section project-next">
+  <div class="container"><div class="row"><div class="col col-12"><div class="container__inner">
+    <div class="section__info">
+      <div class="section__head"><h2 class="section__title">Next project</h2></div>
+      <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
+    </div>
+    <div class="row">
+      {{ partial "project-card.html" . }}
+    </div>
+  </div></div></div></div>
+</section>
+{{ end }}
 
 {{ end }}

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -1,11 +1,10 @@
 {{ define "main" }}
 
 {{/* ---------- 1. HERO ---------- */}}
-{{ $statusLabel := "" }}
-{{ if eq .Params.status "completed" }}{{ $statusLabel = "Completed" }}{{ else if eq .Params.status "fundraising" }}{{ $statusLabel = "Seeking funding" }}{{ end }}
+{{/* Only fundraising projects show an eyebrow above the title ("Seeking
+     funding"); the tools already appear as chips in the facts bar. */}}
 {{ $kicker := slice }}
-{{ with $statusLabel }}{{ $kicker = $kicker | append . }}{{ end }}
-{{ with .Params.tools }}{{ $kicker = $kicker | append (index . 0) }}{{ end }}
+{{ if eq .Params.status "fundraising" }}{{ $kicker = $kicker | append "Seeking funding" }}{{ end }}
 <div class="about-hero project-hero{{ if not .Params.image }} project-hero--gradient{{ end }}">
   {{ if .Params.image }}
   {{ $imgPath := strings.TrimPrefix "/" .Params.image }}
@@ -40,7 +39,8 @@
 </div>
 
 {{/* ---------- 2. FACTS BAR ---------- */}}
-<div class="container">
+{{/* Facts bar and the article body share the same column so their widths line up. */}}
+<div class="project-single__col project-single__body">
   <div class="project-facts">
     {{ with .Params.github_repo }}
     <a class="project-facts__link" target="_blank" rel="noopener" href="{{ . }}"><i class="fa-brands fa-github"></i> Source code</a>
@@ -57,17 +57,15 @@
     <span class="project-facts__live"><span class="project-facts__live-dot" aria-hidden="true"></span>Live</span>
     {{ end }}
   </div>
-</div>
 
 {{/* ---------- 3. READING COLUMN ---------- */}}
-<div class="project-single__body">
   <div class="post__content">
     {{ .Content }}
   </div>
 </div>
 
-{{/* ---------- 4. CTA BAND (status-aware) ---------- */}}
-<div class="container">
+{{/* ---------- 4. CTA BAND (status-aware) — same column width as the article ---------- */}}
+<div class="project-single__col">
   {{ if eq .Params.status "fundraising" }}
   <div class="support__cta-band">
     <div class="support__cta-band-text">
@@ -95,7 +93,7 @@
 
 {{/* ---------- 5. PARTNER STRIP (same treatment as the spaces pages) ---------- */}}
 {{ with .Params.clients }}
-<div class="container">
+<div class="project-single__col">
   <div class="space-partners">
     <div class="space-partners__label">In partnership with</div>
     <div class="space-partners__logos">

--- a/layouts/shortcodes/demo_cta.html
+++ b/layouts/shortcodes/demo_cta.html
@@ -1,0 +1,14 @@
+{{/*
+  demo_cta — inline call-to-action that links to the project's interactive
+  demo (its linked ML Space page) instead of embedding the live widget.
+  Reuses the .about-cta card style. Destination comes from the page's
+  `space` front matter; an explicit URL can be passed as the first argument.
+*/}}
+{{ $url := or (.Get 0) .Page.Params.space }}
+{{ with $url }}
+<div class="about-cta demo-cta">
+  <h3 class="about-cta__title">Try the interactive demo</h3>
+  <p class="about-cta__description">See the model in action right in your browser — try it on the built-in examples or your own data. No install, no setup.</p>
+  <a href="{{ . }}" class="link-no-decoration button button--middle"><i class="fa-solid fa-circle-play"></i>&nbsp;Open the demo</a>
+</div>
+{{ end }}


### PR DESCRIPTION
Fully revamps the individual project pages to match the redesigned post/about/support pages.

## What changed
- **Editorial single-column layout** replacing the old two-column + tan sidebar.
- **Hero**: full-bleed cover with overlay — eyebrow (only "Seeking funding" for fundraising), title, tagline (falls back to `summary`), and optional at-a-glance `stats`.
- **Facts bar**: GitHub + "Try the demo" (play icon) links, tool chips, and a pulsing green **Live** badge (completed projects) — all sharing the article's column width so everything lines up, including on mobile.
- **Reading column** reuses the post page's typography.
- **Demo links instead of embeds**: the heavy in-content Hugging Face widgets are replaced by a `demo_cta` shortcode that links to the project's ML Space (reusing the `.about-cta` card).
- **"In partnership with"** logo strip (same treatment as the spaces pages), placed below the status-aware CTA band, with consistent spacing between the two CTAs.
- **Related posts + next project** as modern `.article` cards.
- Minor: added tags to the biowatch project; fixed a "Maching Learning" typo; cleaned up the header "Work" dropdown hover (colour change instead of a stray dot).

New optional front matter (render-only-when-present): `tagline`, `stats`. No existing project markdown required changes beyond swapping the embeds for the CTA.

Spec: `docs/specs/2026-06-14-project-pages-revamp-design.md`.

## Test plan
- [ ] `hugo` builds clean (verified locally, no errors).
- [ ] Spot-check representative projects: wild_salmon (partners + demo + related + stats), biowatch (completed, no demo), a fundraising project (CTA + kicker variant), and one with minimal metadata.
- [ ] Confirm mobile: facts bar, CTA band, and partner strip align with the text column.
- [ ] Confirm the "Work" dropdown hover looks clean.