### PR TITLE
Revamp Coral Reefs Health Monitoring project page

### DIFF
--- a/assets/images/projects/coral_reef_segmentation/diagrams/pipeline.svg
+++ b/assets/images/projects/coral_reef_segmentation/diagrams/pipeline.svg
@@ -1,0 +1,125 @@
+<svg viewBox="0 0 1062 380" xmlns="http://www.w3.org/2000/svg" font-family="Mulish, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="water" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#7fc6cf"/><stop offset="100%" stop-color="#2f7e88"/></linearGradient>
+  <linearGradient id="deep" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#2f7e88"/><stop offset="100%" stop-color="#13505a"/></linearGradient>
+  <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 1 L9 5 L0 9 Z" fill="#e29578"/></marker>
+  <filter id="cardshadow" x="-20%" y="-20%" width="140%" height="150%"><feDropShadow dx="0" dy="5" stdDeviation="9" flood-color="#1c2b28" flood-opacity="0.08"/></filter>
+  <style>
+    .title { font-family: Newsreader, Georgia, 'Times New Roman', serif; font-size: 26px; font-weight: 600; fill: #161616; }
+    .desc  { font-size: 15px; fill: #60626a; }
+    .step  { font-size: 13px; font-weight: 700; letter-spacing: 0.12em; fill: #e29578; }
+    .chip  { font-size: 12px; font-weight: 700; fill: #fff; }
+    .swim  { transform-box: fill-box; transform-origin: 50% 50%; animation: swim 5s ease-in-out infinite; }
+    .sway  { transform-box: fill-box; transform-origin: 50% 100%; animation: sway 3.4s ease-in-out infinite; }
+    .mask  { animation: maskp 2.6s ease-in-out infinite; } .m2{animation-delay:-0.8s} .m3{animation-delay:-1.6s}
+    .ring  { transform-box: fill-box; transform-origin: 50% 50%; animation: dash 2.4s linear infinite; }
+    @keyframes swim { 0%,100%{transform:translate(-6px,0)} 50%{transform:translate(6px,-3px)} }
+    @keyframes sway { 0%,100%{transform:rotate(-4deg)} 50%{transform:rotate(4deg)} }
+    @keyframes maskp { 0%,100%{opacity:0.5} 50%{opacity:1} }
+    @keyframes dash { to { stroke-dashoffset: -16; } }
+    @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+  </style>
+  <!-- coral colonies (local origin at colony base/centre) -->
+  <g id="hardBoulder"><ellipse cx="0" cy="0" rx="20" ry="15" fill="#4f9aa2"/><g stroke="#2f7e88" stroke-width="1.6" fill="none" opacity="0.7"><path d="M-12 -4 Q0 -10 12 -4"/><path d="M-13 2 Q0 -3 13 3"/><path d="M-9 8 Q0 4 10 8"/></g></g>
+  <g id="hardBranch"><g fill="#83c5be"><path d="M-2 14 L-2 -6 Q-2 -16 -10 -20 Q-6 -14 -6 -4 L-6 14 Z"/><path d="M0 14 L0 -10 Q0 -22 6 -26 Q2 -18 4 -8 L4 14 Z"/><path d="M2 14 L2 -2 Q4 -12 12 -14 Q6 -8 8 0 L6 14 Z"/></g></g>
+  <g id="softCoral"><g class="sway" fill="#e29578"><circle cx="0" cy="-2" r="9"/><circle cx="-9" cy="3" r="7"/><circle cx="9" cy="4" r="7"/><circle cx="-3" cy="-12" r="6"/><circle cx="6" cy="-11" r="5"/></g></g>
+  <!-- diver silhouette (faces right), local origin centre -->
+  <g id="diver" fill="#15463f">
+    <ellipse cx="0" cy="0" rx="22" ry="8"/>
+    <circle cx="20" cy="-2" r="7"/><rect x="24" y="-5" width="6" height="5" rx="1.5"/>
+    <path d="M-22 0 L-36 -8 L-30 0 L-36 8 Z"/>
+    <rect x="2" y="6" width="12" height="9" rx="2"/><circle cx="8" cy="10.5" r="3" fill="#7fc6cf"/>
+  </g>
+</defs>
+
+<g stroke="#e29578" stroke-width="3.5" fill="none" stroke-linecap="round">
+  <line x1="250" y1="134" x2="291" y2="134" marker-end="url(#arrow)"/>
+  <line x1="509" y1="134" x2="550" y2="134" marker-end="url(#arrow)"/>
+  <line x1="768" y1="134" x2="809" y2="134" marker-end="url(#arrow)"/>
+</g>
+
+<!-- CARD 1 — CAPTURE -->
+<rect x="36" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(142,128)">
+  <clipPath id="c1"><rect x="-90" y="-84" width="180" height="168" rx="12"/></clipPath>
+  <g clip-path="url(#c1)">
+    <rect x="-90" y="-84" width="180" height="168" fill="url(#water)"/>
+    <!-- seabed corals -->
+    <g transform="translate(-50,60)"><use href="#hardBoulder"/></g>
+    <g transform="translate(2,54)"><use href="#hardBranch"/></g>
+    <g transform="translate(54,64)"><use href="#softCoral"/></g>
+    <!-- diver with camera -->
+    <g class="swim"><g transform="translate(-6,-44) scale(0.9)"><use href="#diver"/></g></g>
+    <!-- camera viewfinder framing the reef -->
+    <g stroke="#fbf6f6" stroke-width="4" fill="none" stroke-linecap="round" opacity="0.9">
+      <path d="M-72 40 L-72 24 L-56 24"/><path d="M56 24 L72 24 L72 40"/><path d="M-72 70 L-72 78 L-56 78"/><path d="M56 78 L72 78 L72 70"/>
+    </g>
+  </g>
+</g>
+<text class="step" x="142" y="280" text-anchor="middle">01</text>
+<text class="title" x="142" y="312" text-anchor="middle">Capture</text>
+<text class="desc"  x="142" y="338" text-anchor="middle">A diver photographs the reef</text>
+
+<!-- CARD 2 — SEGMENT -->
+<rect x="295" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(401,128)">
+  <clipPath id="c2"><rect x="-90" y="-84" width="180" height="168" rx="12"/></clipPath>
+  <g clip-path="url(#c2)">
+    <rect x="-90" y="-84" width="180" height="168" fill="url(#deep)"/>
+    <g transform="translate(-46,6)"><use href="#hardBoulder"/></g>
+    <g transform="translate(14,-22)"><use href="#hardBranch"/></g>
+    <g transform="translate(40,40)"><use href="#softCoral"/></g>
+    <g transform="translate(-34,52) scale(0.8)"><use href="#hardBoulder"/></g>
+    <!-- instance outlines -->
+    <g fill="none" stroke-linecap="round">
+      <ellipse class="mask" cx="-46" cy="6" rx="26" ry="20" stroke="#7fe0d8" stroke-width="2.5" stroke-dasharray="5 4"/>
+      <rect class="mask m2" x="-2" y="-46" width="34" height="46" rx="8" stroke="#7fe0d8" stroke-width="2.5" stroke-dasharray="5 4"/>
+      <circle class="mask m3" cx="40" cy="38" r="22" stroke="#ffb38a" stroke-width="2.5" stroke-dasharray="5 4"/>
+      <ellipse class="mask m2" cx="-34" cy="52" rx="18" ry="13" stroke="#7fe0d8" stroke-width="2.5" stroke-dasharray="5 4"/>
+    </g>
+  </g>
+</g>
+<text class="step" x="401" y="280" text-anchor="middle">02</text>
+<text class="title" x="401" y="312" text-anchor="middle">Segment</text>
+<text class="desc"  x="401" y="338" text-anchor="middle">Each colony outlined</text>
+
+<!-- CARD 3 — CLASSIFY -->
+<rect x="554" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(660,128)">
+  <clipPath id="c3"><rect x="-90" y="-84" width="180" height="168" rx="12"/></clipPath>
+  <g clip-path="url(#c3)"><rect x="-90" y="-84" width="180" height="168" fill="url(#deep)"/></g>
+  <!-- hard coral, teal label -->
+  <g transform="translate(-42,-2) scale(1.2)"><use href="#hardBoulder"/></g>
+  <ellipse cx="-42" cy="-2" rx="30" ry="22" fill="none" stroke="#7fe0d8" stroke-width="2.5"/>
+  <g transform="translate(-42,-40)"><rect x="-30" y="-11" width="60" height="20" rx="10" fill="#13505a"/><text class="chip" x="0" y="4" text-anchor="middle">Hard</text></g>
+  <!-- soft coral, coral label -->
+  <g transform="translate(46,34) scale(1.15)"><use href="#softCoral"/></g>
+  <circle cx="46" cy="34" r="24" fill="none" stroke="#ffb38a" stroke-width="2.5"/>
+  <g transform="translate(46,68)"><rect x="-30" y="-11" width="60" height="20" rx="10" fill="#b85c3c"/><text class="chip" x="0" y="4" text-anchor="middle">Soft</text></g>
+</g>
+<text class="step" x="660" y="280" text-anchor="middle">03</text>
+<text class="title" x="660" y="312" text-anchor="middle">Classify</text>
+<text class="desc"  x="660" y="338" text-anchor="middle">Hard vs soft coral</text>
+
+<!-- CARD 4 — MEASURE -->
+<rect x="813" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(919,128)">
+  <!-- coral-cover donut -->
+  <g transform="translate(0,-14)">
+    <circle r="40" fill="none" stroke="#e4ded3" stroke-width="14"/>
+    <circle class="ring" r="40" fill="none" stroke="#2f9aa2" stroke-width="14" stroke-linecap="round" stroke-dasharray="105 251" transform="rotate(-90)"/>
+    <text x="0" y="-2" text-anchor="middle" font-size="26" font-weight="800" fill="#13505a" font-family="Mulish, Arial, sans-serif">42%</text>
+    <text x="0" y="16" text-anchor="middle" font-size="11" font-weight="700" fill="#60626a">coral cover</text>
+  </g>
+  <!-- trend over years -->
+  <g transform="translate(0,52)">
+    <g stroke="#cdd4d6" stroke-width="1.5"><line x1="-64" y1="6" x2="64" y2="6"/></g>
+    <polyline points="-58,2 -30,-4 -2,-2 26,-10 58,-14" fill="none" stroke="#e29578" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <g fill="#e29578"><circle cx="-58" cy="2" r="3"/><circle cx="-30" cy="-4" r="3"/><circle cx="-2" cy="-2" r="3"/><circle cx="26" cy="-10" r="3"/><circle cx="58" cy="-14" r="3"/></g>
+    <text x="0" y="22" text-anchor="middle" font-size="10" fill="#80838b">tracked over years</text>
+  </g>
+</g>
+<text class="step" x="919" y="280" text-anchor="middle">04</text>
+<text class="title" x="919" y="312" text-anchor="middle">Measure</text>
+<text class="desc"  x="919" y="338" text-anchor="middle">Coral cover, tracked</text>
+</svg>

--- a/assets/images/projects/coral_reef_segmentation/diagrams/segmentation.svg
+++ b/assets/images/projects/coral_reef_segmentation/diagrams/segmentation.svg
@@ -1,0 +1,82 @@
+<svg viewBox="0 0 804 380" xmlns="http://www.w3.org/2000/svg" font-family="Mulish, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="deep" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#2f7e88"/><stop offset="100%" stop-color="#13505a"/></linearGradient>
+  <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 1 L9 5 L0 9 Z" fill="#e29578"/></marker>
+  <filter id="cardshadow" x="-20%" y="-20%" width="140%" height="150%"><feDropShadow dx="0" dy="5" stdDeviation="9" flood-color="#1c2b28" flood-opacity="0.08"/></filter>
+  <style>
+    .title { font-family: Newsreader, Georgia, 'Times New Roman', serif; font-size: 26px; font-weight: 600; fill: #161616; }
+    .desc  { font-size: 15px; fill: #60626a; }
+    .step  { font-size: 13px; font-weight: 700; letter-spacing: 0.12em; fill: #e29578; }
+    .chip  { font-size: 11px; font-weight: 700; fill: #fff; }
+    .synapse { stroke-dasharray: 3 6; animation: flow 0.8s linear infinite; }
+    .node { animation: nodepulse 1.8s ease-in-out infinite; }
+    .n1{animation-delay:-1.5s}.n2{animation-delay:-1.1s}.n3{animation-delay:-0.7s}.n4{animation-delay:-0.3s}
+    .mask { animation: maskp 2.6s ease-in-out infinite; } .m2{animation-delay:-0.9s} .m3{animation-delay:-1.7s}
+    .sway { transform-box: fill-box; transform-origin: 50% 100%; animation: sway 3.4s ease-in-out infinite; }
+    @keyframes flow { to { stroke-dashoffset: -18; } }
+    @keyframes nodepulse { 0%,100%{opacity:0.35} 50%{opacity:1} }
+    @keyframes maskp { 0%,100%{opacity:0.75} 50%{opacity:1} }
+    @keyframes sway { 0%,100%{transform:rotate(-4deg)} 50%{transform:rotate(4deg)} }
+    @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+  </style>
+  <g id="hardBoulder"><ellipse cx="0" cy="0" rx="20" ry="15" fill="#4f9aa2"/><g stroke="#2f7e88" stroke-width="1.6" fill="none" opacity="0.7"><path d="M-12 -4 Q0 -10 12 -4"/><path d="M-13 2 Q0 -3 13 3"/><path d="M-9 8 Q0 4 10 8"/></g></g>
+  <g id="hardBranch"><g fill="#83c5be"><path d="M-2 14 L-2 -6 Q-2 -16 -10 -20 Q-6 -14 -6 -4 L-6 14 Z"/><path d="M0 14 L0 -10 Q0 -22 6 -26 Q2 -18 4 -8 L4 14 Z"/><path d="M2 14 L2 -2 Q4 -12 12 -14 Q6 -8 8 0 L6 14 Z"/></g></g>
+  <g id="softCoral"><g class="sway" fill="#e29578"><circle cx="0" cy="-2" r="9"/><circle cx="-9" cy="3" r="7"/><circle cx="9" cy="4" r="7"/><circle cx="-3" cy="-12" r="6"/><circle cx="6" cy="-11" r="5"/></g></g>
+  <!-- the reef scene, reused in Photo + Map -->
+  <g id="reef">
+    <g transform="translate(-44,6)"><use href="#hardBoulder"/></g>
+    <g transform="translate(16,-20)"><use href="#hardBranch"/></g>
+    <g transform="translate(40,40)"><use href="#softCoral"/></g>
+    <g transform="translate(-36,50) scale(0.8)"><use href="#hardBoulder"/></g>
+  </g>
+</defs>
+
+<g stroke="#e29578" stroke-width="3.5" fill="none" stroke-linecap="round">
+  <line x1="250" y1="134" x2="291" y2="134" marker-end="url(#arrow)"/>
+  <line x1="509" y1="134" x2="550" y2="134" marker-end="url(#arrow)"/>
+</g>
+
+<!-- CARD 1 — PHOTO -->
+<rect x="36" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(142,128)">
+  <clipPath id="c1"><rect x="-84" y="-72" width="168" height="144" rx="12"/></clipPath>
+  <rect x="-84" y="-72" width="168" height="144" rx="12" fill="url(#deep)"/>
+  <g clip-path="url(#c1)"><use href="#reef"/></g>
+</g>
+<text class="step" x="142" y="280" text-anchor="middle">01</text>
+<text class="title" x="142" y="312" text-anchor="middle">Photo</text>
+<text class="desc"  x="142" y="338" text-anchor="middle">A benthic image</text>
+
+<!-- CARD 2 — MODEL -->
+<rect x="295" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(401,128)">
+  <rect x="-66" y="-56" width="132" height="112" rx="14" fill="#006d77"/>
+  <rect x="-66" y="-56" width="132" height="112" rx="14" fill="none" stroke="#0a7d86" stroke-width="3"/>
+  <g fill="#0a7d86"><rect x="-74" y="-30" width="8" height="6" rx="2"/><rect x="-74" y="-6" width="8" height="6" rx="2"/><rect x="-74" y="18" width="8" height="6" rx="2"/><rect x="66" y="-30" width="8" height="6" rx="2"/><rect x="66" y="-6" width="8" height="6" rx="2"/><rect x="66" y="18" width="8" height="6" rx="2"/></g>
+  <g stroke="#83c5be" stroke-width="1.4" opacity="0.6"><g class="synapse"><path d="M-38 -26 L0 -34 M-38 -26 L0 -2 M-38 -26 L0 30 M-38 0 L0 -34 M-38 0 L0 -2 M-38 0 L0 30 M-38 26 L0 -34 M-38 26 L0 -2 M-38 26 L0 30 M0 -34 L40 -16 M0 -34 L40 18 M0 -2 L40 -16 M0 -2 L40 18 M0 30 L40 -16 M0 30 L40 18"/></g></g>
+  <g fill="#bfe0d6"><circle class="node n1" cx="-38" cy="-26" r="6"/><circle class="node n2" cx="-38" cy="0" r="6"/><circle class="node n3" cx="-38" cy="26" r="6"/><circle class="node n4" cx="0" cy="-34" r="6"/><circle class="node n2" cx="0" cy="-2" r="6"/><circle class="node n3" cx="0" cy="30" r="6"/><circle class="node n1" cx="40" cy="-16" r="6"/><circle class="node n4" cx="40" cy="18" r="6"/></g>
+</g>
+<text class="step" x="401" y="280" text-anchor="middle">02</text>
+<text class="title" x="401" y="312" text-anchor="middle">Model</text>
+<text class="desc"  x="401" y="338" text-anchor="middle">The segmentation model</text>
+
+<!-- CARD 3 — MAP -->
+<rect x="554" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(660,128)">
+  <clipPath id="c3"><rect x="-84" y="-72" width="168" height="144" rx="12"/></clipPath>
+  <rect x="-84" y="-72" width="168" height="144" rx="12" fill="url(#deep)"/>
+  <g clip-path="url(#c3)">
+    <use href="#reef"/>
+    <!-- segmentation masks: filled + outlined, hard = teal, soft = coral -->
+    <g class="mask"><ellipse cx="-44" cy="6" rx="24" ry="18" fill="#7fe0d8" opacity="0.4"/><ellipse cx="-44" cy="6" rx="24" ry="18" fill="none" stroke="#7fe0d8" stroke-width="2.5"/></g>
+    <g class="mask m2"><rect x="0" y="-44" width="32" height="44" rx="9" fill="#7fe0d8" opacity="0.4"/><rect x="0" y="-44" width="32" height="44" rx="9" fill="none" stroke="#7fe0d8" stroke-width="2.5"/></g>
+    <g class="mask m3"><circle cx="40" cy="40" r="21" fill="#ffb38a" opacity="0.4"/><circle cx="40" cy="40" r="21" fill="none" stroke="#ffb38a" stroke-width="2.5"/></g>
+    <g class="mask m2"><ellipse cx="-36" cy="50" rx="17" ry="12" fill="#7fe0d8" opacity="0.4"/><ellipse cx="-36" cy="50" rx="17" ry="12" fill="none" stroke="#7fe0d8" stroke-width="2.5"/></g>
+  </g>
+  <!-- cover chip -->
+  <g transform="translate(46,-58)"><rect x="-34" y="-12" width="68" height="22" rx="11" fill="#13505a"/><text class="chip" x="0" y="4" text-anchor="middle">42% cover</text></g>
+</g>
+<text class="step" x="660" y="280" text-anchor="middle">03</text>
+<text class="title" x="660" y="312" text-anchor="middle">Map</text>
+<text class="desc"  x="660" y="338" text-anchor="middle">Each colony mapped</text>
+</svg>

--- a/content/projects/coral_reef_health_monitoring.md
+++ b/content/projects/coral_reef_health_monitoring.md
@@ -1,6 +1,14 @@
 ---
 title: Coral Reefs Health Monitoring
 summary: Segmentation of coral reefs in benthic imagery to quantify the long-term growth or decline of coral cover within marine protected areas.
+tagline: Mapping hard and soft coral in underwater imagery to track reef health over time.
+stats:
+  - value: "25%"
+    label: of marine life
+  - value: "<1%"
+    label: of the seafloor
+  - value: "open-source"
+    label: models
 clients:
   - name: ReefSupport
     link: https://reef.support
@@ -12,203 +20,139 @@ space: /demos/coral_reef_health_monitoring/
 tools:
   - Computer Vision
   - Machine Learning
+pressures:
+  - name: Warming &amp; bleaching
+    desc: "Rising sea temperatures make corals expel their algae and bleach — turning white, weakening, and falling prey to disease. Acidification weakens their skeletons too."
+  - name: Pollution
+    desc: "Runoff, sewage and debris smother corals and feed the algae that compete with them for light and space."
+  - name: Overfishing
+    desc: "Removing grazing fish lets algae overgrow corals, and destructive methods like blast and cyanide fishing damage reefs directly."
+  - name: Coastal development
+    desc: "Dredging, construction and land clearing bury reefs in sediment and nutrient-laden runoff."
+  - name: Unsustainable tourism
+    desc: "Anchoring, trampling and over-visiting fragile sites — and harvesting for souvenirs — wear reefs down."
+  - name: Invasive species
+    desc: "Non-native species outcompete or prey on reef life and reshape the habitat."
+  - name: Weak governance
+    desc: "Limited awareness and patchy enforcement let reef degradation continue unchecked."
 status: completed
 pinned: true
 date: 2024-01-30
 image: /images/projects/coral_reef_segmentation/cover.jpg
 ---
 
-Marine biologists engaged in the study of coral reefs invest a significant
-portion of their time in manually processing data obtained from research dives.
-The objective of this collaboration is to create an image segmentation pipeline
-that accelerates the analysis of such data. This endeavor aims to assist
-conservationists and researchers in enhancing their efforts to protect and
-comprehend these vital ocean ecosystems. Leveraging computer vision for the
-segmentation of coral reefs in benthic imagery holds the potential to quantify
-the long-term growth or decline of coral cover within marine protected areas.
+Coral reefs are among the richest ecosystems on Earth — and among the most
+threatened. Marine biologists track their health by photographing the seabed on
+research dives, but turning thousands of those images into numbers is slow,
+painstaking work, and the reporting lag blunts conservation's ability to respond
+in time.
 
-![Pipeline Overview](/images/projects/coral_reef_segmentation/pipeline_overview.png)
-*Gallery / Benthic Imagery Analysis - __Pipeline Overview__*
+Together with [ReefSupport](https://reef.support), we built a computer-vision
+pipeline that **maps coral in benthic imagery** — outlining and classifying each
+colony automatically — so researchers can measure how coral cover is growing or
+declining across a protected area, far faster than by hand.
 
-Monitoring coral reefs is fundamental for efficient management, with swift
-reporting being critical for timely guidance. Although underwater photography
-has significantly enhanced the precision and pace of data gathering, the
-bottleneck in reporting results persists due to image processing.
+![From a dive photo to coral cover — capture, segment each colony, classify hard vs soft, and measure coral cover over time](/images/projects/coral_reef_segmentation/diagrams/pipeline.svg)
+*A diver photographs the reef; the model outlines and classifies every coral
+colony, and the result becomes a coral-cover figure that can be tracked over
+time.*
 
 > Our tools tap on AI and computer vision for increasing the capabilities of
 > coral reef and marine monitoring in examining benthic/seabed features.
 >
 > <cite>– ReefSupport</cite>
 
-## Coral reefs play a crucial role in maintaining the health of our planet
+## Why coral reefs matter
 
-Coral reefs are incredibly important for several reasons:
+Reefs cover a sliver of the ocean yet underpin a huge share of marine life — and
+the livelihoods of millions of people.
 
-- __Biodiversity Hotspots__: Coral reefs are among the most biodiverse
-ecosystems on the planet, providing a home for an estimated 25% of all marine
-species despite covering less than 1% of the ocean floor. They offer habitat,
-breeding grounds, and shelter for numerous marine organisms, from fish to
-invertebrates.
-- __Economic Value__: Coral reefs support a vast array of industries and
-economies worldwide. They are crucial for fisheries, tourism, and coastal
-protection. Millions of people depend on coral reefs for food, livelihoods, and
-income through activities such as fishing and tourism.
-- __Coastal Protection__: Coral reefs act as natural barriers that help protect
-coastal communities from storms, waves, and erosion. They absorb and dissipate
-wave energy, reducing the impact of storms and protecting shorelines from
-damage.
-- __Carbon Cycling and Climate Regulation__: Coral reefs play a role in the
-global carbon cycle by sequestering carbon dioxide from the atmosphere. They
-also help regulate the Earth's climate by influencing oceanic and atmospheric
-circulation patterns.
-- __Medicinal Resources__: Coral reef organisms produce compounds that have
-potential pharmaceutical applications. These include treatments for cancer,
-pain, and other diseases. Research into coral reef organisms continues to
-uncover new compounds with medicinal properties.
-- __Recreational and Educational Value__: Coral reefs attract millions of
-tourists each year who engage in activities such as snorkeling, diving, and
-reef exploration. These experiences foster appreciation for marine ecosystems
-and can contribute to conservation efforts.
-- __Cultural Importance__: Coral reefs hold significant cultural value for many
-indigenous and coastal communities around the world. They are often central to
-cultural practices, traditions, and spiritual beliefs, serving as important
-symbols of identity and connection to the sea.
+<div class="support__grid">
 
-Overall, coral reefs are not only ecologically significant but also
-economically, socially, and culturally important. Protecting and preserving
-coral reefs is essential for the health of marine ecosystems and the well-being
-of human societies that depend on them.
+  <div class="support__card">
+    <h3 class="support__card-title">Biodiversity hotspots</h3>
+    <p class="support__card-description">Less than 1% of the seafloor, yet home to around 25% of all marine species — habitat, nursery and shelter for countless fish and invertebrates.</p>
+  </div>
 
-## Conservation concerns
+  <div class="support__card">
+    <h3 class="support__card-title">Coastal &amp; economic backbone</h3>
+    <p class="support__card-description">Reefs sustain the fisheries and tourism that millions rely on, and act as natural breakwaters that shield coastlines from storms and erosion.</p>
+  </div>
 
-There are several reasons why coral reef conservation is a matter of concern:
+  <div class="support__card">
+    <h3 class="support__card-title">Climate, medicine &amp; culture</h3>
+    <p class="support__card-description">They help cycle carbon, yield compounds with real medical promise, and hold deep cultural meaning for coastal and Indigenous communities.</p>
+  </div>
 
-- __Climate Change__: Rising sea temperatures due to climate change lead to
-coral bleaching, where corals expel the symbiotic algae living in their
-tissues, causing them to turn white and become more susceptible to disease and
-mortality. Ocean acidification, another consequence of climate change, can also
-weaken coral skeletons, making them more vulnerable to damage.
-- __Pollution__: Pollution from land-based sources, such as agricultural
-runoff, sewage, and marine debris, can smother corals, introduce harmful
-chemicals, and promote the growth of algae that compete with corals for space.
-Chemical pollutants can weaken corals' immune systems and make them more
-susceptible to disease.
-- __Overfishing and Destructive Fishing Practices__: Overfishing of herbivorous
-fish species, such as parrotfish and surgeonfish, can disrupt the delicate
-balance of coral reef ecosystems by allowing algae to overgrow corals.
-Destructive fishing practices, such as blast fishing and cyanide fishing,
-directly damage coral reefs and reduce fish populations.
-- __Coastal Development and Habitat Destruction__: Coastal development,
-including the construction of resorts, ports, and coastal infrastructure, can
-lead to habitat destruction through dredging, sedimentation, and pollution
-runoff. Deforestation and land clearing also contribute to sedimentation and
-nutrient runoff that can harm coral reefs.
-- __Unsustainable Tourism__: Unsustainable tourism practices, such as anchoring
-on reefs, trampling fragile corals, and overuse of snorkeling and diving sites,
-can damage coral reefs and disturb marine life. In some cases, the extraction
-of marine organisms for souvenirs or aquarium trade can also negatively impact
-coral reef ecosystems.
-- __Invasive Species__: Introduction of non-native species, either
-intentionally or accidentally, can disrupt coral reef ecosystems by
-outcompeting native species for resources, preying on native species, or
-altering habitat structure.
-- __Lack of Awareness and Governance__: Limited public awareness about the
-importance of coral reefs and inadequate governance and enforcement of
-conservation measures contribute to continued degradation of coral reef
-ecosystems.
+</div>
 
-Addressing these conservation concerns requires concerted efforts at local,
-national, and international levels, including sustainable management practices,
-marine protected areas, pollution reduction measures, and climate change
-mitigation strategies.
+## Reefs under pressure
 
-## Project Scope and Objectives
+Coral reefs are squeezed by many forces at once — most of them driven, directly
+or indirectly, by people. Tap each to learn more.
 
-Our collaboration aims to pioneer the development of an advanced underwater
-benthic imagery model capable of accurately identifying and localizing various
-functional groups inhabiting reef ecosystems. This model is designed to be
-versatile, adaptable to diverse marine regions worldwide.
+{{< threats "pressures" >}}
 
-Initially, our focus is on distinguishing between hard and soft coral species.
-However, our iterative approach allows for the gradual incorporation of more
-detailed taxonomic classifications as the system matures and gains
-sophistication. By laying a robust foundation with this generalized framework,
-we pave the way for comprehensive reef ecosystem analysis and management.
+## Mapping coral, colony by colony
 
-## Challenges in underwater imagery
+The system is built around **instance segmentation**: rather than just labelling
+a photo, it finds each individual coral colony, traces its exact outline, and
+classifies it. We started with the key distinction — **hard versus soft coral** —
+with the framework designed to grow into finer functional groups and to adapt to
+reefs anywhere in the world.
 
-Computer vision tasks in underwater imagery pose unique challenges that make
-them particularly difficult. Here are some key reasons:
+![How the model maps a reef — a benthic photo runs through the segmentation model, which outlines and labels every coral colony](/images/projects/coral_reef_segmentation/diagrams/segmentation.svg)
+*Instance segmentation traces the exact outline of each colony — hard coral in
+teal, soft coral in orange — rather than just drawing boxes.*
 
-- __Limited Light and Color Variation:__ Underwater environments typically
-   have limited light penetration, leading to reduced visibility and color
-distortion. The attenuation of light in water results in diminished contrast
-and color richness, making it challenging for computer vision models to
-accurately perceive and differentiate objects.
-- __Scattering and Absorption:__ Water causes scattering and absorption of
-   light, which can obscure details and create hazy or blurry images. This
-phenomenon is exacerbated as the distance from the camera increases, impacting
-the clarity of objects in the scene. The scattering of light can also cause
-objects to appear larger or closer than they are.
-- __Complex Backgrounds:__ Underwater scenes often feature intricate and
-   dynamic backgrounds, such as coral reefs, plants, and marine life. The
-complexity of these backgrounds can make it challenging for computer vision
-models to distinguish between the objects of interest and the surrounding
-environment.
-- __Limited Annotated Data:__ Annotating underwater imagery for training
-   machine learning models is a labor-intensive process. The scarcity of large
-and well-annotated datasets specific to underwater scenes makes it difficult to
-train models effectively. Limited training data can lead to challenges in
-achieving robust generalization.
-- __Distinctive Visual Artifacts:__ Underwater imagery may exhibit visual
-   artifacts such as caustics, backscatter, and particulate matter in the
-water. These artifacts can introduce noise and irregularities, impacting the
-performance of computer vision algorithms.
-- __Variable Environmental Conditions:__ Underwater conditions are highly
-   variable, including changes in water clarity, currents, and turbulence.
-These variations can affect the quality and consistency of images, making it
-difficult for models trained on one set of conditions to generalize well across
-different scenarios.
-- __Lack of Standardization:__ Unlike many computer vision tasks on land,
-   there is less standardization in underwater imaging equipment and
-techniques. Different cameras, lighting setups, and environmental conditions
-can lead to a wide range of image characteristics, complicating the development
-of universally applicable models.
+The models are open source and come in a range of sizes that trade speed against
+accuracy, so a survey team can pick the right balance for their hardware and
+their reef.
 
-{{< gallery caption="Gallery / Pictures of coral reefs in different regions across the world" >}}
+![The open-source instance-segmentation model outlining hard and soft corals on real underwater imagery](/images/projects/coral_reef_segmentation/instance_segmentation.png)
+*The open-source model segmenting hard and soft corals on real benthic imagery.*
+
+## Why underwater vision is hard
+
+Reading a reef from a photo is far harder than it looks — water itself works
+against the camera.
+
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Light &amp; colour loss</h3>
+    <p class="support__card-description">Water absorbs and bends light, so underwater images lose contrast and colour and grow hazier the further away the subject is.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Visual noise</h3>
+    <p class="support__card-description">Caustics, backscatter and drifting particles add artifacts, and busy reef backgrounds blur the line between a coral and its surroundings.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Variable &amp; scarce data</h3>
+    <p class="support__card-description">Conditions shift constantly and gear isn't standardised — and well-labelled underwater datasets are rare, which makes models hard to train and to generalise.</p>
+  </div>
+
+</div>
+
+Models are trained on reef imagery from around the world to cope with this
+variety:
+
+{{< gallery caption="Coral reefs photographed in different regions across the world" >}}
   {{< gallery_image src="/images/projects/coral_reef_segmentation/reefs/reef1.jpg" alt="Reef 1 sample" >}}
   {{< gallery_image src="/images/projects/coral_reef_segmentation/reefs/reef2.jpg" alt="Reef 2 sample" >}}
   {{< gallery_image src="/images/projects/coral_reef_segmentation/reefs/reef3.jpg" alt="Reef 3 sample" >}}
   {{< gallery_image src="/images/projects/coral_reef_segmentation/reefs/reef4.jpg" alt="Reef 4 sample" >}}
 {{< /gallery >}}
 
-Addressing these challenges in underwater computer vision requires specialized
-techniques, data augmentation strategies, and innovative algorithms tailored to
-the unique characteristics of underwater imagery. Advances in this field have
-the potential to contribute significantly to marine biology, environmental
-monitoring, and underwater exploration.
-
-## Developed tools
-
-Open source tools were developed during this project. The system
-comprises of a set of Machine Learning models of
-different sizes and accuracy/speed tradeoff that perform
-instance segmentation of hard and soft corals on
-underwater imagery.
-
-![Instance Segmentation](/images/projects/coral_reef_segmentation/instance_segmentation.png)
-*Gallery / Open Source Instance Segmentation AI Model*
-
 ## Conclusion
 
-Harnessing automated benthic analysis systems holds
-promise for quantifying the long-term growth or decline
-of coral cover, offering valuable insights into reef
-health and dynamics.
+Automated benthic analysis turns a reporting bottleneck into fast, repeatable
+measurement — quantifying the long-term growth or decline of coral cover, and
+giving reef managers the timely picture they need to act.
 
-![Benthic Analysis System](/images/projects/coral_reef_segmentation/coral_ai.gif)
-*Gallery / Benthic Imagery Analysis System by <a href="https://reef.support">Reef Support</a>*
-
-One can try out the model from the [live demo]({{< ref "/demos/coral_reef_health_monitoring" >}}).
+![The benthic imagery analysis system in action, by ReefSupport](/images/projects/coral_reef_segmentation/coral_ai.gif)
+*The benthic imagery analysis system in action — courtesy of [ReefSupport](https://reef.support).*
 
 {{< demo_cta >}}

--- a/docs/specs/2026-06-15-coral-page-revamp-design.md
+++ b/docs/specs/2026-06-15-coral-page-revamp-design.md
@@ -1,0 +1,41 @@
+# Coral Reefs Health Monitoring — Page Revamp
+
+**Date:** 2026-06-15
+**Status:** Approved
+**Base:** latest `origin/main` (worktree `worktree-coral-revamp`). One PR per project page.
+
+## Goal
+
+Rewrite the bullet-heavy coral page into the established hybrid-editorial system (fire/salmon/elephant/smolt/seal): tightened non-technical copy, card grids + interactive pills replacing the three big bullet dumps, two new animated SVG diagrams, hero stats. Keep the real assets (reef photo gallery, `instance_segmentation.png`, the `coral_ai.gif` demo).
+
+## Front matter
+
+`tagline` + `stats`: `25%` of marine life · `<1%` of the seafloor · `open-source` models. Tagline: *"Mapping hard and soft coral in underwater imagery to track reef health over time."*
+
+## Body structure
+
+1. **Lede** (tightened) + **Diagram A** + the ReefSupport blockquote.
+2. **Why coral reefs matter** (7 bullets) → 3-card grid (Biodiversity hotspots · Coastal & economic backbone · Climate, medicine & culture).
+3. **Reefs under pressure** (Conservation concerns, 7 bullets) → interactive **pills** (`{{< threats "pressures" >}}`): warming & bleaching · pollution · overfishing · coastal development · unsustainable tourism · invasive species · weak governance.
+4. **Mapping coral, colony by colony** (Project scope + Developed tools) — short intro + **Diagram B** (segmentation close-up) + keep `instance_segmentation.png`; the model maps hard vs soft coral, building toward finer functional groups.
+5. **Why underwater vision is hard** (7 bullets) → 3-card grid (light & colour loss · haze & artifacts · variable conditions / scarce labels) + keep the real **reef gallery**.
+6. **Conclusion** + keep the `coral_ai.gif`; `demo_cta`.
+
+## Diagrams (new animated SVG, house teal/coral)
+
+New primitives: a **reef scene** (hard coral = teal boulder/branching shapes, soft coral = coral-orange bushy shapes, on a blue seabed), instance-segmentation **outlines/masks**, a **diver** with a camera, a **% coral-cover** gauge.
+
+- **Diagram A — `pipeline.svg` "From a dive photo to coral cover"** — 4 cards: **Capture** (diver photographs the reef) → **Segment** (each coral colony outlined) → **Classify** (hard vs soft) → **Measure** (% coral cover, tracked over time).
+- **Diagram B — `segmentation.svg` "Mapping each colony"** — 3 cards: **Photo** (benthic image) → **Model** (reused neural net) → **Map** (each colony outlined and filled, hard teal / soft coral, with a cover %).
+
+Positioning transform on an outer `<g>`, animation on an inner `<g>`; `prefers-reduced-motion` guard.
+
+## Reuse / non-goals
+
+- Reuse `threats` pills, `support__grid`, `.media-caption`, `demo_cta`, `gallery`.
+- Keep the real reef photos, instance_segmentation.png, coral_ai.gif. The existing `pipeline_overview.png` is superseded by Diagram A.
+- No template/shortcode changes.
+
+## Verification
+
+- `hugo` builds clean; screenshot hero+stats, both diagrams, pills, card grids, reef gallery, gif; diagrams animate + degrade with reduced motion.


### PR DESCRIPTION
## Summary

Revamps the **Coral Reefs Health Monitoring** project page into the same hybrid-editorial system as the other project pages — non-technical copy, card grids and interactive pills replacing the three big bullet lists, two new animated SVG diagrams, and hero stats. Keeps the real assets (reef photo gallery, `instance_segmentation.png`, the `coral_ai.gif` demo).

## What changed

**Two new animated SVG diagrams** (house teal/coral style)
- **Pipeline** — Capture (a diver photographs the reef) → Segment (each coral colony outlined) → Classify (hard vs soft) → Measure (a coral-cover % tracked over years).
- **Segmentation close-up** — a benthic photo → the model → each colony outlined and filled (hard = teal, soft = coral) with a cover %.

**Content / consistency**
- `tagline` + `stats` (25% of marine life · <1% of the seafloor · open-source models).
- Non-technical copy pass; the three bullet dumps tightened.
- **Cards** for why-reefs-matter (3) and underwater-vision challenges (3); **interactive pills** for the conservation pressures (7).
- Kept the real reef gallery, the real `instance_segmentation.png` result, and the `coral_ai.gif` demo.

`hugo` builds clean. The old `pipeline_overview.png` is superseded by the pipeline diagram (left in the bundle, unused).

## Note
The `coral_ai.gif` still renders through the image hook (which rasterises it to a static frame, as it did before) — not a regression, but if you'd like it to actually animate on the page I can wire it to bypass the resize hook.
