### PR TITLE
Compact the footer layout

### DIFF
--- a/assets/sass/3-modules/_footer.scss
+++ b/assets/sass/3-modules/_footer.scss
@@ -75,6 +75,14 @@
 }
 
 /* Widget Recent Posts */
+.widget-recent-posts {
+  padding-right: 32px;
+
+  @media (max-width: $desktop) {
+    padding-right: 0;
+  }
+}
+
 .recent-posts {
   position: relative;
   display: flex;

--- a/assets/sass/3-modules/_footer.scss
+++ b/assets/sass/3-modules/_footer.scss
@@ -5,7 +5,7 @@
   background: #fff5ed;
 
   .footer__inner {
-    padding: 40px 0;
+    padding: 28px 0;
   
     .row .col {
       flex-grow: 1;
@@ -24,23 +24,23 @@
 /* Widgets */
 .widget-footer {
   @media (max-width: $desktop) {
-    margin-bottom: 60px;
+    margin-bottom: 36px;
   }
 
   @media (max-width: $mobile) {
-    margin-bottom: 48px;
+    margin-bottom: 32px;
   }
 }
 
 .widget-title {
-  margin-bottom: 28px;
-  font-size: 24px;
+  margin-bottom: 16px;
+  font-size: 18px;
 }
 
 /* Widget Footer Info */
 .logo-footer__link {
   display: inline-flex;
-  margin-bottom: 28px;
+  margin-bottom: 16px;
   font-size: 32px;
   font-family: $heading-font-family;
   line-height: 1;
@@ -70,7 +70,7 @@
 
 .widget-footer__desc {
   max-width: 480px;
-  margin-bottom: 20px;
+  margin-bottom: 14px;
   font-size: 16px;
 }
 
@@ -79,7 +79,7 @@
   position: relative;
   display: flex;
   align-items: center;
-  margin-bottom: 20px;
+  margin-bottom: 14px;
 
   &:last-child {
     margin-bottom: 0;
@@ -174,6 +174,8 @@
 
   .footer__nav-list {
     line-height: 1;
+    column-count: 2;
+    column-gap: 32px;
   }
 
   .footer__nav-item {
@@ -230,7 +232,7 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  padding: 32px 0;
+  padding: 20px 0;
   border-top: 1px solid var(--border-color);
 
   @media (max-width: $tablet) {

--- a/assets/sass/3-modules/_footer.scss
+++ b/assets/sass/3-modules/_footer.scss
@@ -170,12 +170,14 @@
 
 /* Widget Footer Navigation */
 .widget-nav {
-  text-align: right;
+  text-align: left;
 
   .footer__nav-list {
+    display: grid;
+    grid-auto-flow: column;
+    justify-content: start;
+    column-gap: 48px;
     line-height: 1;
-    column-count: 2;
-    column-gap: 32px;
   }
 
   .footer__nav-item {
@@ -220,10 +222,6 @@
       border-radius: 50%;
       background-color: var(--text-alt-color);
     }
-  }
-
-  @media (max-width: $desktop) {
-    text-align: left;
   }
 }
 

--- a/docs/specs/2026-06-15-footer-compaction-design.md
+++ b/docs/specs/2026-06-15-footer-compaction-design.md
@@ -1,0 +1,70 @@
+# Footer Compaction — Design
+
+**Date:** 2026-06-15
+**Status:** Approved
+
+## Problem
+
+The site footer feels too big. It is a three-column widget block (info, recent
+posts, navigation) followed by a bottom info bar, with generous spacing that
+stacks up — especially tall on mobile where the columns stack vertically.
+
+## Goal
+
+Reduce footer height by roughly 30% while keeping all existing content and the
+overall three-widget layout. The only structural change is laying the
+navigation links out in two columns instead of one tall list.
+
+## Non-goals
+
+- No removal of widgets (info, recent posts, navigation all stay).
+- No change to recent-post thumbnail size (kept as-is).
+- No color, theme-toggle, back-to-top, or social-icon changes.
+- No HTML/partial restructuring beyond what the nav 2-column needs (CSS-only).
+
+## Changes
+
+All changes are in `assets/sass/3-modules/_footer.scss`.
+
+### 1. Spacing / size reductions (current → proposed)
+
+| Selector | Property | Current | Proposed |
+|----------|----------|---------|----------|
+| `.footer__inner` | padding | `40px 0` | `28px 0` |
+| `.widget-title` | margin-bottom | `28px` | `16px` |
+| `.widget-title` | font-size | `24px` | `18px` |
+| `.logo-footer__link` | margin-bottom | `28px` | `16px` |
+| `.widget-footer__desc` | margin-bottom | `20px` | `14px` |
+| `.recent-posts` | margin-bottom | `20px` | `14px` |
+| `.footer__info` | padding | `32px 0` | `20px 0` |
+| `.widget-footer` (@media `$desktop`) | margin-bottom | `60px` | `36px` |
+| `.widget-footer` (@media `$mobile`) | margin-bottom | `48px` | `32px` |
+
+### 2. Navigation → two columns
+
+`.footer__nav-list` becomes a CSS multi-column list:
+
+```scss
+.footer__nav-list {
+  line-height: 1;
+  column-count: 2;
+  column-gap: 32px;
+}
+```
+
+- The 10 links flow 5 + 5 instead of a single tall column.
+- Existing per-item `margin-bottom: 12px` provides row spacing within columns.
+- `text-align: right` (desktop) / `left` (mobile) and the active-dot
+  `::before` indicator are unchanged and continue to work per item.
+- Two columns are kept at all breakpoints for the height saving.
+
+## Verification
+
+1. `hugo` build succeeds with no template/SASS errors.
+2. Screenshot the contact page footer (identical site-wide) at 1440px and
+   390px widths, before and after, and confirm:
+   - Footer is visibly shorter (~30% less vertical space).
+   - All content still present: logo, description, social icons, 3 recent
+     posts with thumbnails, all 10 nav links (now 2 columns), copyright,
+     back-to-top.
+   - No overlap, clipping, or misalignment at either width.

--- a/layouts/partials/footer-widgets/widget-navigation.html
+++ b/layouts/partials/footer-widgets/widget-navigation.html
@@ -1,7 +1,8 @@
 <div class="col col-3 col-d-12">
   <div class="widget-footer widget-nav">
     <h3 class="widget-title">Navigation</h3>
-    <ul class="footer__nav-list list-reset">
+    {{ $rows := int (math.Ceil (div (len .Site.Menus.footer) 2.0)) }}
+    <ul class="footer__nav-list list-reset" style="grid-template-rows: repeat({{ $rows }}, auto);">
       {{ $currentPage := . }}
       {{ range.Site.Menus.footer }}
       {{ $menuURL := .URL | absLangURL }}


### PR DESCRIPTION
## Summary

The footer felt oversized, especially when its three columns stack on mobile. This tightens it up while keeping all existing content (info, recent posts, navigation, bottom info bar).

**Result:** desktop footer is ~23% shorter (593px → 459px); mobile shrinks more thanks to the two-column nav.

## Changes

- **Tighter spacing** throughout `_footer.scss`: inner padding 40→28px, widget titles 28→16px margin (24→18px font), logo margin 28→16px, description 20→14px, recent-post rows 20→14px, info-bar padding 32→20px, stacked-widget margins 60→36px / 48→32px.
- **Navigation in two columns**: the 10 links now flow into two content-width columns (CSS grid, column-major). The partial computes the row count so it always splits into two balanced columns. Left-aligned with the title over the first column.
- **Horizontal breathing room**: right padding on the recent-posts widget (desktop only) so its titles don't crowd the nav column; reset when columns stack on mobile.

## Verification

- Hugo builds clean.
- Screenshot-checked at 1280/1440 (desktop) and 390 (mobile): all content present, nav active-dot correct, no clipping or overlap.

Design spec: `docs/specs/2026-06-15-footer-compaction-design.md`