### PR TITLE
feat(testimonials): hover-lift cards, full-card link, bottom partner logos

### DIFF
--- a/assets/sass/3-modules/_testimonials.scss
+++ b/assets/sass/3-modules/_testimonials.scss
@@ -27,6 +27,8 @@
 
 .testimonial-item {
   margin-bottom: 36px;
+  // Top room so the hover lift isn't clipped by the slider's overflow:hidden
+  padding-top: 12px;
   position: relative;
 
   @media (max-width: $mobile) {
@@ -35,11 +37,18 @@
 }
 
 .testimonial-content {
+  position: relative;
   padding: 32px;
   border-radius: 16px;
   background: var(--background-alt-color);
   border: 1px solid var(--border-color);
   box-shadow: 0 6px 26px rgba(0, 0, 0, 0.05);
+  will-change: transform;
+  transition: transform .3s ease;
+
+  &:hover {
+    transform: translateY(-8px);
+  }
 
   @media (max-width: $mobile) {
     padding: 20px;
@@ -69,11 +78,6 @@
     height: 100%;
     user-select: none;
     object-fit: cover;
-    transition: transform .3s ease;
-  }
-
-  &:hover .client-avatar {
-    transform: scale(1.05);
   }
 
   @media (max-width: $mobile) {
@@ -83,29 +87,23 @@
 }
 
 .client-logo {
-  width: 100%;
-  position: relative;
+  margin-top: 20px;
+  text-align: center;
 
   .client-logo-image {
-    display: block;
-    position: absolute;
-    top: -16px; /* Distance from the top of its normal position */
-    right: -16px; /* Distance from the right of its normal position */
-    height: 30px;
+    display: inline-block;
+    width: auto;
+    height: auto;
+    // Bounding box normalises visual weight across square + wide logos
+    max-width: 140px;
+    max-height: 46px;
     filter: grayscale(100%);
     opacity: 0.7;
-    transition: all 0.3s ease;
 
     @media (max-width: $mobile) {
-      height: 20px;
-      top: -10px; /* Distance from the top of its normal position */
-      right: -10px; /* Distance from the right of its normal position */
+      max-width: 110px;
+      max-height: 36px;
     }
-  }
-
-  &:hover .client-logo-image {
-    filter: grayscale(0%);
-    opacity: 1;
   }
 }
 
@@ -118,6 +116,17 @@
     font-size: 18px;
     font-family: $base-font-family;
     font-weight: 700;
+
+    a::after {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      z-index: 1;
+      border-radius: 16px;
+    }
   }
 
   .client-designation {

--- a/config.toml
+++ b/config.toml
@@ -333,7 +333,7 @@ pagerSize = 6
   [[params.testimonial_item]]
     name = "Mateo Lostanlen"
     image = "/images/testimonials/mateo_pyronear.png"
-    logo = "/images/clients/pyronear/logo_bare.png"
+    logo = "/images/clients/pyronear/logo.png"
     designation = "Co-founder and CEO - Pyronear"
     link = "https://www.pyronear.org"
     content = "We absolutely love working with you. You are incredibly professional. They trained our latest model and achieved outstanding performance, setting a new benchmark. They also implemented the MLOps pipeline!"
@@ -349,7 +349,7 @@ pagerSize = 6
   [[params.testimonial_item]]
     name = "Yohan Runhaar"
     image = "/images/testimonials/yohan-reefsupport.jpg"
-    logo = "/images/clients/reefsupport/logo_without_text.png"
+    logo = "/images/clients/reefsupport/logo.png"
     designation = "CTO - ReefSupport"
     link = "https://reef.support"
     content = "I am very excited for what is ahead, there is so much potential in the work that's been done. Your hard work and passion have really shone through!"
@@ -358,7 +358,7 @@ pagerSize = 6
   [[params.testimonial_item]]
     name = "Thijs Suijten"
     image = "/images/testimonials/thijs-hacktheplanet.jpg"
-    logo = "/images/clients/hacktheplanet/logo_without_text.png"
+    logo = "/images/clients/hacktheplanet/logo.png"
     designation = "Co-founder & CTO - HackThePlanet"
     link = "https://www.hack-the-planet.io/"
     content = "They really helped us by training a YOLOv8 model for our system to prevent human-bear-conflicts. He thinks along well, knows what he is talking about and is a nice person to work with!"
@@ -366,7 +366,7 @@ pagerSize = 6
   [[params.testimonial_item]]
     name = "Melanie Clapham"
     image = "/images/testimonials/melanie-bearid.jpg"
-    logo = "/images/clients/bearid/logo_without_text.png"
+    logo = "/images/clients/bearid/logo_dark.png"
     designation = "Director & Conservation Scientist - The BearID Project"
     link = "https://bearresearch.org/"
     content = "There is definitely a want and need from the conservation community to work with people like you, with your expertise, as the technical side to this type of development is often the barrier. "

--- a/layouts/partials/section-testimonials.html
+++ b/layouts/partials/section-testimonials.html
@@ -51,26 +51,14 @@
               <div class="testimonial-item">
                 <div class="testimonial-content">
                   <div class="client-meta">
-                    {{ if .logo }}
-                      <div class="client-logo">
-                        <a href="{{ .link }}" target="_blank">
-                          {{ $orgName := index (split .designation " - ") 1 }}
-                          {{ $imgPath := strings.TrimPrefix "/" .logo }}
-                          {{ $img := resources.Get $imgPath }}
-                          {{ if $img }}
-                          <img class="client-logo-image" src="{{ $img.RelPermalink }}" title="{{ $orgName }}" alt="{{ $orgName }}" />
-                          {{ end }}
-                        </a>
-                      </div>
-                    {{ end }}
                     {{ if .image }}
-                    <a href="{{ .link }}" class="image-container" target="_blank" rel="noopener" title="Visit {{ index (split .designation " - ") 1 }}">
+                    <div class="image-container">
                       {{ $imgPath := strings.TrimPrefix "/" .image }}
                       {{ $img := resources.Get $imgPath }}
                       {{ if $img }}
                       <img class="client-avatar" src="{{ $img.RelPermalink }}" alt="{{ .name }}" loading="lazy">
                       {{ end }}
-                    </a>
+                    </div>
                     {{ end }}
                     <div class="client-info">
                       {{ if .name }}
@@ -89,7 +77,16 @@
                     {{ if .content }}
                     <p class="client-text">{{ .content }}</p>
                     {{ end }}
-                    <svg xmlns="http://www.w3.org/2000/svg" class="stars-icon" width="104" height="19" fill="none"><path fill="#e59819" d="m9.999.418 2.245 6.91h7.265l-5.877 4.27 2.245 6.91-5.878-4.27-5.878 4.27 2.245-6.91-5.878-4.27h7.266L9.999.418ZM30.999.418l2.245 6.91h7.265l-5.877 4.27 2.245 6.91-5.878-4.27-5.878 4.27 2.245-6.91-5.878-4.27h7.266l2.245-6.91ZM51.999.418l2.245 6.91h7.265l-5.877 4.27 2.245 6.91-5.878-4.27-5.878 4.27 2.245-6.91-5.878-4.27h7.266l2.245-6.91ZM72.999.418l2.245 6.91h7.265l-5.877 4.27 2.245 6.91-5.878-4.27-5.878 4.27 2.245-6.91-5.878-4.27h7.266l2.245-6.91ZM93.999.418l2.245 6.91h7.265l-5.877 4.27 2.245 6.91-5.878-4.27-5.878 4.27 2.245-6.91-5.878-4.27h7.266l2.245-6.91Z"/></svg>
+                    {{ if .logo }}
+                      <div class="client-logo">
+                        {{ $orgName := index (split .designation " - ") 1 }}
+                        {{ $imgPath := strings.TrimPrefix "/" .logo }}
+                        {{ $img := resources.Get $imgPath }}
+                        {{ if $img }}
+                        <img class="client-logo-image" src="{{ $img.RelPermalink }}" title="{{ $orgName }}" alt="{{ $orgName }}" />
+                        {{ end }}
+                      </div>
+                    {{ end }}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## What

Reworks the testimonial card interaction to match the project/tool cards.

- **Hover lift** — the whole card lifts `translateY(-8px)` on hover, identical to `.article__content`.
- **Whole card clickable** — clicking anywhere on a card opens the partner's website (new tab). The three separate logo/avatar/name links are collapsed into a single full-bleed `::after` overlay on the name link, avoiding nested anchors.
- **No clipping** — added top padding to the slide so the upward lift isn't cut off by the tiny-slider viewport's `overflow: hidden`.

## Also tidied up while in here

- **Partner logo moved** from a small grayscale top-right corner badge to a centered **bottom attribution**, sized via a bounding box (max 140×46px) so near-square logos (Wild Salmon Center) and wide wordmarks (Pyronear) read at even visual weight.
- **Full logos** (`logo.png`) instead of the `_bare` / `_without_text` icon variants; BearID uses `logo_dark.png` for contrast on the light card.
- **Removed** the decorative 5-star row and the avatar-zoom / logo-grayscale→color micro-hovers.

## Testing

- `hugo` static build passes.
- Verified live via `hugo server`: cards lift smoothly without clipping, full card is clickable to each partner site, logos balanced and legible.