### PR TITLE
style(sections): emoji-free section titles, enlarged to 28px

### DIFF
--- a/assets/sass/3-modules/_sections.scss
+++ b/assets/sass/3-modules/_sections.scss
@@ -21,7 +21,7 @@
 
   .section__title {
     margin-bottom: 0;
-    font-size: 22px;
+    font-size: 28px;
     font-weight: 600;
   }
 
@@ -33,7 +33,7 @@
     }
 
     .section__title {
-      font-size: 20px;
+      font-size: 24px;
     }
   }
 }

--- a/config.toml
+++ b/config.toml
@@ -169,12 +169,12 @@ pagerSize = 6
 
   [params.projects.completed]
     enable = true
-    projects_title= "👨🏻‍💻 Featured Projects"
+    projects_title= "Featured Projects"
     limit = 6
 
   [params.projects.fundraising]
     enable = false
-    projects_title= "😇 Looking for Funding"
+    projects_title= "Looking for Funding"
     limit = 3
 
 
@@ -182,7 +182,7 @@ pagerSize = 6
   # Home Tools Section
   [params.home_tools]
     enable = true
-    title = "🛠️ Our Tools"
+    title = "Our Tools"
     featured = ["pyronear", "salmonvision", "biowatch"]  # tool slugs, in display order
 
 
@@ -190,7 +190,7 @@ pagerSize = 6
   # Partners Section
   [params.partners]
     enable = true
-    partners_title = "🤝 Our Partners"
+    partners_title = "Our Partners"
 
   [[params.partner_item]]
     name = "Pyronear"
@@ -383,7 +383,7 @@ pagerSize = 6
   # Blog Section
   [params.blog]
     enable = true
-    blog_title = "📚 Read Latest Posts"
+    blog_title = "Read Latest Posts"
     limit = 3
 
 
@@ -391,7 +391,7 @@ pagerSize = 6
   # Tags Section
   [params.tags]
     enable = false
-    tags_title = "✌️ Explore Topics"
+    tags_title = "Explore Topics"
 
 
   #-------------------------------

--- a/layouts/page/support.html
+++ b/layouts/page/support.html
@@ -44,7 +44,7 @@
 
           <div class="section__info">
             <div class="section__head">
-              <h2 class="section__title">🤝 Partner With Us</h2>
+              <h2 class="section__title">Partner With Us</h2>
             </div>
             <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
           </div>
@@ -100,7 +100,7 @@
 
           <div class="section__info">
             <div class="section__head">
-              <h2 class="section__title">✅ Proven in the Field</h2>
+              <h2 class="section__title">Proven in the Field</h2>
             </div>
             <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
           </div>
@@ -133,7 +133,7 @@
 
           <div class="section__info">
             <div class="section__head">
-              <h2 class="section__title">🌱 Fund a Project</h2>
+              <h2 class="section__title">Fund a Project</h2>
             </div>
             <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
           </div>
@@ -178,7 +178,7 @@
 
           <div class="section__info">
             <div class="section__head">
-              <h2 class="section__title">🌍 More Ways to Help</h2>
+              <h2 class="section__title">More Ways to Help</h2>
             </div>
             <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
           </div>

--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -6,7 +6,7 @@
 
     <div class="section__info">
       <div class="section__head">
-        <h2 class="section__title">👍 You may also like</h2>
+        <h2 class="section__title">You may also like</h2>
       </div>
       <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
     </div>

--- a/layouts/partials/section-about-partners.html
+++ b/layouts/partials/section-about-partners.html
@@ -6,7 +6,7 @@
 
     <div class="section__info partners__info">
       <div class="section__head">
-        <h2 class="section__title">{{ $.Site.Params.partners.partners_title | default "🤝 Our Partners" | safeHTML }}</h2>
+        <h2 class="section__title">{{ $.Site.Params.partners.partners_title | default "Our Partners" | safeHTML }}</h2>
         <a class="button button--cta" href="/partners/">View all <i class="fa-solid fa-chevron-right"></i></a>
       </div>
       <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none">

--- a/layouts/partials/section-about-timeline.html
+++ b/layouts/partials/section-about-timeline.html
@@ -5,7 +5,7 @@
 
     <div class="section__info">
       <div class="section__head">
-        <h2 class="section__title">🧭 The Journey</h2>
+        <h2 class="section__title">The Journey</h2>
       </div>
       <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none">
         <path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"

--- a/layouts/partials/section-services.html
+++ b/layouts/partials/section-services.html
@@ -5,7 +5,7 @@
 
     <div class="section__info">
       <div class="section__head">
-        <h2 class="section__title">🛠️ What We Do</h2>
+        <h2 class="section__title">What We Do</h2>
       </div>
       <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none">
         <path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"

--- a/layouts/partials/section-team.html
+++ b/layouts/partials/section-team.html
@@ -5,7 +5,7 @@
 
     <div class="section__info">
       <div class="section__head">
-        <h2 class="section__title">👋 The Team</h2>
+        <h2 class="section__title">The Team</h2>
       </div>
       <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none">
         <path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"

--- a/layouts/partials/section-work-in-field.html
+++ b/layouts/partials/section-work-in-field.html
@@ -5,7 +5,7 @@
 
     <div class="section__info">
       <div class="section__head">
-        <h2 class="section__title">🐾 Work in the Field</h2>
+        <h2 class="section__title">Work in the Field</h2>
       </div>
       <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none">
         <path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"


### PR DESCRIPTION
## What

Removes the leading emoji from every `.section__title` heading site-wide and enlarges the shared section-title size for a more professional look.

### Emoji removed from section titles
- **Homepage:** Featured Projects, Our Tools, Read Latest Posts, Explore Topics, Our Partners
- **About:** What We Do, Work in the Field, The Journey, The Team, Our Partners
- **Support:** Partner With Us, Proven in the Field, Fund a Project, More Ways to Help
- **Posts:** You may also like (related posts)

### Sizing
- `.section__title` bumped from **22px → 28px** desktop and **20px → 24px** mobile (`assets/sass/3-modules/_sections.scss`). Weight unchanged (600).

## Notes
- Scope is the `.section__title` class only; decorative emojis elsewhere (e.g. the "Support our work 🌍" CTA button) are untouched.
- `Looking for Funding` stays disabled (`enable = false`, inherited from main) — its title was de-emojied too in case it's ever re-enabled.

## Verification
- `hugo --gc` builds clean.
- Confirmed zero emoji in rendered `.section__title` across home/about/support, and compiled CSS shows 28px/24px.