### PR TITLE
SalmonVision tool page: stat band, interactive pills (Why + FAQ), demos & layout polish

### DIFF
--- a/assets/sass/3-modules/_tools.scss
+++ b/assets/sass/3-modules/_tools.scss
@@ -441,23 +441,25 @@
   }
 }
 
-// Per-chip selected state: highlight the active chip and reveal its panel.
-@for $i from 0 through 7 {
-  .tool-content #threat-#{$i}:checked ~ .threats__chips label[for="threat-#{$i}"] {
-    background: var(--secondary-color);
-    border-color: var(--secondary-color);
-    color: #fff;
+// Selected/focused chip — uses :has() so it works for any namespaced radio
+// group, allowing multiple .threats instances on one page.
+.tool-content .threats__chip:has(.threats__toggle:checked) {
+  background: var(--secondary-color);
+  border-color: var(--secondary-color);
+  color: #fff;
 
-    &::before { background: #fff; }
-  }
+  &::before { background: #fff; }
+}
 
-  .tool-content #threat-#{$i}:checked ~ .threats__panels #threat-panel-#{$i} {
+.tool-content .threats__chip:has(.threats__toggle:focus-visible) {
+  outline: 2px solid var(--secondary-color);
+  outline-offset: 3px;
+}
+
+// Reveal the panel whose index matches the checked chip (positional pairing).
+@for $i from 1 through 12 {
+  .tool-content .threats:has(.threats__chips > li:nth-child(#{$i}) .threats__toggle:checked) .threats__panels > .threats__panel:nth-child(#{$i}) {
     display: block;
-  }
-
-  .tool-content #threat-#{$i}:focus-visible ~ .threats__chips label[for="threat-#{$i}"] {
-    outline: 2px solid var(--secondary-color);
-    outline-offset: 3px;
   }
 }
 

--- a/assets/sass/4-layouts/_project-single.scss
+++ b/assets/sass/4-layouts/_project-single.scss
@@ -231,25 +231,25 @@ $project-cta-gap: 56px;
   }
 }
 
-// Per-chip selected state: highlight the active chip and reveal its panel.
-// Indices match the .threats shortcode (0..5; a couple extra for safety).
-@for $i from 0 through 7 {
-  .post__content #threat-#{$i}:checked ~ .threats__chips label[for="threat-#{$i}"] {
-    background: var(--secondary-color);
-    border-color: var(--secondary-color);
-    color: #fff;
+// Selected/focused chip — uses :has() so it works for any namespaced radio
+// group, allowing multiple .threats instances on one page.
+.post__content .threats__chip:has(.threats__toggle:checked) {
+  background: var(--secondary-color);
+  border-color: var(--secondary-color);
+  color: #fff;
 
-    &::before { background: #fff; }
-  }
+  &::before { background: #fff; }
+}
 
-  .post__content #threat-#{$i}:checked ~ .threats__panels #threat-panel-#{$i} {
+.post__content .threats__chip:has(.threats__toggle:focus-visible) {
+  outline: 2px solid var(--secondary-color);
+  outline-offset: 3px;
+}
+
+// Reveal the panel whose index matches the checked chip (positional pairing).
+@for $i from 1 through 12 {
+  .post__content .threats:has(.threats__chips > li:nth-child(#{$i}) .threats__toggle:checked) .threats__panels > .threats__panel:nth-child(#{$i}) {
     display: block;
-  }
-
-  // Keyboard focus: show an outline on the chip whose radio is focused.
-  .post__content #threat-#{$i}:focus-visible ~ .threats__chips label[for="threat-#{$i}"] {
-    outline: 2px solid var(--secondary-color);
-    outline-offset: 3px;
   }
 }
 

--- a/content/tools/salmonvision/index.md
+++ b/content/tools/salmonvision/index.md
@@ -23,6 +23,19 @@ why_salmonvision:
     desc: "Models recognize the main Pacific salmon species — and other fish — on the fly, not just a single overall count."
   - name: Exportable reports
     desc: "Daily count reports are generated and exported to support fisheries management, habitat protection, and regulatory compliance."
+faq:
+  - name: How accurate is it?
+    desc: "Models reach over 95% accuracy for salmon detection and counting in good conditions, with 90–95% species classification. Accuracy depends on water clarity, lighting, and camera placement."
+  - name: What footage does it work with?
+    desc: "Video from underwater cameras, weirs, fish ladders, and drones, in standard formats and across a wide range of field conditions."
+  - name: Which species can it identify?
+    desc: "The main Pacific salmon species — Steelhead, Sockeye, Pink, Coho, Chum, and Chinook — plus other fish such as trout, whitefish, and lamprey."
+  - name: Is it open source?
+    desc: "The computer-vision models are released under the MIT license, and the training datasets under CC BY-NC-SA 4.0, to support conservation worldwide."
+  - name: What does it cost?
+    desc: "The web application is free for educational and research use. Conservation groups and Indigenous communities may qualify for subsidized or complimentary access."
+  - name: Can you build a custom model?
+    desc: "Yes — models can be fine-tuned or built from scratch for your specific watershed, camera setup, or target species."
 ---
 
 <div class="tool-hero">
@@ -205,49 +218,11 @@ First Nations across the North and Central Coast of British Columbia are at the 
 <br/>
 <br/>
 
-## Our Partners
-
-SalmonVision is built and sustained through close collaboration with leading conservation organizations, research institutions, and industry partners.
-
-{{< partner_logos >}}
-
-<br/>
-
 ## Frequently Asked Questions
 
-<div class="support__grid">
+Tap a question to see the answer.
 
-  <div class="support__card">
-    <h3 class="support__card-title">How accurate is it?</h3>
-    <p class="support__card-description">Models reach over 95% accuracy for salmon detection and counting in good conditions, with 90–95% species classification. Accuracy depends on water clarity, lighting, and camera placement.</p>
-  </div>
-
-  <div class="support__card">
-    <h3 class="support__card-title">What footage does it work with?</h3>
-    <p class="support__card-description">Video from underwater cameras, weirs, fish ladders, and drones, in standard formats and across a wide range of field conditions.</p>
-  </div>
-
-  <div class="support__card">
-    <h3 class="support__card-title">Which species can it identify?</h3>
-    <p class="support__card-description">The main Pacific salmon species — Steelhead, Sockeye, Pink, Coho, Chum, and Chinook — plus other fish such as trout, whitefish, and lamprey.</p>
-  </div>
-
-  <div class="support__card">
-    <h3 class="support__card-title">Is it open source?</h3>
-    <p class="support__card-description">The computer-vision models are released under the MIT license, and the training datasets under CC BY-NC-SA 4.0, to support conservation worldwide.</p>
-  </div>
-
-  <div class="support__card">
-    <h3 class="support__card-title">What does it cost?</h3>
-    <p class="support__card-description">The web application is free for educational and research use. Conservation groups and Indigenous communities may qualify for subsidized or complimentary access.</p>
-  </div>
-
-  <div class="support__card">
-    <h3 class="support__card-title">Can you build a custom model?</h3>
-    <p class="support__card-description">Yes — models can be fine-tuned or built from scratch for your specific watershed, camera setup, or target species.</p>
-  </div>
-
-</div>
+{{< threats "faq" >}}
 
 <br/>
 <br/>
@@ -257,3 +232,12 @@ SalmonVision is built and sustained through close collaboration with leading con
   <p class="about-cta__description">See deployments, count dashboards, and how to get involved on the SalmonVision website.</p>
   <a href="https://salmonvision.org" class="link-no-decoration button button--middle" target="_blank">Visit SalmonVision</a>
 </div>
+
+<br/>
+<br/>
+
+## Our Partners
+
+SalmonVision is built and sustained through close collaboration with leading conservation organizations, research institutions, and industry partners.
+
+{{< partner_logos >}}

--- a/content/tools/salmonvision/index.md
+++ b/content/tools/salmonvision/index.md
@@ -14,6 +14,15 @@ js:
   - /js/biowatch.js
   - /js/tabs.js
 date: 2024-10-01
+why_salmonvision:
+  - name: Automated counting
+    desc: "Computer-vision models count and classify fish migrating upstream in real time, replacing slow, error-prone manual tallies."
+  - name: Multi-sensor coverage
+    desc: "Underwater cameras, sonar, and drones work in unison to track populations across clear, murky, and hard-to-reach river conditions."
+  - name: Species classification
+    desc: "Models recognize the main Pacific salmon species — and other fish — on the fly, not just a single overall count."
+  - name: Exportable reports
+    desc: "Daily count reports are generated and exported to support fisheries management, habitat protection, and regulatory compliance."
 ---
 
 <div class="tool-hero">
@@ -25,10 +34,6 @@ date: 2024-10-01
     <p class="tool-hero__tagline">Empowering wild salmon conservation through collaborative, AI-powered monitoring.</p>
   </div>
 </div>
-
-SalmonVision is a collaborative system for counting wild salmon as they return to their natal streams. It combines underwater cameras, sonar, and drones with computer-vision models that detect, classify, and count fish in real time — turning a labour-intensive manual task into precise, automated reports.
-
-Built with the Pacific Salmon Foundation, the Wild Salmon Center, Lumax AI, and Simon Fraser University, it gives conservationists the reliable population data they need to manage fisheries, protect habitat, and meet regulatory targets.
 
 <section class="about-stats about-stats--three tools-stats">
   <div class="about-stats__grid">
@@ -47,48 +52,21 @@ Built with the Pacific Salmon Foundation, the Wild Salmon Center, Lumax AI, and 
   </div>
 </section>
 
+SalmonVision is a collaborative system for counting wild salmon as they return to their natal streams. It combines underwater cameras, sonar, and drones with computer-vision models that detect, classify, and count fish in real time — turning a labour-intensive manual task into precise, automated reports.
+
+Built with the Pacific Salmon Foundation, the Wild Salmon Center, Lumax AI, and Simon Fraser University, it gives conservationists the reliable population data they need to manage fisheries, protect habitat, and meet regulatory targets.
+
 {{< image_carousel id="salmonvision-gallery" items="2" >}}
   {{< carousel_image src="/images/tools/salmonvision/review-interface.png" alt="A salmon under review in the SalmonVision web app" caption="Review interface: each fish is tracked and classified by species (Pink, Sockeye…), with counts tallied along a timeline for a reviewer to confirm." >}}
   {{< carousel_image src="/images/projects/wild_salmon_migration_monitoring/sonar/haida-sonar.jpg" alt="Sonar setup at the Haida site" caption="Sonar in the field: an acoustic counter deployed at the Haida site for low-visibility water." >}}
   {{< carousel_image src="/images/projects/wild_salmon_migration_monitoring/drone/drone_imagery.webp" alt="Drone photogrammetry of a salmon stream" caption="Drone photogrammetry of a freshwater stream where salmon migrate — courtesy of Lumax AI." >}}
 {{< /image_carousel >}}
 
-<div class="about-cta">
-  <h3 class="about-cta__title">See the models in action</h3>
-  <p class="about-cta__description">Run the SalmonVision models on real underwater-camera and sonar footage, and watch them count migrating fish — right from your browser.</p>
-  <a href="#demos" class="link-no-decoration button button--middle">Try the live demos</a>
-</div>
-
-<br/>
-<br/>
-
 ## Why SalmonVision
 
-SalmonVision pairs multi-sensor hardware with computer vision to deliver counts that were previously impossible to gather at scale.
+SalmonVision pairs multi-sensor hardware with computer vision to deliver counts that were previously impossible to gather at scale — tap each to learn more.
 
-<div class="support__grid">
-
-  <div class="support__card">
-    <h3 class="support__card-title">Automated counting</h3>
-    <p class="support__card-description">Computer-vision models count and classify fish migrating upstream in real time, replacing slow, error-prone manual tallies.</p>
-  </div>
-
-  <div class="support__card">
-    <h3 class="support__card-title">Multi-sensor coverage</h3>
-    <p class="support__card-description">Underwater cameras, sonar, and drones work in unison to track populations across clear, murky, and hard-to-reach river conditions.</p>
-  </div>
-
-  <div class="support__card">
-    <h3 class="support__card-title">Species classification</h3>
-    <p class="support__card-description">Models recognize the main Pacific salmon species — and other fish — on the fly, not just a single overall count.</p>
-  </div>
-
-  <div class="support__card">
-    <h3 class="support__card-title">Exportable reports</h3>
-    <p class="support__card-description">Daily count reports are generated and exported to support fisheries management, habitat protection, and regulatory compliance.</p>
-  </div>
-
-</div>
+{{< threats "why_salmonvision" >}}
 
 <br/>
 <br/>
@@ -133,31 +111,9 @@ Beyond the salmon above, the system also recognizes Bull Trout, Rainbow Trout, W
 <br/>
 <br/>
 
-## Interactive Demos {#demos}
-
-Two interactive demos let you run the SalmonVision models on real data, right from this website.
-
-{{< tabs labels="::Underwater camera|::Sonar smolt" id="salmonvision-demos" >}}
-{{< tab index="0" >}}
-
-Choose an underwater-camera clip and watch the model draw boxes around salmon, classify the species, and count individuals.
-
-{{< hf_space "earthtoolsmaker-salmon-vision" >}}
-
-{{< /tab >}}
-{{< tab index="1" >}}
-
-Run the sonar pipeline on ARIS footage to detect, track, and count juvenile smolt as they migrate downstream.
-
-<p><iframe src="https://lumax-eco-sonar-smolt.hf.space" loading="lazy" frameborder="0" style="width:100%;height:1000px;border:0;"></iframe></p>
-
-{{< /tab >}}
-{{< /tabs >}}
-
-<br/>
-<br/>
-
 ## See SalmonVision in Action
+
+Watch the system at work — in the field and inside the web app.
 
 {{< tabs labels="::In the field|::In the app" id="salmonvision-videos" >}}
 {{< tab index="0" markdown="true" >}}
@@ -174,6 +130,25 @@ Inside the web app, the model tracks each fish across frames and proposes a spec
 
 <p><video controls muted loop playsinline preload="metadata" style="width:100%;border-radius:12px;"><source src="/videos/salmonvision-tracking.mp4" type="video/mp4"></video></p>
 <em style="font-size:14px;line-height:1.4em;display:block;">Reviewing detections in the SalmonVision web app — bounding boxes, species labels, and counts on a timeline.</em>
+
+{{< /tab >}}
+{{< /tabs >}}
+
+And run the models yourself: two interactive demos let you try SalmonVision on real data, right from your browser.
+
+{{< tabs labels="::Underwater camera|::Sonar smolt" id="salmonvision-demos" >}}
+{{< tab index="0" >}}
+
+Choose an underwater-camera clip and watch the model draw boxes around salmon, classify the species, and count individuals.
+
+{{< hf_space "earthtoolsmaker-salmon-vision" >}}
+
+{{< /tab >}}
+{{< tab index="1" >}}
+
+Run the sonar pipeline on ARIS footage to detect, track, and count juvenile smolt as they migrate downstream.
+
+<p><iframe src="https://lumax-eco-sonar-smolt.hf.space" loading="lazy" frameborder="0" style="width:100%;height:1000px;border:0;"></iframe></p>
 
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/specs/2026-06-15-salmonvision-page-polish-design.md
+++ b/docs/specs/2026-06-15-salmonvision-page-polish-design.md
@@ -33,14 +33,40 @@ section.
    field/app videos: watch the system at work, then run the models yourself.
    Drop the now-unreferenced `#demos` anchor.
 
+5. **FAQ cards → pills.** Convert the six FAQ `support__card` cards to the
+   interactive `threats` pills via a `faq` front-matter list (`{ name: question,
+   desc: answer }`) and `{{< threats "faq" >}}`, with a "Tap a question to see
+   the answer" hint. This is a **second** `.threats` instance on the same page
+   (alongside "Why SalmonVision"), which required the multi-instance refactor
+   below.
+
+6. **Multi-instance `threats` component refactor (shared).** The component
+   previously hardcoded a single radio group (`threat-group`) and global IDs
+   (`threat-0`…), so two instances on one page collided. Reworked to be
+   instance-safe:
+   - Shortcode: each chip wraps its own radio; the radio group name is
+     namespaced per key (`threats-<key>`); no global IDs.
+   - CSS (both `.tool-content` in `_tools.scss` and `.post__content` in
+     `_project-single.scss`): state now uses `:has()` — active/focused chip via
+     `.threats__chip:has(.threats__toggle:checked)`, and panel reveal via
+     positional `nth-child` pairing scoped to each `.threats`. Works for any
+     number of instances per page.
+   - Affects all five consumers: salmonvision (Why + FAQ), pyronear (Why), and
+     three project pages (early_forest_fire_detection, wild_salmon_*,
+     elephants_*) — all re-verified.
+
+7. **Move "Our Partners" to the very end** of the page (after the closing CTA).
+
 ## Out of scope
-- No changes to the hero video, the shared `.tool-hero`/`.threats` CSS, the
-  Species/Partners/FAQ sections, or the final CTA.
+- No changes to the hero video or the `.tool-hero` CSS.
 
 ## Verification
 - `hugo` builds clean.
-- Built HTML: stat band ordered hero → stats → intro; four `threats__chip`
-  pills; no "See the models in action" CTA; both `salmonvision-videos` and
-  `salmonvision-demos` tab groups under "See SalmonVision in Action"; no
-  Interactive Demos heading and no `#demos` anchor.
-- Screenshots confirm the stat band under the hero and the interactive pills.
+- Built HTML: stat band ordered hero → stats → intro; Why + FAQ render as
+  `.threats` pills with **separate** radio groups (`threats-why_salmonvision`,
+  `threats-faq`); no "See the models in action" CTA; demos folded into "See
+  SalmonVision in Action"; no `#demos` anchor; "Our Partners" is the last
+  section. All five `threats` consumers render with namespaced groups and no
+  leftover `id="threat-"`.
+- Screenshots confirm the stat band under the hero and the interactive pills
+  (active chip + reveal panel) under the refactored `:has()` CSS.

--- a/docs/specs/2026-06-15-salmonvision-page-polish-design.md
+++ b/docs/specs/2026-06-15-salmonvision-page-polish-design.md
@@ -1,0 +1,46 @@
+# SalmonVision tool page polish — design
+
+**Date:** 2026-06-15
+**Status:** Approved
+
+## Goal
+
+Bring the SalmonVision tool page in line with the Pyronear tool page treatment
+(merged in PR #89): stat band under the hero, interactive pills for the benefits
+section, no demos CTA, and the interactive demos folded into the "in action"
+section.
+
+## Changes
+
+1. **Stat band below the hero.** Move the existing `about-stats--three
+   tools-stats` band (`24/7` automated monitoring · `20` monitoring projects ·
+   `1M+` salmon counted) from after the intro paragraphs to directly below the
+   hero video, above the intro — matching the Pyronear layout.
+
+2. **"Why SalmonVision" interactive pills.** Replace the four `support__card`
+   cards with the interactive `threats` shortcode (already on `main`): a
+   `why_salmonvision` front-matter list of `{ name, desc }` rendered via
+   `{{< threats "why_salmonvision" >}}`. Clicking a pill reveals its
+   description. Added the "— tap each to learn more" hint. No new CSS (the
+   `.tool-content .threats` rules landed with PR #89).
+
+3. **Remove the "See the models in action" CTA** (the `about-cta` above "Why
+   SalmonVision").
+
+4. **Integrate the interactive demos into "See SalmonVision in Action."** Remove
+   the standalone "Interactive Demos" section and fold its two demo tabs
+   (underwater camera, sonar smolt) into "See SalmonVision in Action", after the
+   field/app videos: watch the system at work, then run the models yourself.
+   Drop the now-unreferenced `#demos` anchor.
+
+## Out of scope
+- No changes to the hero video, the shared `.tool-hero`/`.threats` CSS, the
+  Species/Partners/FAQ sections, or the final CTA.
+
+## Verification
+- `hugo` builds clean.
+- Built HTML: stat band ordered hero → stats → intro; four `threats__chip`
+  pills; no "See the models in action" CTA; both `salmonvision-videos` and
+  `salmonvision-demos` tab groups under "See SalmonVision in Action"; no
+  Interactive Demos heading and no `#demos` anchor.
+- Screenshots confirm the stat band under the hero and the interactive pills.

--- a/layouts/shortcodes/threats.html
+++ b/layouts/shortcodes/threats.html
@@ -1,22 +1,22 @@
 {{/*
   Interactive pill chips. Data comes from a page front-matter list of
   { name, desc }; the list key defaults to `threats` but can be overridden with
-  a positional argument, e.g. {{< threats "forest_protection" >}}. Pure CSS
-  (radio inputs + general-sibling combinator): clicking a chip highlights it and
-  reveals its explanation panel below. Single-select. Styling lives in
-  assets/sass/4-layouts/_project-single.scss (.threats).
+  a positional argument, e.g. {{< threats "forest_protection" >}}. Pure CSS:
+  each chip wraps a radio whose group is namespaced per key, so MULTIPLE
+  instances can coexist on one page. Clicking a chip highlights it and reveals
+  its explanation panel below (single-select). Styling (.threats) lives in
+  assets/sass/3-modules/_tools.scss (.tool-content) and
+  assets/sass/4-layouts/_project-single.scss (.post__content).
 */}}
 {{ $key := .Get 0 | default "threats" }}
 {{ with index .Page.Params $key }}
 <div class="threats">
-  {{ range $i, $t := . }}<input type="radio" name="threat-group" id="threat-{{ $i }}" class="threats__toggle" {{ if eq $i 0 }}checked{{ end }}>
-  {{ end }}
   <ul class="threats__chips">
-    {{ range $i, $t := . }}<li><label for="threat-{{ $i }}" class="threats__chip">{{ $t.name | safeHTML }}</label></li>
+    {{ range $i, $t := . }}<li><label class="threats__chip"><input type="radio" name="threats-{{ $key }}" class="threats__toggle" {{ if eq $i 0 }}checked{{ end }}>{{ $t.name | safeHTML }}</label></li>
     {{ end }}
   </ul>
   <div class="threats__panels">
-    {{ range $i, $t := . }}<p class="threats__panel" id="threat-panel-{{ $i }}">{{ $t.desc | safeHTML }}</p>
+    {{ range $i, $t := . }}<p class="threats__panel">{{ $t.desc | safeHTML }}</p>
     {{ end }}
   </div>
 </div>


### PR DESCRIPTION
Applies the Pyronear-style treatment to the SalmonVision tool page, plus an FAQ conversion and a partners move. Mirrors the patterns from PR #89.

## Page changes
- **Stat band moved below the hero video** (hero → `24/7` · `20` · `1M+` → intro), matching Pyronear.
- **"Why SalmonVision" cards → interactive pills** (`threats` shortcode, `why_salmonvision` front matter); click a pill to reveal its description.
- **Removed** the "See the models in action" CTA.
- **Interactive demos folded into "See SalmonVision in Action"** — the standalone Interactive Demos section is gone; its two demo tabs now sit after the field/app videos ("watch it work, then run it yourself"). Dropped the unused `#demos` anchor.
- **FAQ cards → interactive pills** (`faq` front matter) with a "tap a question to see the answer" hint.
- **"Our Partners" moved to the very end** of the page (after the closing CTA).

## Shared component refactor — multi-instance `threats`
The FAQ makes SalmonVision the first page with **two** pill instances, which the component couldn't support (it hardcoded one radio group `threat-group` and global IDs `threat-0`…). Reworked to be instance-safe:
- Shortcode: each chip wraps its own radio; radio group namespaced per key (`threats-<key>`); no global IDs.
- CSS (`.tool-content` in `_tools.scss` and `.post__content` in `_project-single.scss`): state via `:has()` — active chip is `.threats__chip:has(.threats__toggle:checked)`, panel reveal via positional `nth-child` pairing scoped to each `.threats`.

This touches all five `threats` consumers — salmonvision (Why + FAQ), pyronear (Why), and three project pages (early_forest_fire_detection, wild_salmon_migration_monitoring, elephants_passive_acoustic_monitoring) — **all re-verified** to still render with their own namespaced radio groups and no leftover `id="threat-"`.

## Notes
- Design spec: `docs/specs/2026-06-15-salmonvision-page-polish-design.md`.
- The `:has()` selector is used for state; supported across all current major browsers.
- Verified: `hugo` builds clean; built HTML confirms section order, two separate radio groups on SalmonVision, partners last; screenshots confirm the stat band and the active-pill + reveal-panel behavior under the new CSS.