### PR TITLE
Replace About partners carousel arrows with a 'View all' button

### DIFF
--- a/assets/sass/4-layouts/_about.scss
+++ b/assets/sass/4-layouts/_about.scss
@@ -610,11 +610,6 @@
 /* Partners logo strip — shared by the about page section and the
    homepage testimonials band */
 .about-partners {
-  .controls .prev,
-  .controls .next {
-    color: var(--tertiary-color);
-  }
-
   .partners__carousel {
     margin-bottom: 0;
   }

--- a/layouts/partials/section-about-partners.html
+++ b/layouts/partials/section-about-partners.html
@@ -7,14 +7,7 @@
     <div class="section__info partners__info">
       <div class="section__head">
         <h2 class="section__title">{{ $.Site.Params.partners.partners_title | default "🤝 Our Partners" | safeHTML }}</h2>
-        <ul class="controls list-reset" id="about-partners-controls" aria-label="Partners Slider Navigation" tabindex="0">
-          <li class="prev" data-controls="prev" aria-controls="about-partners-slider" tabindex="-1">
-            <i class="fa-solid fa-arrow-left-long"></i>
-          </li>
-          <li class="next" data-controls="next" aria-controls="about-partners-slider" tabindex="-1">
-            <i class="fa-solid fa-arrow-right-long"></i>
-          </li>
-        </ul>
+        <a class="button button--cta" href="/partners/">View all <i class="fa-solid fa-chevron-right"></i></a>
       </div>
       <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none">
         <path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"


### PR DESCRIPTION
## What

On the About page, the partners section is a logo carousel with prev/next arrows. This replaces those arrows with a **View all** button that links to the full `/partners/` page — mirroring the pattern already used in the homepage testimonials band.

The autoplaying carousel itself is unchanged; only the navigation control swaps from arrows to the button.

## Changes

- `layouts/partials/section-about-partners.html` — swap the `.controls` prev/next `<ul>` for `<a class="button button--cta" href="/partners/">View all …</a>`.
- `assets/sass/4-layouts/_about.scss` — remove the now-orphaned `.about-partners .controls .prev/.next` rule (carousel styling kept).

## Verification

- `hugo` builds cleanly (exit 0).
- Rendered `public/about/index.html` shows the View all button, the carousel markup intact, and no arrow controls.
- Homepage testimonials band unchanged.