### PR TITLE
Align Monitoring Smolt Salmon Migration with Sonar page to the project-page system

### DIFF
--- a/assets/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/counting.svg
+++ b/assets/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/counting.svg
@@ -1,0 +1,70 @@
+<svg viewBox="0 0 760 320" xmlns="http://www.w3.org/2000/svg" font-family="Mulish, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="sonar" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0e3a4a"/><stop offset="100%" stop-color="#176074"/></linearGradient>
+  <radialGradient id="fishglow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#ff7a45"/><stop offset="100%" stop-color="#ff7a45" stop-opacity="0"/></radialGradient>
+  <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 1 L9 5 L0 9 Z" fill="#e29578"/></marker>
+  <filter id="cardshadow" x="-20%" y="-20%" width="140%" height="150%"><feDropShadow dx="0" dy="5" stdDeviation="9" flood-color="#1c2b28" flood-opacity="0.08"/></filter>
+  <pattern id="sonar-noise" width="7" height="7" patternUnits="userSpaceOnUse"><circle cx="1.5" cy="1.5" r="0.7" fill="#bfe0d6" opacity="0.16"/><circle cx="5" cy="4.5" r="0.6" fill="#bfe0d6" opacity="0.12"/></pattern>
+  <style>
+    .cap   { font-size: 14px; fill: #60626a; }
+    .tag   { font-size: 12px; font-weight: 700; fill: #fff; }
+    .cross { transform-box: fill-box; transform-origin: 50% 50%; animation: cross 3.2s ease-in-out infinite; }
+    .glow  { animation: glowp 3.2s ease-in-out infinite; }
+    .dash  { stroke-dasharray: 5 5; animation: flow 0.9s linear infinite; }
+    @keyframes cross { 0%{transform:translateY(-26px)} 55%,100%{transform:translateY(28px)} }
+    @keyframes glowp { 0%,45%{opacity:0.25} 60%,100%{opacity:1} }
+    @keyframes flow { to { stroke-dashoffset: -20; } }
+    @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+  </style>
+  <g id="smolt">
+    <ellipse cx="0" cy="0" rx="20" ry="8" fill="url(#fishglow)" opacity="0.7"/>
+    <ellipse cx="0" cy="0" rx="10" ry="3.1" fill="#ff6a3d"/>
+    <path d="M-10 0 L-16 -3.6 L-13 0 L-16 3.6 Z" fill="#ff6a3d"/>
+  </g>
+  <!-- a sonar tile with range arcs + a weir-box gate -->
+  <g id="tile">
+    <rect x="-140" y="-110" width="280" height="220" rx="14" fill="url(#sonar)"/>
+    <clipPath id="tc"><rect x="-140" y="-110" width="280" height="220" rx="14"/></clipPath>
+    <g clip-path="url(#tc)">
+      <rect x="-140" y="-110" width="280" height="220" fill="url(#sonar-noise)"/>
+      <g stroke="#7fb6c4" stroke-width="1.4" fill="none" opacity="0.28">
+        <path d="M-95 -70 A 118 118 0 0 1 95 -70"/>
+        <path d="M-110 -10 A 150 150 0 0 1 110 -10"/>
+        <path d="M-120 55 A 175 175 0 0 1 120 55"/>
+      </g>
+      <!-- weir-box gate -->
+      <g stroke="#9fd6d4" stroke-width="4" fill="none" opacity="0.85"><path d="M-34 78 L-34 18"/><path d="M34 78 L34 18"/></g>
+    </g>
+  </g>
+</defs>
+
+<!-- PANEL 1 — trigger placed -->
+<rect x="20" y="20" width="280" height="220" rx="14" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(160,130)">
+  <use href="#tile"/>
+  <!-- regional trigger line across the weir-box exit -->
+  <line class="dash" x1="-34" y1="32" x2="34" y2="32" stroke="#e29578" stroke-width="3" stroke-linecap="round"/>
+  <g transform="translate(0,58)"><rect x="-44" y="-12" width="88" height="22" rx="11" fill="#006d77"/><text class="tag" x="0" y="4" text-anchor="middle">weir-box exit</text></g>
+</g>
+<text class="cap" x="160" y="270" text-anchor="middle">A trigger line, just at the weir-box exit</text>
+
+<!-- arrow -->
+<line x1="318" y1="130" x2="362" y2="130" stroke="#e29578" stroke-width="3.5" fill="none" stroke-linecap="round" marker-end="url(#arrow)"/>
+
+<!-- PANEL 2 — fish counted on crossing -->
+<rect x="380" y="20" width="280" height="220" rx="14" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(520,130)">
+  <use href="#tile"/>
+  <g clip-path="url(#tc)">
+    <!-- downstream track crossing the trigger -->
+    <path class="dash" d="M0 -34 L0 40" stroke="#bfe0d6" stroke-width="2" fill="none" opacity="0.7"/>
+    <g class="cross"><use href="#smolt"/></g>
+  </g>
+  <line class="dash" x1="-34" y1="32" x2="34" y2="32" stroke="#e29578" stroke-width="3" stroke-linecap="round"/>
+  <!-- count badge -->
+  <g transform="translate(96,-84)" class="glow"><circle r="18" fill="#006d77"/><text x="0" y="6" text-anchor="middle" font-size="17" font-weight="800" fill="#fff">+1</text></g>
+  <!-- downstream direction -->
+  <g transform="translate(-104,-86)" stroke="#bfe0d6" stroke-width="3" fill="none" stroke-linecap="round" opacity="0.85"><path d="M0 -10 L0 12" marker-end="url(#arrow)"/></g>
+</g>
+<text class="cap" x="520" y="270" text-anchor="middle">Counted once on crossing — by direction</text>
+</svg>

--- a/assets/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/counting.svg
+++ b/assets/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/counting.svg
@@ -8,11 +8,11 @@
   <style>
     .cap   { font-size: 14px; fill: #60626a; }
     .tag   { font-size: 12px; font-weight: 700; fill: #fff; }
-    .cross { transform-box: fill-box; transform-origin: 50% 50%; animation: cross 3.2s ease-in-out infinite; }
-    .glow  { animation: glowp 3.2s ease-in-out infinite; }
+    .cross { transform-box: fill-box; transform-origin: 50% 50%; animation: cross 3.4s linear -2.2s infinite; }
+    .glow  { animation: glowp 3.4s ease-in-out -2.2s infinite; }
     .dash  { stroke-dasharray: 5 5; animation: flow 0.9s linear infinite; }
-    @keyframes cross { 0%{transform:translateY(-26px)} 55%,100%{transform:translateY(28px)} }
-    @keyframes glowp { 0%,45%{opacity:0.25} 60%,100%{opacity:1} }
+    @keyframes cross { from { transform: translateY(-118px); } to { transform: translateY(118px); } }
+    @keyframes glowp { 0%,56%{opacity:0.25} 68%,100%{opacity:1} }
     @keyframes flow { to { stroke-dashoffset: -20; } }
     @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
   </style>
@@ -57,7 +57,7 @@
   <use href="#tile"/>
   <g clip-path="url(#tc)">
     <!-- downstream track crossing the trigger -->
-    <path class="dash" d="M0 -34 L0 40" stroke="#bfe0d6" stroke-width="2" fill="none" opacity="0.7"/>
+    <path class="dash" d="M0 -40 L0 52" stroke="#bfe0d6" stroke-width="2" fill="none" opacity="0.7"/>
     <g class="cross"><use href="#smolt"/></g>
   </g>
   <line class="dash" x1="-34" y1="32" x2="34" y2="32" stroke="#e29578" stroke-width="3" stroke-linecap="round"/>

--- a/assets/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/detection.svg
+++ b/assets/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/detection.svg
@@ -1,0 +1,84 @@
+<svg viewBox="0 0 804 380" xmlns="http://www.w3.org/2000/svg" font-family="Mulish, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="sonar" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0e3a4a"/><stop offset="100%" stop-color="#176074"/></linearGradient>
+  <radialGradient id="fishglow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#ff7a45"/><stop offset="100%" stop-color="#ff7a45" stop-opacity="0"/></radialGradient>
+  <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 1 L9 5 L0 9 Z" fill="#e29578"/></marker>
+  <filter id="cardshadow" x="-20%" y="-20%" width="140%" height="150%"><feDropShadow dx="0" dy="5" stdDeviation="9" flood-color="#1c2b28" flood-opacity="0.08"/></filter>
+  <pattern id="sonar-noise" width="7" height="7" patternUnits="userSpaceOnUse"><circle cx="1.5" cy="1.5" r="0.7" fill="#bfe0d6" opacity="0.16"/><circle cx="5" cy="4.5" r="0.6" fill="#bfe0d6" opacity="0.12"/></pattern>
+  <style>
+    .title { font-family: Newsreader, Georgia, 'Times New Roman', serif; font-size: 26px; font-weight: 600; fill: #161616; }
+    .desc  { font-size: 15px; fill: #60626a; }
+    .step  { font-size: 13px; font-weight: 700; letter-spacing: 0.12em; fill: #e29578; }
+    .pill  { font-size: 11px; font-weight: 700; fill: #fff; }
+    .synapse { stroke-dasharray: 3 6; animation: flow 0.8s linear infinite; }
+    .node { animation: nodepulse 1.8s ease-in-out infinite; }
+    .n1{animation-delay:-1.5s}.n2{animation-delay:-1.1s}.n3{animation-delay:-0.7s}.n4{animation-delay:-0.3s}
+    .box { animation: boxpulse 2.2s ease-in-out infinite; } .box.b{animation-delay:-1.1s}
+    @keyframes flow { to { stroke-dashoffset: -18; } }
+    @keyframes nodepulse { 0%,100%{opacity:0.35} 50%{opacity:1} }
+    @keyframes boxpulse { 0%,100%{opacity:0.55} 50%{opacity:1} }
+    @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+  </style>
+  <g id="smolt"><ellipse cx="0" cy="0" rx="20" ry="8" fill="url(#fishglow)" opacity="0.7"/><ellipse cx="0" cy="0" rx="10" ry="3.2" fill="#ff6a3d"/><path d="M-10 0 L-16 -3.4 L-13 0 L-16 3.4 Z" fill="#ff6a3d"/></g>
+</defs>
+
+<g stroke="#e29578" stroke-width="3.5" fill="none" stroke-linecap="round">
+  <line x1="250" y1="134" x2="291" y2="134" marker-end="url(#arrow)"/>
+  <line x1="509" y1="134" x2="550" y2="134" marker-end="url(#arrow)"/>
+</g>
+
+<!-- CARD 1 — the frame -->
+<rect x="36" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(142,128)">
+  <clipPath id="c1"><rect x="-84" y="-72" width="168" height="144" rx="12"/></clipPath>
+  <rect x="-84" y="-72" width="168" height="144" rx="12" fill="url(#sonar)"/>
+  <g clip-path="url(#c1)">
+    <rect x="-84" y="-72" width="168" height="144" fill="url(#sonar-noise)"/>
+    <g stroke="#7fb6c4" stroke-width="1.4" fill="none" opacity="0.25"><path d="M-60 -40 A 75 75 0 0 1 60 -40"/><path d="M-72 20 A 95 95 0 0 1 72 20"/></g>
+    <!-- noise specks + two fish -->
+    <g fill="#9fb6bd" opacity="0.6"><circle cx="-46" cy="-30" r="2.4"/><circle cx="40" cy="-46" r="2"/><circle cx="54" cy="34" r="2.6"/><circle cx="-30" cy="48" r="2"/></g>
+    <g transform="translate(-22,-6) scale(0.9)"><use href="#smolt"/></g>
+    <g transform="translate(34,30) scale(0.78) rotate(18)"><use href="#smolt"/></g>
+  </g>
+</g>
+<text class="step" x="142" y="280" text-anchor="middle">01</text>
+<text class="title" x="142" y="312" text-anchor="middle">The frame</text>
+<text class="desc"  x="142" y="338" text-anchor="middle">Noisy sonar echoes</text>
+
+<!-- CARD 2 — the model -->
+<rect x="295" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(401,128)">
+  <rect x="-66" y="-56" width="132" height="112" rx="14" fill="#006d77"/>
+  <rect x="-66" y="-56" width="132" height="112" rx="14" fill="none" stroke="#0a7d86" stroke-width="3"/>
+  <g fill="#0a7d86"><rect x="-74" y="-30" width="8" height="6" rx="2"/><rect x="-74" y="-6" width="8" height="6" rx="2"/><rect x="-74" y="18" width="8" height="6" rx="2"/><rect x="66" y="-30" width="8" height="6" rx="2"/><rect x="66" y="-6" width="8" height="6" rx="2"/><rect x="66" y="18" width="8" height="6" rx="2"/></g>
+  <g stroke="#83c5be" stroke-width="1.4" opacity="0.6"><g class="synapse">
+    <path d="M-38 -26 L0 -34 M-38 -26 L0 -2 M-38 -26 L0 30 M-38 0 L0 -34 M-38 0 L0 -2 M-38 0 L0 30 M-38 26 L0 -34 M-38 26 L0 -2 M-38 26 L0 30 M0 -34 L40 -16 M0 -34 L40 18 M0 -2 L40 -16 M0 -2 L40 18 M0 30 L40 -16 M0 30 L40 18"/>
+  </g></g>
+  <g fill="#bfe0d6"><circle class="node n1" cx="-38" cy="-26" r="6"/><circle class="node n2" cx="-38" cy="0" r="6"/><circle class="node n3" cx="-38" cy="26" r="6"/><circle class="node n4" cx="0" cy="-34" r="6"/><circle class="node n2" cx="0" cy="-2" r="6"/><circle class="node n3" cx="0" cy="30" r="6"/><circle class="node n1" cx="40" cy="-16" r="6"/><circle class="node n4" cx="40" cy="18" r="6"/></g>
+</g>
+<text class="step" x="401" y="280" text-anchor="middle">02</text>
+<text class="title" x="401" y="312" text-anchor="middle">The model</text>
+<text class="desc"  x="401" y="338" text-anchor="middle">Trained to know a smolt</text>
+
+<!-- CARD 3 — the result -->
+<rect x="554" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(660,128)">
+  <clipPath id="c3"><rect x="-84" y="-72" width="168" height="144" rx="12"/></clipPath>
+  <rect x="-84" y="-72" width="168" height="144" rx="12" fill="url(#sonar)"/>
+  <g clip-path="url(#c3)">
+    <rect x="-84" y="-72" width="168" height="144" fill="url(#sonar-noise)"/>
+    <g stroke="#7fb6c4" stroke-width="1.4" fill="none" opacity="0.25"><path d="M-60 -40 A 75 75 0 0 1 60 -40"/><path d="M-72 20 A 95 95 0 0 1 72 20"/></g>
+    <g fill="#9fb6bd" opacity="0.5"><circle cx="-46" cy="-30" r="2.4"/><circle cx="40" cy="-46" r="2"/><circle cx="-30" cy="48" r="2"/></g>
+    <g transform="translate(-22,-6) scale(0.9)"><use href="#smolt"/></g>
+    <g transform="translate(34,30) scale(0.78) rotate(18)"><use href="#smolt"/></g>
+  </g>
+  <!-- detection boxes + score pills -->
+  <rect class="box" x="-44" y="-22" width="46" height="32" rx="3" fill="none" stroke="#3fd07a" stroke-width="3"/>
+  <g transform="translate(-21,-30)"><rect x="-28" y="-9" width="56" height="16" rx="8" fill="#1f9e5a"/><text class="pill" x="0" y="3" text-anchor="middle">smolt 0.94</text></g>
+  <rect class="box b" x="16" y="18" width="42" height="28" rx="3" fill="none" stroke="#3fd07a" stroke-width="3"/>
+  <g transform="translate(37,10)"><rect x="-28" y="-9" width="56" height="16" rx="8" fill="#1f9e5a"/><text class="pill" x="0" y="3" text-anchor="middle">smolt 0.88</text></g>
+</g>
+<text class="step" x="660" y="280" text-anchor="middle">03</text>
+<text class="title" x="660" y="312" text-anchor="middle">The result</text>
+<text class="desc"  x="660" y="338" text-anchor="middle">Each fish boxed + scored</text>
+</svg>

--- a/assets/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/pipeline.svg
+++ b/assets/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/pipeline.svg
@@ -1,0 +1,123 @@
+<svg viewBox="0 0 1062 380" xmlns="http://www.w3.org/2000/svg" font-family="Mulish, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="water" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#bfe6e4"/><stop offset="100%" stop-color="#5fb0bb"/></linearGradient>
+  <linearGradient id="sonar" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0e3a4a"/><stop offset="100%" stop-color="#176074"/></linearGradient>
+  <radialGradient id="fishglow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#ff7a45"/><stop offset="100%" stop-color="#ff7a45" stop-opacity="0"/></radialGradient>
+  <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 1 L9 5 L0 9 Z" fill="#e29578"/></marker>
+  <filter id="cardshadow" x="-20%" y="-20%" width="140%" height="150%"><feDropShadow dx="0" dy="5" stdDeviation="9" flood-color="#1c2b28" flood-opacity="0.08"/></filter>
+  <pattern id="sonar-noise" width="7" height="7" patternUnits="userSpaceOnUse"><circle cx="1.5" cy="1.5" r="0.7" fill="#bfe0d6" opacity="0.16"/><circle cx="5" cy="4.5" r="0.6" fill="#bfe0d6" opacity="0.12"/></pattern>
+  <style>
+    .title { font-family: Newsreader, Georgia, 'Times New Roman', serif; font-size: 26px; font-weight: 600; fill: #161616; }
+    .desc  { font-size: 15px; fill: #60626a; }
+    .step  { font-size: 13px; font-weight: 700; letter-spacing: 0.12em; fill: #e29578; }
+    .pill  { font-size: 12px; font-weight: 700; fill: #fff; }
+    .beam  { animation: beam 2.4s ease-in-out infinite; }
+    .swim  { transform-box: fill-box; transform-origin: 50% 50%; animation: swim 3.4s ease-in-out infinite; }
+    .box   { animation: boxpulse 2.2s ease-in-out infinite; }
+    .scan  { animation: sweep 3.2s ease-in-out infinite; }
+    .cross { transform-box: fill-box; transform-origin: 50% 50%; animation: cross 3s ease-in-out infinite; }
+    .glow  { animation: glowp 2s ease-in-out infinite; }
+    @keyframes beam { 0%,100%{opacity:0.25} 50%{opacity:0.6} }
+    @keyframes swim { 0%,100%{transform:translateX(0)} 50%{transform:translateX(5px)} }
+    @keyframes boxpulse { 0%,100%{opacity:0.6} 50%{opacity:1} }
+    @keyframes sweep { 0%{transform:translateY(0)} 50%{transform:translateY(96px)} 100%{transform:translateY(0)} }
+    @keyframes cross { 0%{transform:translateX(-22px)} 100%{transform:translateX(26px)} }
+    @keyframes glowp { 0%,100%{opacity:0.5} 50%{opacity:1} }
+    @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+  </style>
+
+  <!-- reusable smolt mark (bright sonar return, faces right) -->
+  <g id="smolt">
+    <ellipse cx="0" cy="0" rx="22" ry="9" fill="url(#fishglow)" opacity="0.7"/>
+    <ellipse cx="0" cy="0" rx="11" ry="3.4" fill="#ff6a3d"/>
+    <path d="M-11 0 L-18 -4 L-15 0 L-18 4 Z" fill="#ff6a3d"/>
+    <ellipse cx="2" cy="-0.8" rx="7" ry="1.6" fill="#ffc7a8" opacity="0.7"/>
+  </g>
+</defs>
+
+<!-- ARROWS -->
+<g stroke="#e29578" stroke-width="3.5" fill="none" stroke-linecap="round">
+  <line x1="250" y1="134" x2="291" y2="134" marker-end="url(#arrow)"/>
+  <line x1="509" y1="134" x2="550" y2="134" marker-end="url(#arrow)"/>
+  <line x1="768" y1="134" x2="809" y2="134" marker-end="url(#arrow)"/>
+</g>
+
+<!-- CARD 1 — RECORD (cx=142) -->
+<rect x="36" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(142,128)">
+  <clipPath id="c1"><rect x="-90" y="-84" width="180" height="168" rx="12"/></clipPath>
+  <g clip-path="url(#c1)">
+    <rect x="-90" y="-84" width="180" height="168" fill="url(#water)"/>
+    <!-- transducer -->
+    <g transform="translate(0,-66)"><rect x="-13" y="-8" width="26" height="16" rx="4" fill="#15463f"/><rect x="-8" y="8" width="16" height="6" rx="2" fill="#0a3f44"/></g>
+    <!-- fan beam -->
+    <path class="beam" d="M0 -52 L-58 64 L58 64 Z" fill="#e29578" opacity="0.4"/>
+    <!-- range arcs -->
+    <g stroke="#fbf6f6" stroke-width="1.5" fill="none" opacity="0.35"><path d="M-30 8 A 40 40 0 0 0 30 8"/><path d="M-46 40 A 62 62 0 0 0 46 40"/></g>
+    <!-- smolt in the beam -->
+    <g transform="translate(-6,30)"><g class="swim"><use href="#smolt"/></g></g>
+  </g>
+</g>
+<text class="step" x="142" y="280" text-anchor="middle">01</text>
+<text class="title" x="142" y="312" text-anchor="middle">Record</text>
+<text class="desc"  x="142" y="338" text-anchor="middle">ARIS sonar scans the water</text>
+
+<!-- CARD 2 — DETECT (cx=401) -->
+<rect x="295" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(401,128)">
+  <clipPath id="c2"><rect x="-84" y="-72" width="168" height="144" rx="12"/></clipPath>
+  <rect x="-84" y="-72" width="168" height="144" rx="12" fill="url(#sonar)"/>
+  <g clip-path="url(#c2)">
+    <rect x="-84" y="-72" width="168" height="144" fill="url(#sonar-noise)"/>
+    <g stroke="#7fb6c4" stroke-width="1.4" fill="none" opacity="0.3"><path d="M-60 -40 A 75 75 0 0 1 60 -40"/><path d="M-72 0 A 95 95 0 0 1 72 0"/><path d="M-78 40 A 110 110 0 0 1 78 40"/></g>
+    <g transform="translate(-4,4)"><g class="swim"><use href="#smolt"/></g></g>
+    <rect class="scan" x="-84" y="-72" width="168" height="3" fill="#e29578" opacity="0.55"/>
+  </g>
+  <rect class="box" x="-30" y="-12" width="56" height="30" rx="3" fill="none" stroke="#e8232a" stroke-width="3"/>
+  <g transform="translate(50,-58)"><rect x="-16" y="-13" width="32" height="26" rx="6" fill="#006d77"/><circle cx="-6" cy="-3" r="2.6" fill="#bfe0d6"/><circle cx="6" cy="-3" r="2.6" fill="#bfe0d6"/><circle cx="0" cy="7" r="2.6" fill="#bfe0d6"/><path d="M-6 -3 L0 7 L6 -3" stroke="#83c5be" stroke-width="1.8" fill="none"/></g>
+</g>
+<text class="step" x="401" y="280" text-anchor="middle">02</text>
+<text class="title" x="401" y="312" text-anchor="middle">Detect</text>
+<text class="desc"  x="401" y="338" text-anchor="middle">AI finds each smolt</text>
+
+<!-- CARD 3 — MEASURE (cx=660) -->
+<rect x="554" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(660,128)">
+  <clipPath id="c3"><rect x="-84" y="-72" width="168" height="144" rx="12"/></clipPath>
+  <rect x="-84" y="-72" width="168" height="144" rx="12" fill="url(#sonar)"/>
+  <g clip-path="url(#c3)">
+    <rect x="-84" y="-72" width="168" height="144" fill="url(#sonar-noise)"/>
+    <g transform="translate(-2,8)"><use href="#smolt"/></g>
+  </g>
+  <!-- length caliper over the fish -->
+  <g stroke="#bfe0d6" stroke-width="2" stroke-linecap="round">
+    <path d="M-26 -16 L-26 -28 M26 -16 L26 -28"/>
+    <path d="M-26 -22 L26 -22" marker-start="url(#arrow)" marker-end="url(#arrow)"/>
+  </g>
+  <g transform="translate(0,-44)"><rect x="-30" y="-12" width="60" height="22" rx="11" fill="#006d77"/><text class="pill" x="0" y="4" text-anchor="middle">12.4 cm</text></g>
+</g>
+<text class="step" x="660" y="280" text-anchor="middle">03</text>
+<text class="title" x="660" y="312" text-anchor="middle">Measure</text>
+<text class="desc"  x="660" y="338" text-anchor="middle">Estimates its length</text>
+
+<!-- CARD 4 — COUNT (cx=919) -->
+<rect x="813" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(919,128)">
+  <clipPath id="c4"><rect x="-84" y="-72" width="168" height="144" rx="12"/></clipPath>
+  <rect x="-84" y="-72" width="168" height="144" rx="12" fill="url(#sonar)"/>
+  <g clip-path="url(#c4)">
+    <rect x="-84" y="-72" width="168" height="144" fill="url(#sonar-noise)"/>
+    <!-- trigger line -->
+    <path d="M6 -64 L6 64" stroke="#e29578" stroke-width="3" stroke-dasharray="6 6"/>
+    <!-- smolt crossing downstream -->
+    <g transform="translate(0,4)"><g class="cross"><use href="#smolt"/></g></g>
+    <!-- downstream direction arrow -->
+    <g stroke="#bfe0d6" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.8"><path d="M-40 -46 L-14 -46" marker-end="url(#arrow)"/></g>
+  </g>
+  <!-- count badge -->
+  <g transform="translate(48,-50)" class="glow"><circle r="17" fill="#006d77"/><text x="0" y="6" text-anchor="middle" font-size="17" font-weight="800" fill="#fff">+1</text></g>
+</g>
+<text class="step" x="919" y="280" text-anchor="middle">04</text>
+<text class="title" x="919" y="312" text-anchor="middle">Count</text>
+<text class="desc"  x="919" y="338" text-anchor="middle">Tallies it crossing the line</text>
+</svg>

--- a/assets/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/preprocess.svg
+++ b/assets/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/preprocess.svg
@@ -1,0 +1,64 @@
+<svg viewBox="0 0 900 300" xmlns="http://www.w3.org/2000/svg" font-family="Mulish, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="raw" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#3a4145"/><stop offset="100%" stop-color="#20262a"/></linearGradient>
+  <linearGradient id="blue" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1f4aa6"/><stop offset="100%" stop-color="#0c1f4d"/></linearGradient>
+  <radialGradient id="redglow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#ff4530"/><stop offset="100%" stop-color="#ff4530" stop-opacity="0"/></radialGradient>
+  <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 1 L9 5 L0 9 Z" fill="#e29578"/></marker>
+  <filter id="cardshadow" x="-25%" y="-15%" width="150%" height="130%"><feDropShadow dx="0" dy="5" stdDeviation="9" flood-color="#1c2b28" flood-opacity="0.1"/></filter>
+  <pattern id="grit" width="6" height="6" patternUnits="userSpaceOnUse"><circle cx="1.4" cy="1.4" r="0.9" fill="#cfd4d6" opacity="0.22"/><circle cx="4.2" cy="3.8" r="0.7" fill="#cfd4d6" opacity="0.16"/><circle cx="2.6" cy="5" r="0.6" fill="#cfd4d6" opacity="0.12"/></pattern>
+  <pattern id="bnoise" width="7" height="7" patternUnits="userSpaceOnUse"><circle cx="1.5" cy="1.5" r="0.7" fill="#9fc4ff" opacity="0.18"/><circle cx="5" cy="4.5" r="0.6" fill="#9fc4ff" opacity="0.12"/></pattern>
+  <style>
+    .cap { font-size: 14px; fill: #60626a; }
+    .lab { font-size: 12.5px; fill: #2a2f33; }
+    .num { font-size: 13px; font-weight: 800; fill: #fff; }
+    .glow { animation: g 2.6s ease-in-out infinite; }
+    @keyframes g { 0%,100%{opacity:0.55} 50%{opacity:1} }
+    @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+  </style>
+  <!-- ARIS fan: apex at the bottom (transducer), opening upward to the far range -->
+  <path id="fan" d="M0 96 L-58 -80 Q0 -96 58 -80 Z"/>
+</defs>
+
+<!-- LEFT — raw fan -->
+<g transform="translate(108,128)">
+  <use href="#fan" fill="url(#raw)" filter="url(#cardshadow)"/>
+  <clipPath id="cl"><use href="#fan"/></clipPath>
+  <g clip-path="url(#cl)">
+    <use href="#fan" fill="url(#grit)"/>
+    <g stroke="#8b9298" stroke-width="1.2" fill="none" opacity="0.25"><path d="M-46 -52 Q0 -64 46 -52"/><path d="M-30 0 Q0 -10 30 0"/></g>
+    <!-- fish, lost in the clutter -->
+    <ellipse cx="6" cy="34" rx="13" ry="4" fill="#9aa1a5" opacity="0.5"/>
+  </g>
+</g>
+<text class="cap" x="108" y="262" text-anchor="middle">Raw ARIS frame</text>
+
+<line x1="178" y1="124" x2="212" y2="124" stroke="#e29578" stroke-width="3.5" fill="none" stroke-linecap="round" marker-end="url(#arrow)"/>
+
+<!-- MIDDLE — the five preprocessing steps -->
+<line x1="248" y1="48" x2="248" y2="208" stroke="#e29578" stroke-width="2" opacity="0.35"/>
+<g>
+  <g transform="translate(248,52)"><circle r="13" fill="#e29578"/><text class="num" x="0" y="4" text-anchor="middle">1</text><text class="lab" x="24" y="5">Convert <tspan font-family="monospace" font-size="11.5">.aris → .mp4</tspan></text></g>
+  <g transform="translate(248,91)"><circle r="13" fill="#e29578"/><text class="num" x="0" y="4" text-anchor="middle">2</text><text class="lab" x="24" y="5">Stabilize the frames</text></g>
+  <g transform="translate(248,130)"><circle r="13" fill="#e29578"/><text class="num" x="0" y="4" text-anchor="middle">3</text><text class="lab" x="24" y="5">Reduce the noise</text></g>
+  <g transform="translate(248,169)"><circle r="13" fill="#e29578"/><text class="num" x="0" y="4" text-anchor="middle">4</text><text class="lab" x="24" y="5">Encode in colour <tspan fill="#d23b2c" font-weight="700">(fish → red)</tspan></text></g>
+  <g transform="translate(248,208)"><circle r="13" fill="#e29578"/><text class="num" x="0" y="4" text-anchor="middle">5</text><text class="lab" x="24" y="5">Chunk into segments</text></g>
+</g>
+
+<line x1="690" y1="124" x2="724" y2="124" stroke="#e29578" stroke-width="3.5" fill="none" stroke-linecap="round" marker-end="url(#arrow)"/>
+
+<!-- RIGHT — enhanced fan (blue background, fish in red) -->
+<g transform="translate(792,128)">
+  <use href="#fan" fill="url(#blue)" filter="url(#cardshadow)"/>
+  <clipPath id="cr"><use href="#fan"/></clipPath>
+  <g clip-path="url(#cr)">
+    <use href="#fan" fill="url(#bnoise)"/>
+    <g stroke="#9fc4ff" stroke-width="1.2" fill="none" opacity="0.22"><path d="M-46 -52 Q0 -64 46 -52"/><path d="M-30 0 Q0 -10 30 0"/></g>
+    <!-- fish, bright red and unmistakable -->
+    <ellipse class="glow" cx="6" cy="34" rx="26" ry="11" fill="url(#redglow)"/>
+    <ellipse cx="6" cy="34" rx="13" ry="4.2" fill="#ff4530"/>
+    <path d="M-7 34 L-15 30 L-11 34 L-15 38 Z" fill="#ff4530"/>
+    <ellipse cx="-22" cy="-14" rx="7" ry="3" fill="#ff5a3c" opacity="0.7"/>
+  </g>
+</g>
+<text class="cap" x="792" y="262" text-anchor="middle">Enhanced frame</text>
+</svg>

--- a/assets/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/size.svg
+++ b/assets/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/size.svg
@@ -1,0 +1,77 @@
+<svg viewBox="0 0 760 320" xmlns="http://www.w3.org/2000/svg" font-family="Mulish, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="sonar" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0e3a4a"/><stop offset="100%" stop-color="#176074"/></linearGradient>
+  <radialGradient id="fishglow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#ff7a45"/><stop offset="100%" stop-color="#ff7a45" stop-opacity="0"/></radialGradient>
+  <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 1 L9 5 L0 9 Z" fill="#e29578"/></marker>
+  <marker id="tick" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto"><path d="M5 1 L5 9" stroke="#bfe0d6" stroke-width="2"/></marker>
+  <filter id="cardshadow" x="-20%" y="-20%" width="140%" height="150%"><feDropShadow dx="0" dy="5" stdDeviation="9" flood-color="#1c2b28" flood-opacity="0.08"/></filter>
+  <pattern id="sonar-noise" width="7" height="7" patternUnits="userSpaceOnUse"><circle cx="1.5" cy="1.5" r="0.7" fill="#bfe0d6" opacity="0.16"/><circle cx="5" cy="4.5" r="0.6" fill="#bfe0d6" opacity="0.12"/></pattern>
+  <style>
+    .cap  { font-size: 14px; fill: #60626a; }
+    .tag  { font-size: 12px; font-weight: 700; fill: #fff; }
+    .lab  { font-size: 11px; font-weight: 700; fill: #cfe9e0; letter-spacing: 0.04em; }
+    .glow { animation: glowp 2.6s ease-in-out infinite; }
+    .xo   { animation: xo 2.6s ease-in-out infinite; }
+    @keyframes glowp { 0%,100%{opacity:0.55} 50%{opacity:1} }
+    @keyframes xo { 0%,100%{opacity:0.5} 50%{opacity:1} }
+    @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+  </style>
+  <g id="smolt">
+    <ellipse cx="0" cy="0" rx="22" ry="9" fill="url(#fishglow)" opacity="0.7"/>
+    <ellipse cx="0" cy="0" rx="11" ry="3.4" fill="#ff6a3d"/>
+    <path d="M-11 0 L-18 -4 L-15 0 L-18 4 Z" fill="#ff6a3d"/>
+  </g>
+  <g id="stile">
+    <rect x="-140" y="-110" width="280" height="220" rx="14" fill="url(#sonar)"/>
+    <clipPath id="stc"><rect x="-140" y="-110" width="280" height="220" rx="14"/></clipPath>
+    <g clip-path="url(#stc)">
+      <rect x="-140" y="-110" width="280" height="220" fill="url(#sonar-noise)"/>
+      <g stroke="#7fb6c4" stroke-width="1.4" fill="none" opacity="0.22"><path d="M-95 -70 A 118 118 0 0 1 95 -70"/><path d="M-110 -10 A 150 150 0 0 1 110 -10"/></g>
+    </g>
+  </g>
+</defs>
+
+<!-- PANEL 1 — measured every frame -->
+<rect x="20" y="20" width="280" height="220" rx="14" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(160,130)">
+  <use href="#stile"/>
+  <!-- frames badge -->
+  <g transform="translate(86,-86)"><rect x="-30" y="-12" width="60" height="24" rx="6" fill="#006d77"/><rect x="-24" y="-6" width="9" height="9" rx="1.5" fill="#bfe0d6"/><rect x="-21" y="-9" width="9" height="9" rx="1.5" fill="#83c5be"/><text class="tag" x="6" y="4" text-anchor="middle">× N</text></g>
+  <!-- smolt + caliper -->
+  <g transform="translate(0,16)"><use href="#smolt"/></g>
+  <g stroke="#bfe0d6" stroke-width="2" stroke-linecap="round">
+    <path d="M-26 -2 L-26 -16 M26 -2 L26 -16"/>
+    <path d="M-26 -10 L26 -10" marker-start="url(#arrow)" marker-end="url(#arrow)"/>
+  </g>
+  <g transform="translate(0,-40)"><rect x="-30" y="-12" width="60" height="22" rx="11" fill="#0a7d86"/><text class="tag" x="0" y="4" text-anchor="middle">≈ 60 px</text></g>
+</g>
+<text class="cap" x="160" y="270" text-anchor="middle">A length read from every frame</text>
+
+<!-- arrow -->
+<line x1="318" y1="130" x2="362" y2="130" stroke="#e29578" stroke-width="3.5" fill="none" stroke-linecap="round" marker-end="url(#arrow)"/>
+
+<!-- PANEL 2 — filter outliers, take the median -->
+<rect x="380" y="20" width="280" height="220" rx="14" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(520,130)">
+  <use href="#stile"/>
+  <g clip-path="url(#stc)">
+    <!-- axis -->
+    <line x1="-104" y1="34" x2="104" y2="34" stroke="#7fb6c4" stroke-width="1.5" opacity="0.5"/>
+    <!-- IQR band around the kept cluster -->
+    <rect x="-30" y="22" width="66" height="24" rx="12" fill="#83c5be" opacity="0.2"/>
+    <!-- kept measurements -->
+    <g fill="#bfe0d6"><circle cx="-20" cy="34" r="4.5"/><circle cx="-7" cy="34" r="4.5"/><circle cx="3" cy="34" r="4.5"/><circle cx="14" cy="34" r="4.5"/><circle cx="26" cy="34" r="4.5"/></g>
+    <!-- median tick -->
+    <line x1="3" y1="18" x2="3" y2="50" stroke="#e29578" stroke-width="3" stroke-linecap="round"/>
+    <text class="lab" x="3" y="64" text-anchor="middle">median</text>
+    <!-- outliers, dropped -->
+    <g class="xo">
+      <circle cx="-92" cy="34" r="4.5" fill="#e8232a"/><path d="M-97 29 L-87 39 M-97 39 L-87 29" stroke="#fff" stroke-width="1.8"/>
+      <circle cx="86" cy="34" r="4.5" fill="#e8232a"/><path d="M81 29 L91 39 M81 39 L91 29" stroke="#fff" stroke-width="1.8"/>
+    </g>
+  </g>
+  <!-- result pill (px -> cm) -->
+  <g transform="translate(3,-46)" class="glow"><rect x="-44" y="-15" width="88" height="30" rx="15" fill="#006d77"/><path d="M0 15 L-7 23 L7 23 Z" fill="#006d77"/><text class="tag" x="0" y="4" text-anchor="middle" font-size="14">12.4 cm</text></g>
+</g>
+<text class="cap" x="520" y="270" text-anchor="middle">Outliers dropped, median taken — in cm</text>
+</svg>

--- a/assets/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/tracking.svg
+++ b/assets/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/tracking.svg
@@ -1,0 +1,48 @@
+<svg viewBox="0 0 820 320" xmlns="http://www.w3.org/2000/svg" font-family="Mulish, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="sonar" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0e3a4a"/><stop offset="100%" stop-color="#176074"/></linearGradient>
+  <radialGradient id="fishglow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#ff7a45"/><stop offset="100%" stop-color="#ff7a45" stop-opacity="0"/></radialGradient>
+  <filter id="cardshadow" x="-20%" y="-20%" width="140%" height="150%"><feDropShadow dx="0" dy="5" stdDeviation="9" flood-color="#1c2b28" flood-opacity="0.08"/></filter>
+  <pattern id="sonar-noise" width="7" height="7" patternUnits="userSpaceOnUse"><circle cx="1.5" cy="1.5" r="0.7" fill="#bfe0d6" opacity="0.14"/><circle cx="5" cy="4.5" r="0.6" fill="#bfe0d6" opacity="0.1"/></pattern>
+  <style>
+    .cap  { font-size: 14px; fill: #60626a; }
+    .id   { font-size: 12px; font-weight: 800; fill: #fff; }
+    .note { font-size: 12px; font-weight: 700; fill: #cfe9e0; letter-spacing: 0.03em; }
+    .trk  { stroke-dasharray: 4 6; animation: flow 0.9s linear infinite; }
+    .ring { transform-box: fill-box; transform-origin: 50% 50%; animation: ring 2.6s ease-out infinite; }
+    @keyframes flow { to { stroke-dashoffset: -20; } }
+    @keyframes ring { 0%{opacity:0.8; transform:scale(0.6)} 70%{opacity:0} 100%{opacity:0} }
+    @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+  </style>
+  <g id="smolt"><ellipse cx="0" cy="0" rx="20" ry="8" fill="url(#fishglow)" opacity="0.7"/><ellipse cx="0" cy="0" rx="10" ry="3.2" fill="#ff6a3d"/><path d="M-10 0 L-16 -3.4 L-13 0 L-16 3.4 Z" fill="#ff6a3d"/></g>
+</defs>
+
+<rect x="30" y="24" width="760" height="216" rx="16" fill="url(#sonar)" filter="url(#cardshadow)"/>
+<clipPath id="cl"><rect x="30" y="24" width="760" height="216" rx="16"/></clipPath>
+<g clip-path="url(#cl)">
+  <rect x="30" y="24" width="760" height="216" fill="url(#sonar-noise)"/>
+  <g transform="translate(410,132)">
+    <!-- two tracks, crossing -->
+    <polyline class="trk" points="-300,-52 40,22 270,64" fill="none" stroke="#83c5be" stroke-width="2.5" opacity="0.7"/>
+    <polyline class="trk" points="-300,64 40,-22 270,-52" fill="none" stroke="#e29578" stroke-width="2.5" opacity="0.7"/>
+
+    <!-- crossing marker -->
+    <circle class="ring" cx="-18" cy="6" r="26" fill="none" stroke="#bfe0d6" stroke-width="2"/>
+
+    <!-- fish #7 (teal track): ghost -> solid, left to right -->
+    <g transform="translate(-300,-52) scale(0.8)" opacity="0.32"><use href="#smolt"/></g>
+    <g transform="translate(40,22) scale(0.9)" opacity="0.6"><use href="#smolt"/></g>
+    <g transform="translate(270,64)"><use href="#smolt"/></g>
+    <g transform="translate(270,40)"><rect x="-16" y="-11" width="32" height="20" rx="6" fill="#0a7d86"/><text class="id" x="0" y="4" text-anchor="middle">#7</text></g>
+
+    <!-- fish #8 (coral track) -->
+    <g transform="translate(-300,64) scale(0.8)" opacity="0.32"><use href="#smolt"/></g>
+    <g transform="translate(40,-22) scale(0.9)" opacity="0.6"><use href="#smolt"/></g>
+    <g transform="translate(270,-52)"><use href="#smolt"/></g>
+    <g transform="translate(270,-76)"><rect x="-16" y="-11" width="32" height="20" rx="6" fill="#0a7d86"/><text class="id" x="0" y="4" text-anchor="middle">#8</text></g>
+
+    <text class="note" x="-18" y="-30" text-anchor="middle">paths cross — IDs kept</text>
+  </g>
+</g>
+<text class="cap" x="410" y="270" text-anchor="middle">Detections are linked frame to frame into one track per fish — so each smolt is counted once</text>
+</svg>

--- a/content/projects/monitoring_smolt_salmon_migration_with_sonar.md
+++ b/content/projects/monitoring_smolt_salmon_migration_with_sonar.md
@@ -134,12 +134,19 @@ Large sonar files are split into smaller chunks so the downstream detection and 
 
 ## Detection and Tracking
 
-We fine-tuned a pretrained [YOLOv11](https://github.com/ultralytics/ultralytics) model to spot smolt in the preprocessed frames. YOLO ("You Only Look Once") is a family of real-time detectors prized for balancing speed and accuracy — essential when a single session runs to thousands of frames. For each frame it returns a box around every smolt it finds, with a confidence score.
+### Finding each fish
 
-![YOLO tasks](/images/projects/monitoring_smolt_salmon_migration_with_sonar/yolo_tasks.png)
-*Overview of YOLO tasks — detection, segmentation, classification, pose estimation, and oriented bounding boxes (courtesy of [Ultralytics](https://github.com/ultralytics/ultralytics)).*
+First the system has to *find* the fish. We trained a **detector** — a model shown thousands of example frames until it learned what a smolt looks like in sonar. Shown a new frame, it draws a box around every fish it spots and gives each one a confidence score, while leaving the static background and noise alone. (Under the hood it's a fine-tuned [YOLOv11](https://github.com/ultralytics/ultralytics) model, a fast, widely-used object detector.)
 
-Spotting a fish in one frame isn't enough — we need to follow it across many. [BoTSort](https://github.com/NirAharon/BoT-SORT) links detections into continuous tracks, combining motion prediction, visual appearance, and camera-motion compensation. Unlike simpler trackers such as SORT that only compare box overlap, it keeps hold of a fish when paths cross or it briefly vanishes behind noise — so each smolt is counted exactly once as it passes the sonar.
+![How the detector works — it reads a sonar frame and boxes each smolt with a confidence score](/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/detection.svg)
+*The detector reads a noisy sonar frame and returns a box — and a confidence score — around each smolt, ignoring the background clutter.*
+
+### Following each fish
+
+Finding a fish in a single frame isn't enough: the same smolt shows up in dozens of frames as it swims past, and we must count it only **once**. So the system *follows* each fish from frame to frame, linking its boxes into a single path — and holding on to it even when two fish cross or one briefly slips behind the noise. Every smolt becomes exactly one track, and one count. (This uses [BoTSort](https://github.com/NirAharon/BoT-SORT), which combines each fish's motion and appearance to keep it on the right track.)
+
+![How tracking works — detections are linked across frames into one path per fish, keeping their IDs when paths cross](/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/tracking.svg)
+*Each fish's detections are linked across frames into a single track, so it keeps its identity — and is counted once — even when paths cross.*
 
 <p><iframe src="https://www.youtube.com/embed/UY08mjPBHbc" loading="lazy" frameborder="0" allowfullscreen></iframe></p>
 <p class="media-caption">Automated smolt detection and tracking in action on preprocessed ARIS sonar footage.</p>

--- a/content/projects/monitoring_smolt_salmon_migration_with_sonar.md
+++ b/content/projects/monitoring_smolt_salmon_migration_with_sonar.md
@@ -36,7 +36,7 @@ pinned: true
 image: /images/projects/monitoring_smolt_salmon_migration_with_sonar/cover.png
 ---
 
-Monitoring smolt — juvenile salmon migrating downstream toward the ocean — is essential for understanding salmon population health and evaluating the impact of hydroelectric infrastructure on fish survival. In partnership with [BC Hydro](https://www.bchydro.com/) and [Lumax AI](https://lumax.ai/), we are developing an automated system to detect, track, and count smolt from ARIS sonar imagery collected at Cho':lhsh?ta Lake (Jansen Lake), British Columbia.
+Each spring, young salmon called **smolt** leave the rivers where they hatched and ride the current down to the sea — running a gauntlet of predators, dams and turbines along the way. How many survive that journey is one of the clearest measures of a salmon population's health. Together with [BC Hydro](https://www.bchydro.com/) and [Lumax AI](https://lumax.ai/), we're building a system that detects, tracks and counts smolt automatically from **ARIS sonar** footage recorded at Cho':lhsh?ta Lake (Jansen Lake), British Columbia.
 
 {{< image_carousel id="smolt-monitoring-intro" items="2" >}}
   {{< carousel_image src="/images/projects/monitoring_smolt_salmon_migration_with_sonar/map_overview.png" alt="Jansen Lake Map" caption="Jansen Lake, British Columbia, located on Vancouver Island" >}}
@@ -52,14 +52,14 @@ From a raw sonar recording to a verified count, the system runs four automated s
 
 ### What are smolt?
 
-Smolt are juvenile salmonids (8–14 cm) undergoing smoltification — the physiological transformation that prepares them for the transition from freshwater to saltwater. During this critical life stage, they migrate downstream through rivers and past infrastructure on their way to the ocean.
+Smolt are juvenile salmon (8–14 cm) going through **smoltification** — the bodily changes that turn a freshwater fish into one ready for the sea. It's the stage when they leave the river behind, slipping downstream past whatever infrastructure stands between them and the ocean.
 
 ![Salmon lifecycle](/images/projects/monitoring_smolt_salmon_migration_with_sonar/lifecycle_salmon.png)
 *Salmon lifecycle — courtesy of the [Pacific Salmon Foundation](https://psf.ca/learn/species-lifecycle/)*
 
 ### Why the smolt stage is critical
 
-The downstream migration is one of the most dangerous periods in a salmon's life. Smolt must navigate past dams, turbines, and other infrastructure that can cause direct mortality or disorientation. They swim close to the water surface where they are vulnerable to predators, and they often travel in dense groups over short time windows. Climate change is adding further pressure through altered river flows and rising water temperatures, compressing migration windows and increasing stress on already vulnerable juveniles.
+The trip downstream is one of the most dangerous stretches of a salmon's life. Smolt have to slip past dams and turbines that can kill or disorient them, they swim near the surface where predators wait, and they move in dense pulses packed into a few short windows. Climate change tightens the squeeze further — altering river flows and warming the water, which compresses those windows and piles stress onto already-vulnerable juveniles.
 
 ### Why accurate counting matters
 
@@ -69,11 +69,11 @@ Reliable smolt counts are fundamental for salmon conservation — tap each to le
 
 ### The challenge of current methods
 
-Traditional smolt counting relies on manual review of sonar footage, which is time-consuming and error-prone. Analysts must watch hours of recordings by hand, identifying and counting individual fish in noisy acoustic images. Dense migration events — where thousands of smolt pass in a short period — make manual review particularly impractical. The sheer volume of data generated during peak migration windows means that manual methods simply cannot scale to provide the continuous, reliable counts that conservation demands.
+Today, counting mostly means a person watching hours of footage and tallying fish by hand in grainy, noisy acoustic images. During a peak run, thousands of smolt can pass in a short burst — far more than anyone can keep up with frame by frame. The approach is slow, easy to get wrong, and impossible to scale to the continuous, reliable counts conservation actually needs.
 
 ## What is ARIS Sonar?
 
-ARIS sonar creates acoustic images using sound reflections, enabling fish detection in conditions where optical cameras fail: turbid water, zero visibility, and nighttime. It produces high-resolution, video-like acoustic image sequences that are well suited for detecting and counting small fish like smolt.
+ARIS sonar "sees" with sound instead of light, building video-like images from the echoes that bounce back off objects in the water. That lets it pick out fish where an ordinary camera is blind — in murky water, total darkness, at night — and its resolution is fine enough to catch something as small as a smolt.
 
 ![Sonar Aris Frame](/images/projects/monitoring_smolt_salmon_migration_with_sonar/sonar_aris_frame.png)
 *Example ARIS sonar frame — acoustic image showing fish targets in the sonar beam.*
@@ -82,31 +82,50 @@ ARIS sonar creates acoustic images using sound reflections, enabling fish detect
 
 ### Project scope
 
-The overarching goal of this project is to assess the feasibility of automated smolt enumeration from ARIS sonar data. We do this by reviewing existing methods, selecting the most promising candidates, and developing an end-to-end analysis pipeline combining deep learning-based object detection with tracking algorithms.
+The goal is to find out whether smolt can be counted automatically from ARIS sonar — and to build the pipeline that does it. We surveyed the existing methods, picked the most promising, and assembled an end-to-end workflow that pairs deep-learning object detection with tracking.
 
 ### Sonar analysis challenges
 
-Hydroacoustic imaging is a widely used and effective method to enumerate fish in waterways, but the analysis of large amounts of data is time-consuming and requires trained personnel. Methods to facilitate the analysis of sonar data are much needed but challenging to develop, especially due to background noise and variation in the intensity and type of the return signal of fish. Significant progress has been made in background subtraction and object detection in software such as [Echoview](https://echoview.com/) and [ArisFish](https://arisfish.software.informer.com/), but reliable algorithms to detect, track, and enumerate fish in an automated workflow remain elusive.
+Acoustic imaging is a proven way to count fish, but turning the footage into numbers is hard work: the signal is noisy, and a fish's echo varies in both strength and shape. Tools like [Echoview](https://echoview.com/) and [ArisFish](https://arisfish.software.informer.com/) have pushed background subtraction and detection forward, yet a fully automated detect-track-count workflow has stayed out of reach. Recent progress in deep neural networks is finally changing that.
 
-Over the last years, the fast development of Artificial Intelligence (AI), in particular Deep Neural Networks, has led to rapid progress in image analysis, including automated detection and tracking of fish in sonar imagery. Smolt present unique challenges compared to adult salmon: their small size (8–14 cm) makes them harder to detect and separate from noise, they swim close to the noisy water surface, and they can migrate in dense groups over short time periods.
+Smolt make it harder still. Next to adult salmon they're tiny (8–14 cm) and easily lost in noise, they hug the cluttered water surface, and they arrive in dense groups over short windows — exactly the conditions that trip up older methods.
 
 ### Key technical achievements
 
-Some key technical achievements of this project include:
-- Automated conversion and preprocessing of proprietary .aris format with motion-enhanced noise reduction
-- Detection and tracking of individual smolt using deep learning
-- Length estimation of the detected smolt
-- Directional counting of smolt migrating past a virtual trigger segment
+The pipeline now does four things end to end:
+
+<div class="services__list">
+  <div class="services__item">
+    <span class="services__number" aria-hidden="true">01</span>
+    <h4 class="services__item-title">Convert &amp; clean</h4>
+    <p class="services__item-description">Convert the proprietary <code>.aris</code> format and clean it up, with motion-aware noise reduction.</p>
+  </div>
+  <div class="services__item">
+    <span class="services__number" aria-hidden="true">02</span>
+    <h4 class="services__item-title">Detect &amp; track</h4>
+    <p class="services__item-description">Detect and follow each individual smolt across frames with deep learning.</p>
+  </div>
+  <div class="services__item">
+    <span class="services__number" aria-hidden="true">03</span>
+    <h4 class="services__item-title">Estimate length</h4>
+    <p class="services__item-description">Estimate every tracked fish's body length and convert it to real-world centimetres.</p>
+  </div>
+  <div class="services__item">
+    <span class="services__number" aria-hidden="true">04</span>
+    <h4 class="services__item-title">Count by direction</h4>
+    <p class="services__item-description">Count smolt as they cross a virtual line, recording each fish's direction of travel.</p>
+  </div>
+</div>
 
 ### Study site
 
-The [Alouette River](https://en.wikipedia.org/wiki/Alouette_River) is the target site for deployment of sonar smolt enumeration. For the first year we used smolt data from the outflow of Jansen Lake, as data collection at the Alouette River was not possible in 2025.
+The [Alouette River](https://en.wikipedia.org/wiki/Alouette_River) is the eventual deployment site. Because data collection there wasn't possible in 2025, this first year drew on smolt data from the outflow of Jansen Lake.
 
 ## Preprocessing
 
-Raw ARIS sonar files go through a five-step preprocessing pipeline before analysis: file conversion from the proprietary `.aris` format to `.mp4`, frame stabilization, noise reduction, colour channel adjustment, and chunking into manageable segments. Together these steps transform noisy acoustic recordings into clean, analysis-ready video.
+Before any analysis, each raw `.aris` file runs through five preprocessing steps — converting the proprietary format to `.mp4`, stabilizing the frames, reducing noise, adjusting the colour channels, and chunking the result into manageable segments. Together they turn noisy recordings into clean, analysis-ready video.
 
-The preprocessed output is visualized as an RGB image where each colour channel encodes a different layer of information. The blue background represents the original raw sonar input, while fish appear as bright red regions that stand out clearly against it, making them easy to distinguish from the static sonar information.
+The output is encoded as an RGB image, with each channel carrying a different layer: the raw sonar sits in the blue background, while moving fish light up in bright red — easy for both a person and the model to pick out from the static clutter.
 
 ![Preprocessing before and after](/images/projects/monitoring_smolt_salmon_migration_with_sonar/preprocess.png)
 *Before and after preprocessing — the RGB encoding makes fish (red) clearly distinguishable from the static sonar information (blue).*
@@ -115,47 +134,47 @@ Large sonar files are split into smaller chunks so the downstream detection and 
 
 ## Detection and Tracking
 
-We fine-tuned a pretrained [YOLOv11](https://github.com/ultralytics/ultralytics) model for smolt detection in preprocessed sonar frames. YOLO (You Only Look Once) is a family of real-time object detection models known for their excellent balance of speed and accuracy — critical when processing thousands of sonar frames per recording session. The model learns to locate smolt in each frame and output bounding boxes with confidence scores.
+We fine-tuned a pretrained [YOLOv11](https://github.com/ultralytics/ultralytics) model to spot smolt in the preprocessed frames. YOLO ("You Only Look Once") is a family of real-time detectors prized for balancing speed and accuracy — essential when a single session runs to thousands of frames. For each frame it returns a box around every smolt it finds, with a confidence score.
 
 ![YOLO tasks](/images/projects/monitoring_smolt_salmon_migration_with_sonar/yolo_tasks.png)
 *Overview of YOLO tasks — detection, segmentation, classification, pose estimation, and oriented bounding boxes (courtesy of [Ultralytics](https://github.com/ultralytics/ultralytics)).*
 
-To follow individual smolt across consecutive frames we use [BoTSort](https://github.com/NirAharon/BoT-SORT) (Robust Associations Multi-Pedestrian Tracking). Unlike simpler tracking approaches such as SORT that rely solely on bounding-box overlap, BoTSort combines motion prediction with visual appearance features and camera-motion compensation. This makes it far more robust when fish cross paths or temporarily disappear behind noise, providing continuous trajectories that allow us to count each smolt exactly once as it migrates past the sonar.
+Spotting a fish in one frame isn't enough — we need to follow it across many. [BoTSort](https://github.com/NirAharon/BoT-SORT) links detections into continuous tracks, combining motion prediction, visual appearance, and camera-motion compensation. Unlike simpler trackers such as SORT that only compare box overlap, it keeps hold of a fish when paths cross or it briefly vanishes behind noise — so each smolt is counted exactly once as it passes the sonar.
 
 <p><iframe src="https://www.youtube.com/embed/UY08mjPBHbc" loading="lazy" frameborder="0" allowfullscreen></iframe></p>
 <p class="media-caption">Automated smolt detection and tracking in action on preprocessed ARIS sonar footage.</p>
 
 ## Size Estimation
 
-Estimating the length of each detected smolt is an important step in the pipeline because fish length is one of the key characteristics used to distinguish species and life stages. Our approach uses the dimensions of the bounding boxes drawn around each detection to estimate fish length.
+Length is one of the most telling things you can know about a fish — it helps separate species and life stages — so the pipeline estimates it for every smolt it tracks, working from the size of the detection boxes.
 
-For each detection the algorithm determines whether the fish is swimming roughly horizontally or vertically and selects the bounding-box dimension that best represents its body length. Because individual detections can vary, the system collects multiple measurements across a fish's tracked trajectory and filters out extreme values as outliers, keeping the estimates reliable. Each final length estimate is assigned a confidence rating based on how many consistent measurements were available — more observations mean higher confidence.
+For each detection the system reads whether the fish is swimming roughly horizontally or vertically and picks the box dimension that best matches its body. Single detections are noisy, so it gathers measurements across the whole track, discards the outliers, and combines the rest — trusting the estimate more the more consistent readings back it up.
 
-This method provides length estimates for the vast majority of tracked fish. As a final step, pixel measurements are converted to real-world centimetres using a known-size reference object placed in the sonar's field of view during installation.
+That yields a length for the vast majority of tracked fish. A known-size reference placed in the sonar's field of view at installation then converts the pixel measurements into real-world centimetres.
 
 ![Length estimation process](/images/projects/monitoring_smolt_salmon_migration_with_sonar/length_estimation.png)
 *Length estimation — multiple detections across frames are collected, filtered for outliers, and combined into a single length estimate in pixels.*
 
 ## Counting
 
-The counting step translates the tracked fish trajectories into actual migration counts. A fish is counted when its track crosses a defined trigger segment — a virtual line drawn across the sonar image. To avoid double-counting, the system only registers a crossing when the track has crossed the segment an odd number of times, and it records the direction of travel (upstream or downstream) based on the sonar's orientation.
+Counting turns those tracks into migration numbers. A smolt is counted when its track crosses a **trigger line** drawn across the image; to avoid double-counting, a crossing only registers on an odd number of passes, and the direction of travel — upstream or downstream — is read from the sonar's orientation.
 
-Rather than spanning the trigger segment across the entire sonar range, this project uses a regional trigger segment focused on the area of interest — specifically the weir box exit. This focused approach brings several advantages: it eliminates false detections from outside the migration corridor, and it allows more targeted optimization of the detection and tracking models. This matters because sonar imagery characteristics change with distance from the transducer, so a model tuned for one region performs better than one stretched across the full range.
+Rather than stretch that line across the full sonar range, we place a focused **regional trigger** right at the weir-box exit. That keeps detections from outside the migration corridor from ever counting, and lets us tune the model for a single zone — which matters because sonar imagery changes with distance from the transducer, so a region-specific model beats one stretched across the whole range.
 
-![Counting trigger](/images/projects/monitoring_smolt_salmon_migration_with_sonar/counting_trigger.png)
-*Regional trigger segment — a fish is counted when its track crosses the segment placed at the weir box exit.*
+![How counting works — a smolt is tallied as its track crosses the regional trigger line at the weir-box exit](/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/counting.svg)
+*A focused trigger line at the weir-box exit: each smolt is counted once as it crosses, and its direction of travel is recorded.*
 
 ## Interactive Demo
 
-Experience the smolt detection and counting model in action. Upload preprocessed sonar footage or use the provided examples to see automated detection and tracking:
+See the model work for yourself. Upload preprocessed sonar footage, or run one of the built-in examples, and watch it detect and track smolt in real time:
 
 {{< demo_cta >}}
 
 ## Conclusion
 
-This project demonstrates that automated smolt enumeration from ARIS sonar imagery is feasible and effective. By combining deep learning-based detection with robust tracking, size estimation, and directional counting, the pipeline transforms hours of manual sonar review into an automated workflow that delivers reliable migration data.
+Counting smolt automatically from ARIS sonar works. By chaining deep-learning detection with robust tracking, length estimation and directional counting, the pipeline turns hours of manual review into a workflow that produces reliable migration data on its own.
 
-The system developed in partnership with [BC Hydro](https://www.bchydro.com/) and [Lumax AI](https://lumax.ai/) handles the full analysis chain — from raw sonar files through to individual fish counts with length estimates and migration direction. By making smolt monitoring faster and more consistent, this approach supports the data-driven conservation decisions that are essential for protecting salmon populations.
+Built with [BC Hydro](https://www.bchydro.com/) and [Lumax AI](https://lumax.ai/), it handles the whole chain — from raw sonar files to per-fish counts with lengths and travel direction. Faster, more consistent smolt monitoring means the people protecting salmon get the data they depend on, season after season.
 
 <p><iframe src="https://www.youtube.com/embed/Tg-gyDn8zfk" loading="lazy" frameborder="0" allowfullscreen></iframe></p>
 <p class="media-caption">Full pipeline demo — detection, tracking, counting, and size estimation on ARIS sonar footage.</p>

--- a/content/projects/monitoring_smolt_salmon_migration_with_sonar.md
+++ b/content/projects/monitoring_smolt_salmon_migration_with_sonar.md
@@ -152,8 +152,8 @@ For each detection the system reads whether the fish is swimming roughly horizon
 
 That yields a length for the vast majority of tracked fish. A known-size reference placed in the sonar's field of view at installation then converts the pixel measurements into real-world centimetres.
 
-![Length estimation process](/images/projects/monitoring_smolt_salmon_migration_with_sonar/length_estimation.png)
-*Length estimation — multiple detections across frames are collected, filtered for outliers, and combined into a single length estimate in pixels.*
+![How length is estimated — many per-frame measurements are filtered down to one length](/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/size.svg)
+*A length is read in every frame; the outliers are dropped, the rest are combined at the median, and the result is converted from pixels to centimetres.*
 
 ## Counting
 

--- a/content/projects/monitoring_smolt_salmon_migration_with_sonar.md
+++ b/content/projects/monitoring_smolt_salmon_migration_with_sonar.md
@@ -1,6 +1,14 @@
 ---
 title: Monitoring Smolt Salmon Migration with Sonar
 summary: An innovative use of sonar imagery to monitor and analyze the migration patterns of smolt salmon as they journey from freshwater to the ocean
+tagline: Counting juvenile salmon by sonar as they run the gauntlet downstream to the ocean.
+stats:
+  - value: "8–14 cm"
+    label: smolt detected
+  - value: "Day & night"
+    label: sonar imaging
+  - value: "Automated"
+    label: counting
 clients:
   - name: BC Hydro 
     link: https://www.bchydro.com/
@@ -12,6 +20,15 @@ tools:
   - Machine Learning
   - Computer Vision
   - Sonar
+why_count:
+  - name: Population trends
+    desc: "Tracking smolt numbers year over year reveals whether a salmon population is growing, stable or declining — an early warning of collapse."
+  - name: Dam impact
+    desc: "Counts above and below a dam quantify how hydroelectric infrastructure affects downstream fish survival."
+  - name: Regulatory compliance
+    desc: "Facilities must monitor and mitigate their impact on fish; automated counting provides the consistent, auditable data regulators require."
+  - name: Management actions
+    desc: "Smolt abundance feeds decisions on dam operations, habitat-restoration priorities, and fishing quotas for the adults that return."
 date: 2026-01-10
 space: /demos/smolt_sonar_monitoring/
 status: completed
@@ -25,6 +42,11 @@ Monitoring smolt — juvenile salmon migrating downstream toward the ocean — i
   {{< carousel_image src="/images/projects/monitoring_smolt_salmon_migration_with_sonar/map_overview.png" alt="Jansen Lake Map" caption="Jansen Lake, British Columbia, located on Vancouver Island" >}}
   {{< carousel_image src="/images/projects/monitoring_smolt_salmon_migration_with_sonar/map_satellite.png" alt="Jansen Lake Satellite" caption="Jansen Lake, British Columbia, Satellite close up" >}}
 {{< /image_carousel >}}
+
+From a raw sonar recording to a verified count, the system runs four automated steps:
+
+![From a sonar recording to a counted smolt — the analysis pipeline](/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/pipeline.svg)
+*ARIS sonar records the water, a model detects and measures each smolt, and fish are tallied as they cross a virtual line.*
 
 ## Why count smolt?
 
@@ -41,12 +63,9 @@ The downstream migration is one of the most dangerous periods in a salmon's life
 
 ### Why accurate counting matters
 
-Reliable smolt counts are fundamental for salmon conservation:
+Reliable smolt counts are fundamental for salmon conservation — tap each to learn more.
 
-- __Population trend assessment__: Tracking smolt numbers over multiple years reveals whether salmon populations are growing, stable, or declining — providing early warning of population collapse.
-- __Evaluating dam impact__: Hydroelectric operators like [BC Hydro](https://www.bchydro.com/) need to understand how their infrastructure affects downstream fish survival. Accurate counts above and below dams quantify this impact.
-- __Regulatory compliance__: Hydroelectric facilities operate under environmental regulations that require monitoring and mitigating impacts on fish populations. Automated counting provides the consistent, auditable data needed for compliance.
-- __Informing management actions__: Smolt abundance data feeds directly into decisions about dam operations, habitat restoration priorities, and fishing quotas for returning adults.
+{{< threats "why_count" >}}
 
 ### The challenge of current methods
 
@@ -104,7 +123,7 @@ We fine-tuned a pretrained [YOLOv11](https://github.com/ultralytics/ultralytics)
 To follow individual smolt across consecutive frames we use [BoTSort](https://github.com/NirAharon/BoT-SORT) (Robust Associations Multi-Pedestrian Tracking). Unlike simpler tracking approaches such as SORT that rely solely on bounding-box overlap, BoTSort combines motion prediction with visual appearance features and camera-motion compensation. This makes it far more robust when fish cross paths or temporarily disappear behind noise, providing continuous trajectories that allow us to count each smolt exactly once as it migrates past the sonar.
 
 <p><iframe src="https://www.youtube.com/embed/UY08mjPBHbc" loading="lazy" frameborder="0" allowfullscreen></iframe></p>
-<em style="font-size:14px;line-height:1.4em;display:block;">Automated smolt detection and tracking in action on preprocessed ARIS sonar footage.</em>
+<p class="media-caption">Automated smolt detection and tracking in action on preprocessed ARIS sonar footage.</p>
 
 ## Size Estimation
 
@@ -139,4 +158,4 @@ This project demonstrates that automated smolt enumeration from ARIS sonar image
 The system developed in partnership with [BC Hydro](https://www.bchydro.com/) and [Lumax AI](https://lumax.ai/) handles the full analysis chain — from raw sonar files through to individual fish counts with length estimates and migration direction. By making smolt monitoring faster and more consistent, this approach supports the data-driven conservation decisions that are essential for protecting salmon populations.
 
 <p><iframe src="https://www.youtube.com/embed/Tg-gyDn8zfk" loading="lazy" frameborder="0" allowfullscreen></iframe></p>
-<em style="font-size:14px;line-height:1.4em;display:block;">Full pipeline demo — detection, tracking, counting, and size estimation on ARIS sonar footage.</em>
+<p class="media-caption">Full pipeline demo — detection, tracking, counting, and size estimation on ARIS sonar footage.</p>

--- a/content/projects/monitoring_smolt_salmon_migration_with_sonar.md
+++ b/content/projects/monitoring_smolt_salmon_migration_with_sonar.md
@@ -123,12 +123,12 @@ The [Alouette River](https://en.wikipedia.org/wiki/Alouette_River) is the eventu
 
 ## Preprocessing
 
-Before any analysis, each raw `.aris` file runs through five preprocessing steps — converting the proprietary format to `.mp4`, stabilizing the frames, reducing noise, adjusting the colour channels, and chunking the result into manageable segments. Together they turn noisy recordings into clean, analysis-ready video.
+Before any analysis, each raw `.aris` file runs through five preprocessing steps that turn a noisy acoustic recording into clean, analysis-ready video.
 
 The output is encoded as an RGB image, with each channel carrying a different layer: the raw sonar sits in the blue background, while moving fish light up in bright red — easy for both a person and the model to pick out from the static clutter.
 
-![Preprocessing before and after](/images/projects/monitoring_smolt_salmon_migration_with_sonar/preprocess.png)
-*Before and after preprocessing — the RGB encoding makes fish (red) clearly distinguishable from the static sonar information (blue).*
+![How preprocessing works — five steps turn a raw ARIS frame into a clean, colour-encoded one where fish show up in red](/images/projects/monitoring_smolt_salmon_migration_with_sonar/diagrams/preprocess.svg)
+*Five steps turn a raw, noisy ARIS frame into clean video — the colour encoding makes fish (red) stand out from the static sonar background (blue).*
 
 Large sonar files are split into smaller chunks so the downstream detection and tracking steps can process them efficiently.
 

--- a/docs/specs/2026-06-15-smolt-page-alignment-design.md
+++ b/docs/specs/2026-06-15-smolt-page-alignment-design.md
@@ -1,0 +1,35 @@
+# Monitoring Smolt Salmon Migration with Sonar — Alignment
+
+**Date:** 2026-06-15
+**Status:** Approved
+**Base:** latest `origin/main` (worktree `worktree-smolt-revamp`). One PR per project page.
+**Scope:** The smolt page is already editorial/well-structured. This is an alignment pass to match the fire/salmon/elephant system — not a rewrite.
+
+## Changes
+
+1. **Front matter:** add `tagline` + `stats`. Stats: `8–14 cm` smolt detected · `day & night` (sonar) · `automated` counting. Tagline e.g. *"Counting juvenile salmon by sonar as they run the gauntlet downstream to the ocean."*
+2. **One new animated SVG pipeline diagram** (house teal/coral system), placed right after the lede (the overview beat the page lacks). Steps: **Record → Detect → Measure → Count**:
+   - Record — an ARIS sonar transducer casting a fan beam into the water, a smolt in the beam.
+   - Detect — a dark sonar frame (range arcs + noise) with a bright smolt blob, red bounding box + AI chip.
+   - Measure — the boxed smolt with a length caliper + "12 cm" pill (size estimation).
+   - Count — a dashed trigger line with a smolt crossing it, a downstream arrow + "+1" badge.
+   The existing technical figures (preprocess before/after, YOLO tasks, length estimation, counting trigger, ARIS frame) all stay in their sections — the diagram is a complementary overview.
+3. **Pills:** convert the "Why accurate counting matters" 4-bullet list into the interactive pills component. Needs the key-argument shortcode (the version on fire PR #87): generalize `threats.html` here too (superset, default key `threats`, overridable positional arg) and call `{{< threats "why_count" >}}` with a `why_count:` front-matter list. Reuses the `.threats` CSS already on `main`.
+4. **Polish:** switch the two inline-styled video captions (`<em style=...>`) to the `.media-caption` class (already on `main`).
+
+## New primitives (in the diagram)
+
+A **sonar frame** (deep blue-teal rounded tile + faint range arcs + light noise), a bright **smolt blob** (orange-red elongated mark, as fish appear in sonar), an **ARIS transducer + fan beam**, a length **caliper**, and a **trigger line + direction arrow**. Positioning transform on an outer `<g>`, animation class on an inner `<g>` (avoid the transform-attribute override).
+
+## Non-goals
+
+- No rewrite of the existing well-structured body; no removal of the technical figures.
+- No second (detection close-up) diagram — the existing YOLO/tracking figures + video already cover that.
+
+## Merge note
+
+This PR generalizes `threats.html` with a positional key arg — the same superset as the open fire PR #87. Whichever merges second keeps this version (identical); trivial conflict.
+
+## Verification
+
+- `hugo` builds clean; screenshot the page (hero+stats, pipeline diagram, pills, captions); diagram animates and degrades with reduced motion.

--- a/layouts/shortcodes/threats.html
+++ b/layouts/shortcodes/threats.html
@@ -1,10 +1,13 @@
 {{/*
-  Interactive threat chips. Data comes from the page front matter `threats:`
-  (a list of { name, desc }). Pure CSS (radio inputs + general-sibling
-  combinator): clicking a chip highlights it and reveals its explanation panel
-  below. Single-select. Styling lives in _project-single.scss (.threats).
+  Interactive pill chips. Data comes from a page front-matter list of
+  { name, desc }; the list key defaults to `threats` but can be overridden with
+  a positional argument, e.g. {{< threats "forest_protection" >}}. Pure CSS
+  (radio inputs + general-sibling combinator): clicking a chip highlights it and
+  reveals its explanation panel below. Single-select. Styling lives in
+  assets/sass/4-layouts/_project-single.scss (.threats).
 */}}
-{{ with .Page.Params.threats }}
+{{ $key := .Get 0 | default "threats" }}
+{{ with index .Page.Params $key }}
 <div class="threats">
   {{ range $i, $t := . }}<input type="radio" name="threat-group" id="threat-{{ $i }}" class="threats__toggle" {{ if eq $i 0 }}checked{{ end }}>
   {{ end }}


### PR DESCRIPTION
## Summary

Aligns the **Monitoring Smolt Salmon Migration with Sonar** page to the project-page system used by the fire, salmon and elephant pages. The page was already editorial/well-structured, so this is a focused alignment pass — not a rewrite. The existing technical figures (preprocessing, YOLO tasks, length estimation, counting trigger, ARIS frame) and videos are all kept.

## What changed

- **Front matter:** added `tagline` + `stats` (8–14 cm smolt detected · Day & night sonar · Automated counting) for the hero band.
- **New animated SVG overview diagram** (house teal/coral style) after the lede — the overview beat the page lacked. Steps **Record → Detect → Measure → Count**: an ARIS transducer casting a fan beam, dark sonar frames with range arcs, a red detection box, a length caliper ("12.4 cm"), and a trigger-line crossing with a "+1" count.
- **Interactive pills:** the "Why accurate counting matters" bullet list → the pills component (Population trends · Dam impact · Regulatory compliance · Management actions), data in a `why_count:` front-matter list.
- **Shortcode:** generalized `threats` with a positional key argument so it reads any front-matter list (`{{< threats "why_count" >}}`), defaulting to `threats`. Same superset as the open fire PR #87.
- **Polish:** the two inline-styled video captions now use the `.media-caption` class.

`hugo` builds clean; hero stats, diagram, pills (with explanation panel), and captions all render.

## Merge note
This generalizes `layouts/shortcodes/threats.html` with the positional key argument — identical to the open **fire PR #87**. Whichever merges second keeps this version (trivial/no conflict). After both land, `main` has a single key-aware pills component used by all project pages.
