### PR TITLE
Lowercase site title to earthtoolsmaker

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@
 # General Site Settings
 baseURL = "https://earthtoolsmaker.org"
 languageCode = "en-us"
-title = "EarthToolsMaker"
+title = "earthtoolsmaker"
 googleAnalytics = "" # Add your identifier. For example UA-99631805-1.
 # paginate = 6
 


### PR DESCRIPTION
Changes the site `title` in `config.toml` from `EarthToolsMaker` to `earthtoolsmaker`, so the rendered `<title>` and other `.Site.Title` references display lowercase.

## Verification
- `hugo` build passes
- Rendered homepage `<title>` is now `earthtoolsmaker`

## Note
`params.author.author_name` is still `EarthToolsMaker` — left untouched since the request was specifically about the site title. Let me know if you want that lowercased too.