### PR TITLE
Revamp Wadden Sea Seal Monitoring project page

### DIFF
--- a/assets/images/projects/wadden_sea_seal_monitoring/diagrams/pipeline.svg
+++ b/assets/images/projects/wadden_sea_seal_monitoring/diagrams/pipeline.svg
@@ -1,0 +1,121 @@
+<svg viewBox="0 0 1062 380" xmlns="http://www.w3.org/2000/svg" font-family="Mulish, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#cfeef0"/><stop offset="100%" stop-color="#9fd6da"/></linearGradient>
+  <linearGradient id="sand" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#e7d6b5"/><stop offset="100%" stop-color="#cdb487"/></linearGradient>
+  <linearGradient id="sea" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#7fc0c6"/><stop offset="100%" stop-color="#4f9aa2"/></linearGradient>
+  <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 1 L9 5 L0 9 Z" fill="#e29578"/></marker>
+  <filter id="cardshadow" x="-20%" y="-20%" width="140%" height="150%"><feDropShadow dx="0" dy="5" stdDeviation="9" flood-color="#1c2b28" flood-opacity="0.08"/></filter>
+  <style>
+    .title { font-family: Newsreader, Georgia, 'Times New Roman', serif; font-size: 26px; font-weight: 600; fill: #161616; }
+    .desc  { font-size: 15px; fill: #60626a; }
+    .step  { font-size: 13px; font-weight: 700; letter-spacing: 0.12em; fill: #e29578; }
+    .chip  { font-size: 11px; font-weight: 700; fill: #fff; }
+    .fly   { animation: fly 4s ease-in-out infinite; }
+    .scan  { animation: pulse 2.2s ease-in-out infinite; }
+    .box   { animation: boxpulse 2.4s ease-in-out infinite; } .box.b{animation-delay:-0.8s} .box.c{animation-delay:-1.6s}
+    .pop   { transform-box: fill-box; transform-origin: 50% 50%; animation: pop 3s ease-in-out infinite; }
+    @keyframes fly { 0%,100%{transform:translate(-6px,2px)} 50%{transform:translate(6px,-2px)} }
+    @keyframes pulse { 0%,100%{opacity:0.25} 50%{opacity:0.7} }
+    @keyframes boxpulse { 0%,100%{opacity:0.55} 50%{opacity:1} }
+    @keyframes pop { 0%,100%{opacity:0.85} 50%{opacity:1} }
+    @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+  </style>
+  <!-- top-down seal: grey body with a slightly tapered head, faces right -->
+  <g id="seal"><ellipse cx="0" cy="0" rx="18" ry="7" fill="#737a80"/><circle cx="15" cy="0" r="5.5" fill="#7f868c"/><path d="M-18 0 L-26 -3 L-23 0 L-26 3 Z" fill="#737a80"/><ellipse cx="-2" cy="-1.5" rx="11" ry="2.4" fill="#8b9298" opacity="0.6"/></g>
+</defs>
+
+<g stroke="#e29578" stroke-width="3.5" fill="none" stroke-linecap="round">
+  <line x1="250" y1="134" x2="291" y2="134" marker-end="url(#arrow)"/>
+  <line x1="509" y1="134" x2="550" y2="134" marker-end="url(#arrow)"/>
+  <line x1="768" y1="134" x2="809" y2="134" marker-end="url(#arrow)"/>
+</g>
+
+<!-- CARD 1 — SURVEY -->
+<rect x="36" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(142,128)">
+  <clipPath id="c1"><rect x="-90" y="-84" width="180" height="168" rx="12"/></clipPath>
+  <g clip-path="url(#c1)">
+    <rect x="-90" y="-84" width="180" height="168" fill="url(#sky)"/>
+    <!-- sea + sandbank -->
+    <rect x="-90" y="34" width="180" height="50" fill="url(#sea)"/>
+    <path d="M-90 56 Q-20 30 40 44 Q80 52 90 48 L90 84 L-90 84 Z" fill="url(#sand)"/>
+    <!-- seals hauled out -->
+    <g transform="translate(-38,64) scale(0.62)"><use href="#seal"/></g>
+    <g transform="translate(4,70) scale(0.62) rotate(-8)"><use href="#seal"/></g>
+    <g transform="translate(46,62) scale(0.62) rotate(6)"><use href="#seal"/></g>
+    <!-- aircraft + camera cone -->
+    <g class="fly">
+      <g transform="translate(-2,-48)">
+        <path class="scan" d="M0 6 L-26 56 L26 56 Z" fill="#e29578"/>
+        <g fill="#15463f"><ellipse cx="0" cy="0" rx="16" ry="5"/><rect x="-22" y="-2" width="44" height="4" rx="2"/><path d="M0 -3 L8 -14 L11 -13 L4 -1 Z"/><rect x="-4" y="2" width="8" height="6" rx="1.5"/></g>
+      </g>
+    </g>
+  </g>
+</g>
+<text class="step" x="142" y="280" text-anchor="middle">01</text>
+<text class="title" x="142" y="312" text-anchor="middle">Survey</text>
+<text class="desc"  x="142" y="338" text-anchor="middle">Photographed from the air</text>
+
+<!-- CARD 2 — DETECT -->
+<rect x="295" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(401,128)">
+  <clipPath id="c2"><rect x="-90" y="-84" width="180" height="168" rx="12"/></clipPath>
+  <g clip-path="url(#c2)">
+    <rect x="-90" y="-84" width="180" height="168" fill="url(#sand)"/>
+    <rect x="-90" y="-84" width="180" height="40" fill="url(#sea)" opacity="0.85"/>
+    <g transform="translate(-44,-8) scale(0.7)"><use href="#seal"/></g>
+    <g transform="translate(28,-28) scale(0.7) rotate(-12)"><use href="#seal"/></g>
+    <g transform="translate(40,40) scale(0.7) rotate(8)"><use href="#seal"/></g>
+    <g transform="translate(-30,52) scale(0.7) rotate(-4)"><use href="#seal"/></g>
+  </g>
+  <g fill="none" stroke="#3fd07a" stroke-width="3">
+    <rect class="box" x="-66" y="-24" width="44" height="30" rx="3"/>
+    <rect class="box b" x="2" y="-44" width="46" height="30" rx="3"/>
+    <rect class="box c" x="16" y="24" width="44" height="30" rx="3"/>
+    <rect class="box b" x="-52" y="36" width="44" height="28" rx="3"/>
+  </g>
+</g>
+<text class="step" x="401" y="280" text-anchor="middle">02</text>
+<text class="title" x="401" y="312" text-anchor="middle">Detect</text>
+<text class="desc"  x="401" y="338" text-anchor="middle">Every seal located</text>
+
+<!-- CARD 3 — CLASSIFY -->
+<rect x="554" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(660,128)">
+  <clipPath id="c3"><rect x="-90" y="-84" width="180" height="168" rx="12"/></clipPath>
+  <g clip-path="url(#c3)"><rect x="-90" y="-84" width="180" height="168" fill="url(#sand)"/></g>
+  <!-- focal seal -->
+  <g transform="translate(-50,0) scale(1.05)"><use href="#seal"/></g>
+  <rect class="box" x="-88" y="-22" width="78" height="40" rx="3" fill="none" stroke="#3fd07a" stroke-width="3"/>
+  <!-- five attribute chips -->
+  <g class="pop">
+    <g transform="translate(40,-58)"><rect x="-42" y="-11" width="84" height="20" rx="10" fill="#006d77"/><text class="chip" x="0" y="4" text-anchor="middle">Grey seal</text></g>
+    <g transform="translate(40,-32)"><rect x="-42" y="-11" width="84" height="20" rx="10" fill="#0a7d86"/><text class="chip" x="0" y="4" text-anchor="middle">Pup</text></g>
+    <g transform="translate(40,-6)"><rect x="-42" y="-11" width="84" height="20" rx="10" fill="#0a7d86"/><text class="chip" x="0" y="4" text-anchor="middle">On land</text></g>
+    <g transform="translate(40,20)"><rect x="-42" y="-11" width="84" height="20" rx="10" fill="#0a7d86"/><text class="chip" x="0" y="4" text-anchor="middle">Alive</text></g>
+    <g transform="translate(40,46)"><rect x="-42" y="-11" width="84" height="20" rx="10" fill="#0a7d86"/><text class="chip" x="0" y="4" text-anchor="middle">Female ♀</text></g>
+  </g>
+</g>
+<text class="step" x="660" y="280" text-anchor="middle">03</text>
+<text class="title" x="660" y="312" text-anchor="middle">Classify</text>
+<text class="desc"  x="660" y="338" text-anchor="middle">Tagged five ways</text>
+
+<!-- CARD 4 — REVIEW -->
+<rect x="813" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(919,128)">
+  <rect x="-78" y="-66" width="156" height="120" rx="12" fill="#006d77"/>
+  <rect x="-78" y="-66" width="156" height="26" rx="12" fill="#0a7d86"/><rect x="-78" y="-52" width="156" height="12" fill="#0a7d86"/>
+  <circle cx="-64" cy="-53" r="3.5" fill="#bfe0d6"/><circle cx="-53" cy="-53" r="3.5" fill="#83c5be"/>
+  <text class="chip" x="14" y="-49" text-anchor="middle" font-size="10" fill="#cfe9e0" letter-spacing="0.08em">SEAL COUNTS</text>
+  <!-- count rows -->
+  <g font-size="12" font-weight="700">
+    <g transform="translate(0,-22)"><circle cx="-58" cy="0" r="5" fill="#9fb6bd"/><text x="-46" y="4" fill="#eaf3ef">Grey seal</text><text x="64" y="4" text-anchor="end" fill="#fff">142</text></g>
+    <g transform="translate(0,2)"><circle cx="-58" cy="0" r="5" fill="#cdb487"/><text x="-46" y="4" fill="#eaf3ef">Harbour</text><text x="64" y="4" text-anchor="end" fill="#fff">88</text></g>
+    <g transform="translate(0,26)"><circle cx="-58" cy="0" r="5" fill="#e29578"/><text x="-46" y="4" fill="#eaf3ef">Pups</text><text x="64" y="4" text-anchor="end" fill="#fff">37</text></g>
+  </g>
+  <g transform="translate(40,46)"><rect x="-30" y="-11" width="60" height="22" rx="11" fill="#3fd07a"/><text class="chip" x="0" y="4" text-anchor="middle">Export ✓</text></g>
+</g>
+<text class="step" x="919" y="280" text-anchor="middle">04</text>
+<text class="title" x="919" y="312" text-anchor="middle">Review</text>
+<text class="desc"  x="919" y="338" text-anchor="middle">Checked &amp; exported</text>
+</svg>

--- a/assets/images/projects/wadden_sea_seal_monitoring/diagrams/reid.svg
+++ b/assets/images/projects/wadden_sea_seal_monitoring/diagrams/reid.svg
@@ -1,0 +1,91 @@
+<svg viewBox="0 0 804 380" xmlns="http://www.w3.org/2000/svg" font-family="Mulish, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0e3a4a"/><stop offset="100%" stop-color="#176074"/></linearGradient>
+  <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 1 L9 5 L0 9 Z" fill="#e29578"/></marker>
+  <filter id="cardshadow" x="-20%" y="-20%" width="140%" height="150%"><feDropShadow dx="0" dy="5" stdDeviation="9" flood-color="#1c2b28" flood-opacity="0.08"/></filter>
+  <style>
+    .title { font-family: Newsreader, Georgia, 'Times New Roman', serif; font-size: 26px; font-weight: 600; fill: #161616; }
+    .desc  { font-size: 15px; fill: #60626a; }
+    .step  { font-size: 13px; font-weight: 700; letter-spacing: 0.12em; fill: #e29578; }
+    .chip  { font-size: 12px; font-weight: 700; fill: #fff; }
+    .bar   { animation: barp 2.4s ease-in-out infinite; }
+    .b2{animation-delay:-0.4s}.b3{animation-delay:-0.8s}.b4{animation-delay:-1.2s}.b5{animation-delay:-1.6s}
+    .match { animation: glow 2.4s ease-in-out infinite; }
+    .wsk   { animation: barp 3s ease-in-out infinite; }
+    @keyframes barp { 0%,100%{opacity:0.55} 50%{opacity:1} }
+    @keyframes glow { 0%,100%{opacity:0.6} 50%{opacity:1} }
+    @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+  </style>
+  <!-- seal face: rounded head, eyes, snout, whiskers, coat spots -->
+  <g id="face">
+    <path d="M0 -32 C 22 -32 28 -10 25 9 C 21 29 11 38 0 38 C -11 38 -21 29 -25 9 C -28 -10 -22 -32 0 -32 Z" fill="#828990"/>
+    <g fill="#626a6f" opacity="0.6"><circle cx="-12" cy="-12" r="2.4"/><circle cx="10" cy="-15" r="2"/><circle cx="-5" cy="3" r="2"/><circle cx="14" cy="1" r="2.2"/><circle cx="3" cy="-21" r="1.8"/></g>
+    <ellipse cx="-10" cy="-7" rx="3.8" ry="4.8" fill="#1f2426"/><ellipse cx="10" cy="-7" rx="3.8" ry="4.8" fill="#1f2426"/>
+    <circle cx="-8.6" cy="-9" r="1.1" fill="#fff" opacity="0.85"/><circle cx="11.4" cy="-9" r="1.1" fill="#fff" opacity="0.85"/>
+    <path d="M0 13 C 5 13 6 19 0 21 C -6 19 -5 13 0 13 Z" fill="#2a2f31"/>
+    <g class="wsk" stroke="#e6ebed" stroke-width="1" opacity="0.85" stroke-linecap="round"><path d="M-5 17 L-28 12"/><path d="M-5 19 L-27 20"/><path d="M-5 21 L-25 28"/><path d="M5 17 L28 12"/><path d="M5 19 L27 20"/><path d="M5 21 L25 28"/></g>
+  </g>
+  <!-- a small fingerprint (feature vector as bars) -->
+  <g id="fp"><g fill="#bfe0d6"><rect x="-30" y="-4" width="4" height="8" rx="1"/><rect x="-23" y="-9" width="4" height="18" rx="1"/><rect x="-16" y="-6" width="4" height="12" rx="1"/><rect x="-9" y="-11" width="4" height="22" rx="1"/><rect x="-2" y="-5" width="4" height="10" rx="1"/><rect x="5" y="-10" width="4" height="20" rx="1"/><rect x="12" y="-7" width="4" height="14" rx="1"/><rect x="19" y="-9" width="4" height="18" rx="1"/><rect x="26" y="-4" width="4" height="8" rx="1"/></g></g>
+</defs>
+
+<g stroke="#e29578" stroke-width="3.5" fill="none" stroke-linecap="round">
+  <line x1="250" y1="134" x2="291" y2="134" marker-end="url(#arrow)"/>
+  <line x1="509" y1="134" x2="550" y2="134" marker-end="url(#arrow)"/>
+</g>
+
+<!-- CARD 1 — A FACE -->
+<rect x="36" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(142,128)">
+  <circle r="66" fill="#eef3f1" stroke="#cdd4d6" stroke-width="2"/>
+  <g transform="translate(0,2) scale(1.25)"><use href="#face"/></g>
+</g>
+<text class="step" x="142" y="280" text-anchor="middle">01</text>
+<text class="title" x="142" y="312" text-anchor="middle">A face</text>
+<text class="desc"  x="142" y="338" text-anchor="middle">Unique whiskers &amp; spots</text>
+
+<!-- CARD 2 — A FINGERPRINT -->
+<rect x="295" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(401,128)">
+  <rect x="-78" y="-58" width="156" height="116" rx="14" fill="url(#panel)"/>
+  <!-- tall feature vector / fingerprint -->
+  <g>
+    <rect class="bar"    x="-58" y="-8" width="9" height="16" rx="2" fill="#bfe0d6"/>
+    <rect class="bar b2" x="-44" y="-26" width="9" height="52" rx="2" fill="#83c5be"/>
+    <rect class="bar b3" x="-30" y="-16" width="9" height="32" rx="2" fill="#bfe0d6"/>
+    <rect class="bar b4" x="-16" y="-32" width="9" height="64" rx="2" fill="#e29578"/>
+    <rect class="bar b5" x="-2"  y="-12" width="9" height="24" rx="2" fill="#83c5be"/>
+    <rect class="bar b2" x="12"  y="-28" width="9" height="56" rx="2" fill="#bfe0d6"/>
+    <rect class="bar b3" x="26"  y="-18" width="9" height="36" rx="2" fill="#83c5be"/>
+    <rect class="bar b4" x="40"  y="-24" width="9" height="48" rx="2" fill="#bfe0d6"/>
+  </g>
+  <text class="chip" x="0" y="46" text-anchor="middle" font-size="10" fill="#cfe9e0" letter-spacing="0.1em">FEATURE FINGERPRINT</text>
+</g>
+<text class="step" x="401" y="280" text-anchor="middle">02</text>
+<text class="title" x="401" y="312" text-anchor="middle">A fingerprint</text>
+<text class="desc"  x="401" y="338" text-anchor="middle">The model encodes it</text>
+
+<!-- CARD 3 — A MATCH -->
+<rect x="554" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(660,128)">
+  <rect x="-80" y="-60" width="160" height="120" rx="12" fill="url(#panel)"/>
+  <text class="chip" x="-66" y="-44" font-size="10" fill="#cfe9e0" letter-spacing="0.08em">DATABASE</text>
+  <!-- database rows -->
+  <g transform="translate(0,-22)">
+    <g><rect x="-66" y="-12" width="132" height="22" rx="6" fill="#0a4a55"/><g transform="translate(-40,-1) scale(0.46)"><use href="#fp"/></g><text class="chip" x="40" y="3" text-anchor="end" font-size="11" fill="#9fc3c0">#017</text></g>
+  </g>
+  <g transform="translate(0,8)" class="match">
+    <rect x="-68" y="-13" width="136" height="24" rx="6" fill="#0a7d86" stroke="#3fd07a" stroke-width="2.5"/>
+    <g transform="translate(-40,-1) scale(0.46)"><use href="#fp"/></g>
+    <text class="chip" x="30" y="3" text-anchor="end">#042</text>
+    <circle cx="50" cy="0" r="9" fill="#3fd07a"/><path d="M46 0 L49 3 L54 -3" stroke="#fff" stroke-width="1.8" fill="none"/>
+  </g>
+  <g transform="translate(0,38)">
+    <g><rect x="-66" y="-12" width="132" height="22" rx="6" fill="#0a4a55"/><g transform="translate(-40,-1) scale(0.46)"><use href="#fp"/></g><text class="chip" x="40" y="3" text-anchor="end" font-size="11" fill="#9fc3c0">#103</text></g>
+  </g>
+  <g transform="translate(0,56)"><rect x="-40" y="-10" width="80" height="20" rx="10" fill="#15463f"/><text class="chip" x="0" y="4" text-anchor="middle" font-size="11">0.97 match</text></g>
+</g>
+<text class="step" x="660" y="280" text-anchor="middle">03</text>
+<text class="title" x="660" y="312" text-anchor="middle">A match</text>
+<text class="desc"  x="660" y="338" text-anchor="middle">Same seal, seasons later</text>
+</svg>

--- a/assets/images/projects/wadden_sea_seal_monitoring/diagrams/reid.svg
+++ b/assets/images/projects/wadden_sea_seal_monitoring/diagrams/reid.svg
@@ -59,7 +59,7 @@
     <rect class="bar b3" x="26"  y="-18" width="9" height="36" rx="2" fill="#83c5be"/>
     <rect class="bar b4" x="40"  y="-24" width="9" height="48" rx="2" fill="#bfe0d6"/>
   </g>
-  <text class="chip" x="0" y="46" text-anchor="middle" font-size="10" fill="#cfe9e0" letter-spacing="0.1em">FEATURE FINGERPRINT</text>
+  <text class="chip" x="0" y="46" text-anchor="middle" font-size="10" fill="#cfe9e0" letter-spacing="0.06em">FINGERPRINT</text>
 </g>
 <text class="step" x="401" y="280" text-anchor="middle">02</text>
 <text class="title" x="401" y="312" text-anchor="middle">A fingerprint</text>

--- a/assets/sass/4-layouts/_project-single.scss
+++ b/assets/sass/4-layouts/_project-single.scss
@@ -256,3 +256,13 @@ $project-cta-gap: 56px;
 @media (prefers-reduced-motion: reduce) {
   .post__content .threats__chip { transition: none; }
 }
+
+// Card/component titles inside the article column are headings (<h3>/<h4>), so
+// they'd otherwise inherit the article's heading top-margin (.post__content h3
+// = 1.5em) and sit pushed down from the card top. Keep them flush to the top.
+.post__content {
+  .support__card-title,
+  .services__item-title {
+    margin-top: 0;
+  }
+}

--- a/content/projects/wadden_sea_seal_monitoring.md
+++ b/content/projects/wadden_sea_seal_monitoring.md
@@ -98,11 +98,10 @@ Doing this well, by hand, is genuinely hard. Tap each challenge to see why.
 
 ## Two systems working together
 
-In partnership with Wageningen Marine Research, we built two AI systems that
-work side by side for grey seals (*Halichoerus grypus*) and harbour seals
-(*Phoca vitulina*): one that **counts and classifies** every seal in a photo,
-and one that **recognises individuals** over time. Both feed a web app where
-researchers review the AI's work and export validated data for analysis.
+Two AI systems work side by side, across both grey seals (*Halichoerus grypus*)
+and harbour seals (*Phoca vitulina*): one **counts and classifies** every seal
+in a photo, the other **recognises individuals** over time. Both feed a single
+web app where researchers check the AI's work and export validated data.
 
 ## Counting and classifying every seal
 
@@ -202,8 +201,8 @@ Recognising individuals over time turns a population count into a living record:
 
 The system has reshaped the work at Wageningen Marine Research. Analysis that
 once took hundreds of hours now takes a fraction of the time, and the counts are
-more consistent from one survey year to the next. Researchers spend their effort
-on biology and conservation strategy instead of data entry — and the
+more consistent from one survey year to the next. Researchers can focus on
+biology and conservation strategy instead of data entry — and the
 re-identification system opens an entirely new, individual-level view of seal
 life that simply wasn't possible before. The same framework can extend to other
 colonies, regions, or marine-mammal species.

--- a/content/projects/wadden_sea_seal_monitoring.md
+++ b/content/projects/wadden_sea_seal_monitoring.md
@@ -1,6 +1,14 @@
 ---
 title: Wadden Sea Seal Monitoring
 summary: Automated seal population monitoring system using AI to count, classify, and identify individual seals from aerial imagery in the Wadden Sea.
+tagline: Counting, classifying and recognising individual seals from aerial surveys of the Wadden Sea.
+stats:
+  - value: "2"
+    label: seal species
+  - value: "5"
+    label: attributes per seal
+  - value: "90%"
+    label: less manual work
 clients:
   - name: Wageningen Marine Research
     link: https://www.wur.nl/en/Research-Results/Research-Institutes/marine-research.htm
@@ -13,13 +21,38 @@ tools:
   - Computer Vision
   - Machine Learning
   - Deep Learning
+challenges:
+  - name: Labour-intensive
+    desc: "Counting and classifying thousands of seals across aerial photos takes hundreds of researcher-hours every survey season."
+  - name: Five attributes at once
+    desc: "Each seal has to be recorded by species, life stage, position, vitality and sex — all at the same time."
+  - name: Breeding-season counts
+    desc: "Accurate pup counts and sex ratios during the breeding season are vital for population health, yet hard to get by hand."
+  - name: Variable imagery
+    desc: "Aerial photos vary in lighting, angle, resolution and seal density, demanding expert judgement for every call."
+  - name: Tracking individuals
+    desc: "Understanding movement and site fidelity needs a way to recognise individual seals — without tagging them."
+  - name: Consistency over years
+    desc: "Keeping counting standards stable across seasons and different observers is hard without automation."
 status: completed
 date: 2025-11-24
 pinned: true
 image: /images/projects/wadden_sea_seal_monitoring/cover.jpg
 ---
 
-The Wadden Sea, a UNESCO World Heritage Site stretching between the Netherlands and Denmark, hosts critical breeding colonies of grey seals and harbour seals. Understanding the health and dynamics of these populations is essential for marine conservation efforts in the region. Research teams at Wageningen Marine Research conduct aerial surveys multiple times annually, photographing seal colonies from aircraft to monitor population trends, age structure, and reproductive success.
+The Wadden Sea — a UNESCO World Heritage Site spanning the Dutch, German and
+Danish coasts — is one of Europe's most important nurseries for grey seals and
+harbour seals. To track the health of those colonies, researchers at
+[Wageningen Marine Research](https://www.wur.nl/en/Research-Results/Research-Institutes/marine-research.htm)
+photograph them from light aircraft several times a year, building a record of
+population size, age structure and breeding success.
+
+But turning those photos into numbers has meant hundreds of hours of painstaking
+work — counting and classifying every seal by hand. Together with Wageningen
+Marine Research and [Lumax AI](https://lumax.ai/), we built an AI system that
+does it automatically: it **detects, counts and classifies** every seal in an
+aerial image, and even **recognises individuals** by their natural markings —
+freeing researchers to spend their time on the science.
 
 {{< image_carousel id="wadden-sea-intro" >}}
   {{< carousel_image src="/images/projects/wadden_sea_seal_monitoring/wadden-sea.jpg" alt="Aerial view of the Wadden Sea" caption="The Wadden Sea, a UNESCO World Heritage Site, features extensive tidal flats and sandbanks that serve as critical haul-out sites for seal colonies." >}}
@@ -27,149 +60,157 @@ The Wadden Sea, a UNESCO World Heritage Site stretching between the Netherlands 
   {{< carousel_image src="/images/projects/wadden_sea_seal_monitoring/wadden-sea-map.png" alt="Map of the Wadden Sea" caption="The Wadden Sea stretches along the coasts of the Netherlands, Germany, and Denmark." >}}
 {{< /image_carousel >}}
 
-However, analyzing these aerial images has traditionally been an enormously time-consuming task. Researchers spend hundreds of hours manually counting and classifying individual seals across thousands of photographs, identifying species, life stages, positions, and vital status. This tedious work leaves limited time for the higher-level biological analysis and statistical modeling that drives conservation decisions.
+From a survey flight to a validated count, the system runs in four steps:
 
-We partnered with Wageningen Marine Research to develop an end-to-end AI-powered system that automates the detection, counting, and classification of seals from aerial imagery. The system employs advanced computer vision models to handle five distinct classification tasks, coupled with a seal re-identification capability that enables long-term tracking of individual animals. Researchers now use an intuitive web application to review and refine AI predictions, dramatically reducing manual workload while maintaining scientific rigor.
+![From an aerial survey to a seal census — detect every seal, classify it five ways, and review the counts](/images/projects/wadden_sea_seal_monitoring/diagrams/pipeline.svg)
+*Aircraft photograph the colony; a model finds every seal, classifies each one
+five ways, and the counts are reviewed and exported in a web app.*
 
-## Vital for Marine Ecosystems
+## Why seals matter
 
-Seals play crucial roles in the Wadden Sea ecosystem and serve as important indicators of marine environmental health:
+Seals sit near the top of the Wadden Sea food web, which makes them a sensitive
+barometer for the health of the whole ecosystem.
 
-- **Apex predators**: Maintain balance in fish populations and marine food webs through selective predation
-- **Ecosystem health indicators**: Population trends reflect broader changes in marine ecosystem quality and prey availability
-- **Nutrient cycling**: Transfer nutrients between offshore feeding grounds and coastal haul-out sites
-- **Biodiversity support**: Contribute to the ecological complexity of the UNESCO World Heritage Site
-- **Scientific value**: Long-term monitoring provides data for understanding climate change impacts on marine mammals
-- **Economic and cultural importance**: Support eco-tourism and represent iconic species of European coastal heritage
+<div class="support__grid">
 
-## Conservation and Monitoring Challenges
+  <div class="support__card">
+    <h3 class="support__card-title">Apex predators</h3>
+    <p class="support__card-description">As top predators they help keep fish populations and the wider marine food web in balance.</p>
+  </div>
 
-Effective seal population management in the Wadden Sea faces several challenges:
+  <div class="support__card">
+    <h3 class="support__card-title">Health indicators</h3>
+    <p class="support__card-description">Their numbers rise and fall with prey availability and water quality, so population trends reveal the state of the whole ecosystem.</p>
+  </div>
 
-- **Labor-intensive surveys**: Manual counting and classification of thousands of seals across aerial photographs requires hundreds of researcher hours per survey season
-- **Multi-attribute monitoring**: Researchers must simultaneously record species (grey vs harbour), life stage (adult vs pup), position (on land vs in water), vitality (alive vs dead), and sex (male vs female)
-- **Seasonal breeding dynamics**: Precise pup counts and sex ratios during breeding season are critical for understanding population health but difficult to obtain manually
-- **Image quality variation**: Aerial photographs vary in lighting, angle, resolution, and seal density, requiring expert judgment for accurate classification
-- **Individual tracking needs**: Understanding movement patterns, site fidelity, and individual life histories requires non-invasive identification methods
-- **Long-term data consistency**: Maintaining standardized counting protocols across years and different observers is challenging without automated assistance
+  <div class="support__card">
+    <h3 class="support__card-title">Biodiversity &amp; heritage</h3>
+    <p class="support__card-description">Iconic animals of this World Heritage Site, seals support eco-tourism, and long-term monitoring tracks how climate change is reshaping coastal life.</p>
+  </div>
 
-## How Automated Monitoring Helps Conservation
+</div>
 
-An AI-powered seal monitoring system addresses these challenges and amplifies conservation impact:
+## The monitoring challenge
 
-- **Increased efficiency**: Automated detection and classification reduces analysis time from hundreds of hours to a fraction, enabling more frequent surveys
-- **Standardized methodology**: Consistent AI-driven classification reduces observer bias and improves data comparability across years
-- **Enhanced accuracy**: Deep learning models trained on thousands of examples can detect subtle differences and reduce counting errors
-- **Focus on biology**: Researchers spend less time on tedious counting and more time on ecological interpretation and conservation strategy
-- **Individual life histories**: Re-identification capabilities enable tracking of individual seals across seasons and years, revealing movement patterns and survival rates
-- **Scalable monitoring**: The system can process large image datasets quickly, enabling expansion to additional colonies and more comprehensive coverage
+Doing this well, by hand, is genuinely hard. Tap each challenge to see why.
 
-## Project Scope and Objectives
+{{< threats "challenges" >}}
 
-In partnership with Wageningen Marine Research, we developed a comprehensive monitoring solution for two seal species in the Wadden Sea: grey seals (*Halichoerus grypus*) and harbour seals (*Phoca vitulina*). The project delivers two integrated AI systems working in tandem:
+## Two systems working together
 
-**Multi-Classifier Detection System**: Automatically processes aerial images to detect all seals and classify them across five critical attributes:
-- **Species**: Grey seal vs harbour seal
-- **Life stage**: Adult vs pup
-- **Location**: On land (haul-out) vs swimming in water
-- **Vitality**: Alive vs dead
-- **Sex**: Male vs female
+In partnership with Wageningen Marine Research, we built two AI systems that
+work side by side for grey seals (*Halichoerus grypus*) and harbour seals
+(*Phoca vitulina*): one that **counts and classifies** every seal in a photo,
+and one that **recognises individuals** over time. Both feed a web app where
+researchers review the AI's work and export validated data for analysis.
 
-**Seal Re-Identification System**: Employs advanced computer vision to identify individual seals based on unique whisker patterns and facial features, enabling non-invasive long-term tracking without physical tagging.
+## Counting and classifying every seal
 
-Both systems integrate into a web application where researchers review AI predictions, make corrections when needed, and export validated data for statistical analysis.
+The first system starts with a **detector** that finds every seal in an aerial
+photo — even animals that are partly submerged, overlapping, or caught in
+awkward light. It then classifies each one five different ways:
 
-## Developed Tools: Multi-Classifier Detection System
+<div class="support__grid">
 
-### Detection and Classification Pipeline
+  <div class="support__card">
+    <h3 class="support__card-title">Species</h3>
+    <p class="support__card-description">Grey or harbour seal — told apart by size, head shape and coat. Grey seals are larger with longer snouts; harbour seals are rounder and spotted.</p>
+  </div>
 
-![Detection Pipeline](/images/projects/wadden_sea_seal_monitoring/seals/pipeline-detection-classification.png)
-*Overview of the multi-classifier detection pipeline from aerial imagery to classified seal counts*
+  <div class="support__card">
+    <h3 class="support__card-title">Life stage</h3>
+    <p class="support__card-description">Adult or pup. Pup counts during the breeding season drive birth-rate and population-growth estimates.</p>
+  </div>
 
-The detection system operates in multiple stages:
+  <div class="support__card">
+    <h3 class="support__card-title">Location</h3>
+    <p class="support__card-description">Hauled out on land or swimming in the water — a window into habitat use and behaviour.</p>
+  </div>
 
-**1. Seal Detection**: A deep learning object detection model scans aerial photographs to locate all individual seals, regardless of density, overlap, or positioning. The model handles challenging conditions including partially submerged animals, varying lighting, and different camera angles.
+  <div class="support__card">
+    <h3 class="support__card-title">Vitality</h3>
+    <p class="support__card-description">Alive or dead, so mortality can be monitored — especially important through the breeding season.</p>
+  </div>
 
-**2. Multi-Attribute Classification**: Once detected, each seal is processed through five specialized classification heads:
+  <div class="support__card">
+    <h3 class="support__card-title">Sex</h3>
+    <p class="support__card-description">Male or female, where it can be told — feeding the sex ratios that inform breeding biology and population structure.</p>
+  </div>
 
-- **Species Classifier**: Distinguishes grey seals from harbour seals based on body size, head shape, and coloration patterns. Grey seals are larger with more elongated snouts, while harbour seals have rounder heads and spotted coats.
-- **Life Stage Classifier**: Identifies adults versus pups based on size ratios and, during breeding season, proximity to larger adults. Pup counts are critical for calculating birth rates and population growth.
-- **Location Classifier**: Determines whether seals are hauled out on land/sandbanks or swimming in shallow water. This helps understand habitat use and behavior patterns.
-- **Vitality Classifier**: Detects deceased individuals, which is important for mortality monitoring and understanding causes of death during breeding season.
-- **Sex Classifier**: Differentiates males from females based on size dimorphism and, when visible, secondary sexual characteristics. Sex ratios inform breeding biology and population structure analyses.
+</div>
 
-### Web Application for Review and Validation
+Every prediction lands in a web app that keeps researchers firmly in control:
+detected seals are drawn with colour-coded labels for all five attributes,
+uncertain cases are flagged for a closer look, any label can be fixed (or a
+missed seal added) in one click, and the validated counts export straight to a
+spreadsheet.
 
 {{< image_carousel id="webapp-review" items="2" >}}
-  {{< carousel_image src="/images/projects/wadden_sea_seal_monitoring/seals/webapp-screen-2.png" alt="Web Application Review Interface" caption="Researchers review and validate AI predictions through an intuitive web interface" >}}
-  {{< carousel_image src="/images/projects/wadden_sea_seal_monitoring/seals/webapp-screen-3.png" alt="Web Application Review Interface" caption="Researchers review and validate AI predictions through an intuitive web interface" >}}
-  {{< carousel_image src="/images/projects/wadden_sea_seal_monitoring/seals/webapp-detour-screen-2.png" alt="Web Application Review detouring tools" caption="Web application tools for reviewing and adjusting AI predictions" >}}
+  {{< carousel_image src="/images/projects/wadden_sea_seal_monitoring/seals/webapp-screen-2.png" alt="Web Application Review Interface" caption="Researchers review and validate AI predictions through an intuitive web interface." >}}
+  {{< carousel_image src="/images/projects/wadden_sea_seal_monitoring/seals/webapp-screen-3.png" alt="Web Application Review Interface" caption="Every detection can be checked, corrected, and confirmed before the counts are exported." >}}
+  {{< carousel_image src="/images/projects/wadden_sea_seal_monitoring/seals/webapp-detour-screen-2.png" alt="Web Application Review detouring tools" caption="Tools for adjusting AI predictions and adding any seals the model missed." >}}
 {{< /image_carousel >}}
 
-The web application provides researchers with powerful tools to interact with AI predictions:
+## Recognising individual seals
 
-- **Visual Overlay**: Detected seals are highlighted with bounding boxes and color-coded labels showing all five classification attributes
-- **Batch Review**: Researchers can quickly scan through hundreds of detections, focusing attention on uncertain predictions flagged by the model
-- **One-Click Corrections**: Simple interface to update any classification attribute or add missed seals that the model failed to detect
-- **Confidence Scoring**: Model displays confidence levels for each prediction, helping researchers prioritize quality control efforts
-- **Export Functionality**: Validated data exports to spreadsheets and databases for integration with existing research workflows
+Tracking individual animals usually means tagging them — capture, handling,
+stress for the seal and logistics for the team. Our second system avoids all of
+that. Seals carry **stable, distinctive markings** — whisker spots, coat
+patterns, facial features — that stay with them for life, so the AI can
+recognise an individual from a photo alone, the way facial recognition works for
+people.
 
-## Developed Tools: Seal Re-Identification System
+![How seal re-identification works — a face becomes a unique fingerprint that is matched against a database of known individuals](/images/projects/wadden_sea_seal_monitoring/diagrams/reid.svg)
+*The model turns each seal's face into a compact "fingerprint", then compares it
+against a database of known individuals to find the best match.*
 
-### Non-Invasive Individual Tracking
-
-Traditional methods for tracking individual marine mammals often involve physical tags, which require capture and handling—stressful for animals and logistically challenging for researchers. Our seal re-identification system provides a completely non-invasive alternative by recognizing unique natural markings.
-
-Seals possess stable, distinctive whisker patterns and facial features that remain consistent across their lifetimes. Similar to human facial recognition or the spot patterns used in trout identification, these natural markers enable AI-powered individual identification from photographs alone.
-
-### Re-Identification Pipeline
-
-![Re-Identification Pipeline](/images/projects/wadden_sea_seal_monitoring/reid/pipeline.png)
-*Two-stage re-identification pipeline: feature extraction followed by similarity matching against database*
-
-The seal re-identification system operates in two stages:
-
-**1. Feature Extraction**: A deep learning model processes cropped seal face images to extract high-dimensional feature embeddings that capture unique whisker configurations, facial markings, and head shape characteristics. These embeddings are designed to remain stable across different poses, lighting conditions, and image quality.
-
-**2. Similarity Matching**: When a new seal is photographed, its embedding is compared against a database of known individuals using cosine similarity or Euclidean distance metrics. The system returns the top-k most similar matches with confidence scores, allowing researchers to confirm identity or register a new individual.
-
-### Example Matches and Unique Features
+When a new photo comes in, the model condenses the seal's face into that
+fingerprint and compares it with every seal already on file, returning the
+closest matches for a researcher to confirm — or registering a brand-new
+individual. The matches below were all made this way, from natural markings
+alone:
 
 {{< image_carousel id="seal-reid-matches" >}}
-  {{< carousel_image src="/images/projects/wadden_sea_seal_monitoring/reid/match_different_seasons.png" alt="Same seal photographed in different seasons" caption="The same individual seal successfully re-identified across different survey seasons, demonstrating the system's ability to track seals over time." shadow="false" rounded="false" >}}
-  {{< carousel_image src="/images/projects/wadden_sea_seal_monitoring/reid/match_whisker_patterns.png" alt="Matching whisker patterns between sightings" caption="Re-identification based on unique whisker spot patterns that remain stable throughout a seal's lifetime." shadow="false" rounded="false" >}}
-  {{< carousel_image src="/images/projects/wadden_sea_seal_monitoring/reid/match_spot_patterns.png" alt="Matching spot patterns between sightings" caption="Distinctive spot patterns on the seal's coat provide reliable identification markers across different photographs." shadow="false" rounded="false" >}}
-  {{< carousel_image src="/images/projects/wadden_sea_seal_monitoring/reid/match_facial_patterns.png" alt="Matching facial patterns between sightings" caption="Facial feature matching identifies the same individual seal using unique head shape and marking patterns." shadow="false" rounded="false" >}}
+  {{< carousel_image src="/images/projects/wadden_sea_seal_monitoring/reid/match_different_seasons.png" alt="Same seal photographed in different seasons" caption="The same individual seal, re-identified across different survey seasons." shadow="false" rounded="false" >}}
+  {{< carousel_image src="/images/projects/wadden_sea_seal_monitoring/reid/match_whisker_patterns.png" alt="Matching whisker patterns between sightings" caption="A match made on unique whisker-spot patterns, which stay stable for life." shadow="false" rounded="false" >}}
+  {{< carousel_image src="/images/projects/wadden_sea_seal_monitoring/reid/match_spot_patterns.png" alt="Matching spot patterns between sightings" caption="Distinctive coat spots provide reliable identification markers across photos." shadow="false" rounded="false" >}}
+  {{< carousel_image src="/images/projects/wadden_sea_seal_monitoring/reid/match_facial_patterns.png" alt="Matching facial patterns between sightings" caption="Facial features — head shape and markings — identify the same individual." shadow="false" rounded="false" >}}
 {{< /image_carousel >}}
 
-### Conservation Insights from Re-Identification
+Recognising individuals over time turns a population count into a living record:
 
-Tracking individual seals over time unlocks powerful conservation insights:
+<div class="support__grid">
 
-- **Site Fidelity**: Understanding which individuals return to the same haul-out sites year after year versus those that move between colonies
-- **Movement Patterns**: Mapping how seals distribute across the Wadden Sea throughout different seasons and life stages
-- **Survival Rates**: Calculating individual survival probabilities by tracking re-sightings across multiple survey years
-- **Reproductive Success**: Identifying individual females and tracking their pupping success over time
-- **Colony Dynamics**: Understanding immigration, emigration, and social structure within breeding colonies
-- **Behavioral Ecology**: Linking individual identification with behavioral observations and habitat use patterns
+  <div class="support__card">
+    <h3 class="support__card-title">Site fidelity &amp; movement</h3>
+    <p class="support__card-description">Which seals return to the same haul-out year after year, and how individuals move across the Wadden Sea between seasons.</p>
+  </div>
 
-This individual-level data complements population-wide counts to provide a comprehensive picture of Wadden Sea seal ecology and conservation status.
+  <div class="support__card">
+    <h3 class="support__card-title">Survival &amp; reproduction</h3>
+    <p class="support__card-description">Re-sightings across years yield survival rates, and following individual females reveals their pupping success over time.</p>
+  </div>
 
-## Impact and Future Applications
+  <div class="support__card">
+    <h3 class="support__card-title">Colony dynamics</h3>
+    <p class="support__card-description">Immigration, emigration and social structure within breeding colonies come into focus once individuals can be told apart.</p>
+  </div>
 
-The automated seal monitoring system has transformed research workflows at Wageningen Marine Research:
+</div>
 
-- **Time Savings**: Researchers estimate 85-90% reduction in time spent on manual counting and classification tasks
-- **Research Focus**: Scientists now dedicate more effort to biological interpretation, statistical modeling, and conservation recommendations rather than tedious data entry
-- **Improved Data Quality**: Standardized AI classification reduces observer bias and improves consistency across survey years
-- **Expanded Capacity**: The efficiency gains enable processing of larger image datasets and potentially more frequent surveys
-- **Individual Insights**: Re-identification capabilities provide entirely new dimensions of data on seal behavior, movement, and life history
-- **Scalable Framework**: The system architecture can be adapted for seal monitoring in other regions or extended to additional marine mammal species
+## The impact
 
-By combining cutting-edge computer vision with ecological expertise, this project demonstrates how AI can amplify conservation science without replacing the critical judgment and biological knowledge of field researchers.
+The system has reshaped the work at Wageningen Marine Research. Analysis that
+once took hundreds of hours now takes a fraction of the time, and the counts are
+more consistent from one survey year to the next. Researchers spend their effort
+on biology and conservation strategy instead of data entry — and the
+re-identification system opens an entirely new, individual-level view of seal
+life that simply wasn't possible before. The same framework can extend to other
+colonies, regions, or marine-mammal species.
 
-## Try the Seal Re-Identification System
+## Try the seal re-identification system
 
-Experience the re-identification model in action through our interactive demonstration. Upload images of seal faces to see how the system extracts unique features and matches individuals:
+Upload images of seal faces and watch the model extract their features and match
+individuals — right in your browser:
 
 {{< demo_cta >}}

--- a/content/projects/wadden_sea_seal_monitoring.md
+++ b/content/projects/wadden_sea_seal_monitoring.md
@@ -207,9 +207,4 @@ re-identification system opens an entirely new, individual-level view of seal
 life that simply wasn't possible before. The same framework can extend to other
 colonies, regions, or marine-mammal species.
 
-## Try the seal re-identification system
-
-Upload images of seal faces and watch the model extract their features and match
-individuals — right in your browser:
-
 {{< demo_cta >}}

--- a/docs/specs/2026-06-15-seal-page-revamp-design.md
+++ b/docs/specs/2026-06-15-seal-page-revamp-design.md
@@ -1,0 +1,43 @@
+# Wadden Sea Seal Monitoring — Page Revamp
+
+**Date:** 2026-06-15
+**Status:** Approved
+**Base:** latest `origin/main` (worktree `worktree-seal-revamp`). One PR per project page.
+
+## Goal
+
+Rewrite the bullet-heavy seal page into the established hybrid-editorial system (fire/salmon/elephant/smolt): tightened non-technical copy, card grids and interactive pills replacing bullet dumps, two new animated SVG diagrams, hero stats. Keep the real assets (web-app screens, the re-ID example-match carousel, Wadden Sea photos/map).
+
+## Front matter
+
+Add `tagline` + `stats`: `2` seal species · `5` attributes per seal · `90%` less manual work. Tagline: *"Counting, classifying and recognising individual seals from aerial surveys of the Wadden Sea."*
+
+## Body structure
+
+1. **Lede** — tighten the 3 intro paragraphs; keep the intro carousel (Wadden Sea / seals / map). Add **Diagram A** as the overview.
+2. **Why seals matter** ("Vital for Marine Ecosystems", 6 bullets) → 3-card grid (apex predator · ecosystem-health indicator · biodiversity & heritage).
+3. **The monitoring challenge** (6 bullets) → interactive **pills** (`{{< threats "challenges" >}}`): labour-intensive · multi-attribute · breeding-season counts · image-quality variation · individual tracking · long-term consistency.
+4. **Two AI systems** (Project scope) — short intro to the detection/classification system + the re-ID system.
+5. **Counting & classifying** — Diagram A reference; the 5 classification attributes as numbered `.services` columns (Species · Life stage · Location · Vitality · Sex); keep the web-app review carousel; tighten the web-app feature list.
+6. **Recognising individuals** (re-ID) — **Diagram B** + tightened 2-stage explanation; keep the real example-match carousel (whisker/spot/facial). Conservation insights (6 bullets) → 3-card grid.
+7. **Impact** (6 bullets) → tightened prose / small grid (headline already in stats).
+8. **Demo** — `{{< demo_cta >}}`.
+
+## Diagrams (new animated SVG, house teal/coral + warm sand)
+
+New primitives: a top-down **seal** (grey blob with a head), a **sandbank/tidal flat** (tan), an **aircraft** + camera cone, aerial **bounding boxes**, attribute **chips**, a seal **face** (whiskers + spots), a feature **fingerprint** (embedding bars), a **database** stack.
+
+- **Diagram A — `pipeline.svg` "From aerial survey to seal census"** — 4 cards: **Survey** (aircraft photographs the colony) → **Detect** (every seal boxed on the sandbank) → **Classify** (one seal tagged five ways) → **Review** (web-app counts, exported).
+- **Diagram B — `reid.svg` "Recognising an individual"** — 3 cards: **A face** (whisker + spot pattern) → **A fingerprint** (model turns the pattern into an embedding) → **A match** (compared against the database → same individual, e.g. across seasons).
+
+Positioning transform on an outer `<g>`, animation on an inner `<g>`; `prefers-reduced-motion` guard.
+
+## Reuse / non-goals
+
+- Reuse the `threats` pills shortcode, `.services` columns, `support__grid`, `.media-caption`, `demo_cta`, `image_carousel` — all on `main`.
+- Keep the real photographic assets; the existing `pipeline.png` / `reid/pipeline.png` may be retired in favour of the SVGs (decide during build).
+- No template/shortcode changes.
+
+## Verification
+
+- `hugo` builds clean; screenshot hero+stats, both diagrams, pills, columns, carousels; diagrams animate + degrade with reduced motion.


### PR DESCRIPTION
## Summary

Revamps the **Wadden Sea Seal Monitoring** project page into the same hybrid-editorial system as the fire, salmon, elephant and smolt pages — non-technical copy, card grids and interactive pills replacing the long bullet lists, two new animated SVG diagrams, and hero stats. The real photographic assets (web-app screens, the re-ID example matches, Wadden Sea photos/map) are kept.

## What changed

**Two new animated SVG diagrams** (house teal/coral style)
- **Census pipeline** — Survey (aircraft over the haul-out) → Detect (every seal boxed on the sandbank) → Classify (one seal tagged five ways: species · life stage · location · vitality · sex) → Review (web-app counts, exported).
- **Re-identification** — a seal face → a unique feature "fingerprint" → matched against the database (same individual, seasons later).

**Content / consistency with the other pages**
- `tagline` + `stats` (2 species · 5 attributes · 90% less manual work).
- Non-technical copy pass; the bullet-heavy sections tightened.
- **Cards** for why-seals-matter (3), the five classification attributes (5), and the re-ID conservation insights (3).
- **Interactive pills** for the monitoring challenges.
- Kept the real web-app review carousel and the real re-ID example-match carousel (whisker / spot / facial / cross-season).

`hugo` builds clean. The old `pipeline-detection-classification.png` / `reid/pipeline.png` schematic images are superseded by the SVGs (left in the bundle, unused).
