### PR TITLE
feat(nav): clarify Support CTA as 'Support Us'

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -112,7 +112,7 @@ pagerSize = 6
       weight = 7
 
       [[menu.footer]]
-      name = "Support"
+      name = "Support Us"
       url = "/support/"
       weight = 8
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -69,7 +69,7 @@
         </nav>
 
         <div class="header__cta">
-          <a class="button" href="{{ "/support/" | relLangURL }}">Support</a>
+          <a class="button" href="{{ "/support/" | relLangURL }}">Support Us</a>
         </div>
 
       </div>


### PR DESCRIPTION
The bare **"Support"** button read ambiguously — it could be mistaken for site/tech support rather than backing the team.

## Changes
- `layouts/partials/header.html` — header CTA button: `Support` → `Support Us`
- `config.toml` — footer menu link renamed to match for consistency

The `/support/` page is titled *"Support Our Work"* (sponsorships + partnerships funding free, open-source conservation tools), so the new label aligns the entry point with the destination.

Verified with a clean `hugo` build; both the button and footer link render as "Support Us".