### PR TITLE
feat(partners): restyle support CTA as bordered card

### DIFF
--- a/assets/sass/4-layouts/_partners-page.scss
+++ b/assets/sass/4-layouts/_partners-page.scss
@@ -86,11 +86,4 @@
 
 .partners-cta {
   text-align: center;
-
-  p {
-    max-width: 640px;
-    margin: 0 auto 24px;
-    font-size: 1.1rem;
-    line-height: 1.6;
-  }
 }

--- a/layouts/page/partners.html
+++ b/layouts/page/partners.html
@@ -107,7 +107,11 @@
   {{/* ---- Support CTA ---- */}}
   <section class="section partners-cta animate">
     <div class="container-wide">
-      {{ partial "support-cta.html" . }}
+      <div class="about-cta">
+        <h3 class="about-cta__title">Powered by our community</h3>
+        <p class="about-cta__description">We rely on support from our community. It's because of your contributions that we can carry out these projects and partnerships, helping us fulfill our mission. Please consider sponsoring this project.</p>
+        <a href="/support/" class="link-no-decoration button">Support our work 🌍</a>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary

Restyles the support call-to-action at the bottom of the **Partners** page to use the bordered `.about-cta` card pattern (serif title, centered copy, teal shadowed button) instead of the plain paragraph + button.

- Swap the `support-cta.html` partial for an inline `.about-cta` card in `layouts/page/partners.html`.
- Add a serif title: **"Powered by our community"**.
- Keep the original support copy and the **Support our work 🌍** button linking to `/support/`.
- Remove the now-orphaned `.partners-cta p` SCSS rule (its `<p>` target is gone and it would override `.about-cta__description`).

No new CSS — reuses the existing `.about-cta` and default `.button` (teal `#006d77`, dark offset shadow) components. The shared `support-cta.html` partial is untouched (still used by the `donate_sponsor_cta` shortcode).

## Verification

- `hugo` builds clean (exit 0).
- Visually confirmed via static-build screenshot.