### PR TITLE
Homepage: featured tools section + 'build technology that matters' CTA

### DIFF
--- a/assets/sass/3-modules/_tools.scss
+++ b/assets/sass/3-modules/_tools.scss
@@ -307,3 +307,10 @@
   justify-content: center;
   flex-wrap: wrap;
 }
+
+/* homepage tools section — the CTA band sits outside .container__inner, so it
+   misses the -32px pull-up the other sections get and leaves an oversized gap
+   before the next section. Pull it back up to match the section rhythm. */
+.tools-section .build-cta {
+  margin-bottom: -32px;
+}

--- a/assets/sass/3-modules/_tools.scss
+++ b/assets/sass/3-modules/_tools.scss
@@ -308,9 +308,20 @@
   flex-wrap: wrap;
 }
 
-/* homepage tools section — the CTA band sits outside .container__inner, so it
-   misses the -32px pull-up the other sections get and leaves an oversized gap
-   before the next section. Pull it back up to match the section rhythm. */
-.tools-section .build-cta {
-  margin-bottom: -32px;
+/* homepage tools section — the CTA band ends the section in its own .container.
+   The following section (the partners/testimonials band) carries 96px of its
+   own top padding, which stacked with the section margins left an oversized gap
+   below the CTA. Drop this section's bottom margin and trim the next section's
+   top spacing for this adjacency so the gap matches the page rhythm. */
+.tools-section {
+  margin-bottom: 0;
+
+  .build-cta {
+    margin-bottom: 0;
+  }
+}
+
+.tools-section + .section {
+  margin-top: 0;
+  padding-top: 48px;
 }

--- a/config.toml
+++ b/config.toml
@@ -173,7 +173,7 @@ pagerSize = 6
     limit = 6
 
   [params.projects.fundraising]
-    enable = true
+    enable = false
     projects_title= "😇 Looking for Funding"
     limit = 3
 

--- a/config.toml
+++ b/config.toml
@@ -179,6 +179,14 @@ pagerSize = 6
 
 
   #-------------------------------
+  # Home Tools Section
+  [params.home_tools]
+    enable = true
+    title = "🛠️ Our Tools"
+    featured = ["pyronear", "salmonvision", "biowatch"]  # tool slugs, in display order
+
+
+  #-------------------------------
   # Partners Section
   [params.partners]
     enable = true

--- a/content/projects/biowatch-app.md
+++ b/content/projects/biowatch-app.md
@@ -15,7 +15,7 @@ clients:
     logo: /images/clients/inbo/logo.jpg
 status: completed
 github_repo: https://github.com/earthtoolsmaker/biowatch
-pinned: true
+pinned: false
 date: 2025-02-20
 image: /images/projects/biowatch-app/cover.png
 aliases:

--- a/docs/specs/2026-06-14-homepage-tools-cta-revamp-design.md
+++ b/docs/specs/2026-06-14-homepage-tools-cta-revamp-design.md
@@ -1,0 +1,114 @@
+# Homepage tools section + "build technology that matters" CTA — Design
+
+**Date:** 2026-06-14
+**Branch:** `worktree-homepage-tools-cta-revamp`
+
+## Goal
+
+Revamp the homepage to (1) showcase a curated set of the open-source tools we
+offer, and (2) add a call-to-action inviting people to support or partner with
+us — "Help us build technology that matters".
+
+## Current state
+
+- Homepage (`layouts/index.html`) composes: hero → projects → testimonials →
+  blog → tags.
+- 4 tools exist in `content/tools/`: `pyronear`, `salmonvision`, `biowatch`,
+  `animal-reid`.
+- The tool card markup (`.tool` article) lives inline in
+  `layouts/tools/list.html`.
+- Reusable CTA partials already exist (`tools-cta.html`, `projects-cta.html`,
+  `spaces-cta.html`, `support-cta.html`), all built on the shared `.about-cta`
+  styling.
+- Section sections (projects, testimonials, blog) are config-driven via
+  `config.toml` `params`.
+
+## New homepage flow
+
+hero → projects → **tools** → **build-CTA** → testimonials → blog → tags
+
+The tools section and its CTA are inserted directly after `section-projects`,
+so the tools sit right under the projects they power.
+
+## Components
+
+### 1. `tool-card.html` partial (DRY extraction)
+
+Extract the existing `.tool` card markup from `layouts/tools/list.html` into a
+new `layouts/partials/tool-card.html` partial that takes a tool page as context
+(`.`). Update `tools/list.html` to call the partial inside its range loop.
+
+- No visual change to the `/tools/` page.
+- The card renders: tinted logo header (`card_tint`, `logo_container`),
+  optional `subtitle`, linked `title`, and `summary`.
+
+### 2. `section-tools.html` partial
+
+New `layouts/partials/section-tools.html`, rendered from `index.html` after
+`section-projects.html`. Gated on `params.home_tools.enable`.
+
+Contents:
+- Section header matching the site pattern: `params.home_tools.title` (default
+  `🛠️ Our Tools`) inside `.section__info`/`.section__head` with the squiggle
+  SVG used by the projects/services sections.
+- A one-line intro paragraph (e.g. "Free, open-source software we build with
+  field teams — download and run it yourself.").
+- The featured tool cards in a `.container > .row`, each rendered via
+  `tool-card.html`.
+- A `View all tools →` link to `/tools/` (styled like the existing
+  `button button--cta` "View all" links in the projects section).
+- The build-CTA (`build-cta.html`) at the end of the section.
+
+**Tool selection (config-driven):** the partial reads
+`params.home_tools.featured` — a list of tool slugs in display order — and looks
+each one up among `where site.RegularPages "Section" "tools"`. Slugs that don't
+resolve are skipped silently. This mirrors how the projects/testimonials
+sections are configured and lets the featured set be reordered or swapped
+without editing templates.
+
+### 3. `build-cta.html` partial
+
+New `layouts/partials/build-cta.html`, built on the existing `.about-cta`
+structure (consistent with `tools-cta.html`/`projects-cta.html`, no new CSS):
+
+- Title: **"Help us build technology that matters"**
+- Description: a short line about supporting or partnering with us.
+- Buttons:
+  - `Support our work 🌍` → `/support/` (primary, `button button--cta`)
+  - `Partner with us` → `/contact/` (secondary, `button button--ghost`)
+
+Accepts an optional `class` (like the other CTA partials) for placement
+variants.
+
+### 4. Config
+
+Add to `config.toml`:
+
+```toml
+[params.home_tools]
+  enable = true
+  title = "🛠️ Our Tools"
+  featured = ["pyronear", "salmonvision", "biowatch"]  # slugs, in display order
+```
+
+## Styling
+
+Reuses existing classes — `.section`, `.section__info`, `.section__head`,
+`.section__title`, the `.tool` card styles, `.about-cta`, and the `col col-4`
+grid. At most a small intro-text rule may be added if no existing class fits;
+no new card or CTA components.
+
+## Out of scope
+
+- No changes to the `/tools/` page content or the tool cards' visual design.
+- No new tool content.
+- No changes to the existing `tools-cta.html` (different messaging; left as-is
+  for the `/tools/` page).
+
+## Verification
+
+- `hugo` builds with no errors/warnings.
+- Homepage renders the tools section (3 cards in order: Pyronear, SalmonVision,
+  Biowatch) followed by the build-CTA, between projects and testimonials.
+- `/tools/` page is visually unchanged after the card extraction.
+- CTA buttons link to `/support/` and `/contact/`.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,6 +4,8 @@
 
 {{ partial "section-projects.html" . }}
 
+{{ partial "section-tools.html" . }}
+
 {{ partial "section-testimonials.html" . }}
 
 {{ partial "section-blog.html" . }}

--- a/layouts/partials/build-cta.html
+++ b/layouts/partials/build-cta.html
@@ -1,11 +1,17 @@
-<!-- build technology that matters — support / partner CTA -->
+<!-- build technology that matters — support / partner CTA (mimics the support page cta-band) -->
 <div class="container">
-  <div class="about-cta build-cta {{ .class }} animate">
-    <h3 class="about-cta__title">Help us build technology that matters</h3>
-    <p class="about-cta__description">Our tools are free and open source. Support our work or partner with us, and help bring conservation technology to the field teams who need it.</p>
-    <div class="build-cta__buttons">
-      <a href="/support/" class="link-no-decoration button button--cta">Support our work 🌍</a>
-      <a href="/contact/" class="link-no-decoration button button--ghost">Partner with us</a>
+  <div class="support__cta-band build-cta {{ .class }} animate">
+    <div class="support__cta-band-text">
+      <h3 class="support__cta-band-title">Help us build technology that matters</h3>
+      <p class="support__cta-band-description">Our tools are free and open source. Support our work or partner with us, and help bring conservation technology to the field teams who need it.</p>
+    </div>
+    <div class="support__cta-band-buttons">
+      <a class="link-no-decoration" href="/support/">
+        <button class="button">Support our work 🌍</button>
+      </a>
+      <a class="link-no-decoration" href="/contact/">
+        <button class="button button--ghost">Partner with us</button>
+      </a>
     </div>
   </div>
 </div>

--- a/layouts/partials/build-cta.html
+++ b/layouts/partials/build-cta.html
@@ -1,0 +1,11 @@
+<!-- build technology that matters — support / partner CTA -->
+<div class="container">
+  <div class="about-cta build-cta {{ .class }} animate">
+    <h3 class="about-cta__title">Help us build technology that matters</h3>
+    <p class="about-cta__description">Our tools are free and open source. Support our work or partner with us, and help bring conservation technology to the field teams who need it.</p>
+    <div class="build-cta__buttons">
+      <a href="/support/" class="link-no-decoration button button--cta">Support our work 🌍</a>
+      <a href="/contact/" class="link-no-decoration button button--ghost">Partner with us</a>
+    </div>
+  </div>
+</div>

--- a/layouts/partials/section-tools.html
+++ b/layouts/partials/section-tools.html
@@ -1,0 +1,38 @@
+{{ if .Site.Params.home_tools.enable }}
+<!-- begin home tools -->
+<section class="section tools-section animate">
+  <div class="container">
+    <div class="row">
+      <div class="col col-12">
+        <div class="container__inner">
+
+          <div class="section__info">
+            <div class="section__head">
+              <h2 class="section__title">{{ .Site.Params.home_tools.title | safeHTML }}</h2>
+              <a class="button button--cta" href="/tools/">View all <i class="fa-solid fa-chevron-right"></i></a>
+            </div>
+            <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
+          </div>
+
+          <p class="services__intro">
+            Free, open-source software we build with field teams — download it and run it yourself.
+          </p>
+
+          <div class="row">
+            {{ range .Site.Params.home_tools.featured }}
+            {{ with site.GetPage (printf "/tools/%s" .) }}
+            {{ partial "tool-card.html" . }}
+            {{ end }}
+            {{ end }}
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {{ partial "build-cta.html" (dict "class" "build-cta--home") }}
+
+</section>
+<!-- end home tools -->
+{{ end }}

--- a/layouts/partials/section-tools.html
+++ b/layouts/partials/section-tools.html
@@ -15,7 +15,7 @@
           </div>
 
           <p class="services__intro">
-            Free, open-source software we build with field teams — download it and run it yourself.
+            Free, open-source software we build with field teams — explore each one and try it for yourself.
           </p>
 
           <div class="row">

--- a/layouts/partials/tool-card.html
+++ b/layouts/partials/tool-card.html
@@ -1,0 +1,27 @@
+{{- /* Renders one tool card. Context (.) is a tool page. */ -}}
+<article class="tool col col-4 col-w-6 col-t-12">
+  <div class="tool__content">
+    <div class="tool__image"{{ with .Params.card_tint }} style="--tool-tint: {{ . }}"{{ end }}>
+      <div class="tool__logo{{ if .Params.logo_container }} tool__logo--chip{{ end }}">
+        {{ $iconPath := strings.TrimPrefix "/" .Params.icon }}
+        {{ $icon := resources.Get $iconPath }}
+        {{ if $icon }}
+        <img src="{{ $icon.RelPermalink }}" alt="{{ .Title }} logo" />
+        {{ else }}
+        <img src="{{ .Params.icon }}" alt="{{ .Title }} logo" />
+        {{ end }}
+      </div>
+    </div>
+    <div class="tool__inner">
+      <div class="tool__info">
+        {{ with .Params.subtitle }}
+        <div class="tool__subtitle">{{ . }}</div>
+        {{ end }}
+        <h3 class="tool__title"><a href="{{ .RelPermalink }}" class="tool__link">{{ .Title }}</a></h3>
+        {{ with .Params.summary }}
+        <p class="tool__excerpt">{{ . }}</p>
+        {{ end }}
+      </div>
+    </div>
+  </div>
+</article>

--- a/layouts/tools/list.html
+++ b/layouts/tools/list.html
@@ -60,32 +60,7 @@
   <div class="container animate">
     <div class="row">
       {{ range (where .Site.RegularPages "Section" "tools" ) }}
-      <article class="tool col col-4 col-w-6 col-t-12">
-        <div class="tool__content">
-          <div class="tool__image"{{ with .Params.card_tint }} style="--tool-tint: {{ . }}"{{ end }}>
-            <div class="tool__logo{{ if .Params.logo_container }} tool__logo--chip{{ end }}">
-              {{ $iconPath := strings.TrimPrefix "/" .Params.icon }}
-              {{ $icon := resources.Get $iconPath }}
-              {{ if $icon }}
-              <img src="{{ $icon.RelPermalink }}" alt="{{ .Title }} logo" />
-              {{ else }}
-              <img src="{{ .Params.icon }}" alt="{{ .Title }} logo" />
-              {{ end }}
-            </div>
-          </div>
-          <div class="tool__inner">
-            <div class="tool__info">
-              {{ with .Params.subtitle }}
-              <div class="tool__subtitle">{{ . }}</div>
-              {{ end }}
-              <h3 class="tool__title"><a href="{{ .RelPermalink }}" class="tool__link">{{ .Title }}</a></h3>
-              {{ with .Params.summary }}
-              <p class="tool__excerpt">{{ . }}</p>
-              {{ end }}
-            </div>
-          </div>
-        </div>
-      </article>
+      {{ partial "tool-card.html" . }}
       {{ end }}
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Add an **Our Tools** section to the homepage (between Featured Projects and Partners) featuring **Pyronear, SalmonVision, Biowatch** — config-driven via `params.home_tools.featured` (slugs, in display order)
- Extract the tool-card markup into a reusable `tool-card.html` partial, shared by the `/tools/` page and the new homepage section (no visual change to `/tools/`)
- Add a **"Help us build technology that matters"** CTA, styled like the support page's `cta-band` (Support our work / Partner with us)
- **Hide** the "Looking for Funding" section on the homepage (`params.projects.fundraising.enable = false`; `/projects/` and `/support/` unaffected)
- **Unpin Biowatch** from Featured Projects since it's now surfaced in the Tools section (another completed project fills the slot)
- Tools intro copy avoids "download" (not all tools are downloadable — some are HF Space demos), favoring "explore each one and try it for yourself"
- Trim the oversized gap below the CTA band (the following partners band carries 96px of its own top padding) so it matches the page's section rhythm

## Test plan
- [ ] `hugo` builds with no errors/warnings
- [ ] Homepage shows the Tools section (3 cards, in order) + CTA band between Projects and Partners
- [ ] CTA buttons link to `/support/` and `/contact/`
- [ ] `/tools/` page renders unchanged (4 cards)
- [ ] "Looking for Funding" no longer on the homepage; still present on `/projects/` and `/support/`