### PR TITLE
style(project): widen single-project column to 1000px

### DIFF
--- a/assets/sass/4-layouts/_project-single.scss
+++ b/assets/sass/4-layouts/_project-single.scss
@@ -128,7 +128,7 @@ $project-live-color: #3fb950;
 //     bar, article, CTA band, partner strip) uses this so their widths and
 //     gutters line up at every breakpoint — including mobile. ---
 .project-single__col {
-  max-width: 780px;
+  max-width: 1000px;
   margin: 0 auto;
   padding-left: $base-spacing-unit;
   padding-right: $base-spacing-unit;


### PR DESCRIPTION
## What

Widen the single-project content column from **780px → 1000px**.

The shared `.project-single__col` controls the width of the facts bar, article body, CTA band, and partner strip on individual project pages. At 780px it read narrow against the full-width hero (1400px `container-wide`) above it.

1000px matches the About page content width, giving figures and SVGs more room while staying centered.

## Verification

- `hugo` clean build succeeds (exit 0)
- Compiled CSS confirms `project-single__col{max-width:1000px;...}`

## Notes

Single-line change in `assets/sass/4-layouts/_project-single.scss`. Because the column is shared, all blocks below the hero stay aligned at every breakpoint.