### PR TITLE
Revamp Trout Identification project page

### DIFF
--- a/assets/images/projects/trout_identification/diagrams/pipeline.svg
+++ b/assets/images/projects/trout_identification/diagrams/pipeline.svg
@@ -1,0 +1,99 @@
+<svg viewBox="0 0 1062 380" xmlns="http://www.w3.org/2000/svg" font-family="Mulish, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="water" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#bfe6e4"/><stop offset="100%" stop-color="#5fb0bb"/></linearGradient>
+  <linearGradient id="troutg" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#9c8638"/><stop offset="55%" stop-color="#c2ad5e"/><stop offset="100%" stop-color="#e0d28a"/></linearGradient>
+  <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0e3a4a"/><stop offset="100%" stop-color="#176074"/></linearGradient>
+  <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 1 L9 5 L0 9 Z" fill="#e29578"/></marker>
+  <filter id="cardshadow" x="-20%" y="-20%" width="140%" height="150%"><feDropShadow dx="0" dy="5" stdDeviation="9" flood-color="#1c2b28" flood-opacity="0.08"/></filter>
+  <style>
+    .title { font-family: Newsreader, Georgia, 'Times New Roman', serif; font-size: 26px; font-weight: 600; fill: #161616; }
+    .desc  { font-size: 15px; fill: #60626a; }
+    .step  { font-size: 13px; font-weight: 700; letter-spacing: 0.12em; fill: #e29578; }
+    .chip  { font-size: 12px; font-weight: 700; fill: #fff; }
+    .swim  { transform-box: fill-box; transform-origin: 50% 50%; animation: swim 3.6s ease-in-out infinite; }
+    .kp    { animation: kpp 2.2s ease-in-out infinite; } .k2{animation-delay:-0.5s}.k3{animation-delay:-1s}.k4{animation-delay:-1.5s}
+    .match { animation: glow 2.4s ease-in-out infinite; }
+    @keyframes swim { 0%,100%{transform:translateX(0)} 50%{transform:translateX(5px)} }
+    @keyframes kpp { 0%,100%{opacity:0.45} 50%{opacity:1} }
+    @keyframes glow { 0%,100%{opacity:0.6} 50%{opacity:1} }
+    @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+  </style>
+  <!-- trout: olive-gold body, black spots, red cutthroat slash (faces right) -->
+  <g id="trout">
+    <path d="M-46 0 L-66 -17 C -57 -7 -57 7 -66 17 Z" fill="#8a7a3a"/>
+    <path d="M-4 13 C 0 23 10 22 13 12 Z" fill="#9a8a44"/>
+    <path d="M-26 12 C -23 19 -14 19 -14 11 Z" fill="#9a8a44"/>
+    <path d="M50 0 C 46 -8 34 -14 18 -16 C 4 -17 -16 -16 -34 -11 C -40 -9 -44 -6 -46 -3 L-46 3 C -44 6 -40 9 -34 11 C -16 16 4 17 18 16 C 34 14 46 8 50 0 Z" fill="url(#troutg)"/>
+    <path d="M20 7 C 24 17 33 16 35 8 Z" fill="#8a7a3a"/>
+    <path d="M2 -15 C 8 -26 19 -24 25 -12 C 16 -16 9 -16 2 -15 Z" fill="#9a8a44"/>
+    <path d="M-30 -11 C -34 -17 -40 -16 -42 -12 C -38 -13 -33 -13 -30 -11 Z" fill="#9a8a44"/>
+    <g fill="#2a2620"><circle cx="-32" cy="-4" r="1.7"/><circle cx="-24" cy="3" r="1.6"/><circle cx="-16" cy="-6" r="1.7"/><circle cx="-9" cy="4" r="1.5"/><circle cx="-2" cy="-7" r="1.6"/><circle cx="3" cy="6" r="1.4"/><circle cx="-20" cy="-1" r="1.4"/><circle cx="-27" cy="6" r="1.3"/><circle cx="-11" cy="-1" r="1.3"/><circle cx="7" cy="-4" r="1.4"/><circle cx="13" cy="3" r="1.3"/><circle cx="-6" cy="-2" r="1.2"/></g>
+    <path d="M24 8 q 8 2 14 1" stroke="#d6452f" stroke-width="2.4" fill="none" stroke-linecap="round"/>
+    <path d="M30 -10 C 26 -3 26 4 30 10" stroke="#8a7a3a" stroke-width="1.4" fill="none" opacity="0.7"/>
+    <circle cx="39" cy="-3" r="3.2" fill="#2a2320"/><circle cx="40.1" cy="-4.1" r="1" fill="#fff"/>
+  </g>
+  <g id="kpmark" stroke="#e29578" stroke-width="1.6"><path d="M-3 0 H3 M0 -3 V3"/></g>
+</defs>
+
+<g stroke="#e29578" stroke-width="3.5" fill="none" stroke-linecap="round">
+  <line x1="250" y1="134" x2="291" y2="134" marker-end="url(#arrow)"/>
+  <line x1="509" y1="134" x2="550" y2="134" marker-end="url(#arrow)"/>
+  <line x1="768" y1="134" x2="809" y2="134" marker-end="url(#arrow)"/>
+</g>
+
+<!-- CARD 1 — PHOTO -->
+<rect x="36" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(142,128)">
+  <rect x="-66" y="-50" width="132" height="100" rx="9" fill="#eef5f2" stroke="#cdd4d6" stroke-width="2"/>
+  <clipPath id="ph"><rect x="-64" y="-48" width="128" height="96" rx="8"/></clipPath>
+  <g clip-path="url(#ph)">
+    <rect x="-64" y="-48" width="128" height="96" fill="url(#water)"/>
+    <g transform="translate(-2,6) rotate(-8)"><g class="swim"><use href="#trout"/></g></g>
+  </g>
+  <g transform="translate(-50,-38)"><circle r="7" fill="#fff" stroke="#e29578" stroke-width="2"/><circle r="3" fill="#e29578"/></g>
+</g>
+<text class="step" x="142" y="280" text-anchor="middle">01</text>
+<text class="title" x="142" y="312" text-anchor="middle">Photo</text>
+<text class="desc"  x="142" y="338" text-anchor="middle">A photo of a trout</text>
+
+<!-- CARD 2 — NORMALIZE -->
+<rect x="295" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(401,128)">
+  <rect x="-78" y="-58" width="156" height="116" rx="12" fill="#f1f5f3"/>
+  <g stroke="#d7e0db" stroke-width="1"><path d="M-78 -20 H78 M-78 20 H78 M-26 -58 V58 M26 -58 V58"/></g>
+  <g transform="translate(0,2)"><use href="#trout"/></g>
+  <g stroke="#83c5be" stroke-width="3" fill="none" stroke-linecap="round">
+    <path d="M-70 -40 L-70 -52 L-58 -52"/><path d="M58 -52 L70 -52 L70 -40"/><path d="M-70 40 L-70 52 L-58 52"/><path d="M58 52 L70 52 L70 40"/>
+  </g>
+</g>
+<text class="step" x="401" y="280" text-anchor="middle">02</text>
+<text class="title" x="401" y="312" text-anchor="middle">Normalize</text>
+<text class="desc"  x="401" y="338" text-anchor="middle">Straightened &amp; cut out</text>
+
+<!-- CARD 3 — KEYPOINTS -->
+<rect x="554" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(660,128)">
+  <rect x="-78" y="-58" width="156" height="116" rx="12" fill="#10303a"/>
+  <g transform="translate(0,2)" opacity="0.5"><use href="#trout"/></g>
+  <!-- keypoint constellation over the spots -->
+  <g stroke="#e29578" stroke-width="1" opacity="0.5" fill="none"><path d="M-32 -4 L-24 3 L-16 -6 L-9 4 L-2 -7 L3 6 L13 3"/></g>
+  <g><g class="kp" transform="translate(-32,-4)"><use href="#kpmark"/></g><g class="kp k2" transform="translate(-24,3)"><use href="#kpmark"/></g><g class="kp k3" transform="translate(-16,-6)"><use href="#kpmark"/></g><g class="kp k4" transform="translate(-9,4)"><use href="#kpmark"/></g><g class="kp k2" transform="translate(-2,-7)"><use href="#kpmark"/></g><g class="kp k3" transform="translate(3,6)"><use href="#kpmark"/></g><g class="kp" transform="translate(13,3)"><use href="#kpmark"/></g></g>
+</g>
+<text class="step" x="660" y="280" text-anchor="middle">03</text>
+<text class="title" x="660" y="312" text-anchor="middle">Keypoints</text>
+<text class="desc"  x="660" y="338" text-anchor="middle">Spot pattern extracted</text>
+
+<!-- CARD 4 — MATCH -->
+<rect x="813" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(919,128)">
+  <rect x="-80" y="-60" width="160" height="120" rx="12" fill="url(#panel)"/>
+  <text class="chip" x="-66" y="-44" font-size="10" fill="#cfe9e0" letter-spacing="0.08em">DATABASE</text>
+  <g transform="translate(0,-22)"><rect x="-66" y="-12" width="132" height="22" rx="6" fill="#0a4a55"/><g stroke="#9fc3c0" stroke-width="1.4" opacity="0.7"><path d="M-52 0 l8 -5 l8 5 l8 -4"/></g><text class="chip" x="48" y="3" text-anchor="end" font-size="11" fill="#9fc3c0">#A07</text></g>
+  <g transform="translate(0,8)" class="match"><rect x="-68" y="-13" width="136" height="24" rx="6" fill="#0a7d86" stroke="#3fd07a" stroke-width="2.5"/><g stroke="#bfe0d6" stroke-width="1.6"><path d="M-54 0 l8 -5 l8 5 l8 -4"/></g><text class="chip" x="34" y="3" text-anchor="end">#A12</text><circle cx="52" cy="0" r="9" fill="#3fd07a"/><path d="M48 0 L51 3 L56 -3" stroke="#fff" stroke-width="1.8" fill="none"/></g>
+  <g transform="translate(0,38)"><rect x="-66" y="-12" width="132" height="22" rx="6" fill="#0a4a55"/><g stroke="#9fc3c0" stroke-width="1.4" opacity="0.7"><path d="M-52 0 l8 -5 l8 5 l8 -4"/></g><text class="chip" x="48" y="3" text-anchor="end" font-size="11" fill="#9fc3c0">#B33</text></g>
+  <g transform="translate(0,56)"><rect x="-44" y="-10" width="88" height="20" rx="10" fill="#15463f"/><text class="chip" x="0" y="4" text-anchor="middle" font-size="11">0.95 match</text></g>
+</g>
+<text class="step" x="919" y="280" text-anchor="middle">04</text>
+<text class="title" x="919" y="312" text-anchor="middle">Match</text>
+<text class="desc"  x="919" y="338" text-anchor="middle">Found in the database</text>
+</svg>

--- a/content/projects/trout_identification.md
+++ b/content/projects/trout_identification.md
@@ -49,7 +49,7 @@ from a photo** — no tags, no handling, no stress to the fish.
 and those keypoints are matched against a database of known fish.*
 
 {{< image_carousel id="trout-intro" items="2" >}}
-  {{< carousel_image src="/images/projects/trout_identification/wct_example.png" alt="Westslope Cutthroat Trout" caption="The Westslope Cutthroat Trout — note the golden body, black spots, and the red slash beneath the jaw that gives it its name." >}}
+  {{< carousel_image src="/images/projects/trout_identification/wct_example.png" alt="Westslope Cutthroat Trout" caption="The Westslope Cutthroat Trout — note the golden body, black spots, and the red slash beneath the jaw that gives it its name." shadow="false" rounded="false" >}}
   {{< carousel_image src="/images/projects/trout_identification/map_elk_river.png" alt="Map of the Elk River" caption="The Elk River, British Columbia, where this trout population is monitored." >}}
 {{< /image_carousel >}}
 
@@ -94,28 +94,21 @@ Each raw photo is **normalized** — the fish is cut out from its background and
 straightened into a standard pose — and its unique spots are extracted as
 **keypoints**. Getting this right is what makes the later matching accurate.
 
-| Original photo | Normalized trout | Extracted keypoints |
-|:-------:|:----------:|:---------:|
-| ![Picture 1](/images/projects/trout_identification/images/raw/1.jpg) | ![Normalized 1](/images/projects/trout_identification/images/normalized/1.webp) | ![Keypoints 1](/images/projects/trout_identification/images/keypoints/1.webp) |
-| ![Picture 2](/images/projects/trout_identification/images/raw/2.jpg) | ![Normalized 2](/images/projects/trout_identification/images/normalized/2.webp) | ![Keypoints 2](/images/projects/trout_identification/images/keypoints/2.webp) |
-| ![Picture 3](/images/projects/trout_identification/images/raw/3.jpg) | ![Normalized 3](/images/projects/trout_identification/images/normalized/3.webp) | ![Keypoints 3](/images/projects/trout_identification/images/keypoints/3.webp) |
-| ![Picture 4](/images/projects/trout_identification/images/raw/4.jpg) | ![Normalized 4](/images/projects/trout_identification/images/normalized/4.webp) | ![Keypoints 4](/images/projects/trout_identification/images/keypoints/4.webp) |
-| ![Picture 5](/images/projects/trout_identification/images/raw/5.jpg) | ![Normalized 5](/images/projects/trout_identification/images/normalized/5.webp) | ![Keypoints 5](/images/projects/trout_identification/images/keypoints/5.webp) |
+{{< gallery caption="A normalized trout — cut out and straightened — and the unique spot pattern extracted from it as keypoints." >}}
+  {{< gallery_image src="/images/projects/trout_identification/images/normalized/1.webp" alt="A trout, normalized and cut out from its background" >}}
+  {{< gallery_image src="/images/projects/trout_identification/images/keypoints/1.webp" alt="The trout's spot pattern extracted as keypoints" >}}
+{{< /gallery >}}
 
 ### Match the spots
 
 The keypoints from a new photo are compared against a database of known trout. A
 strong enough match returns that individual — and its PIT tag and name; a weak
-match means it is a fish we have not seen before, ready to be registered. The
-pairs below show the matcher at work: genuine matches on the left, where the
-spot patterns line up, and non-matches on the right, where they don't.
+match means it is a fish we have not seen before, ready to be registered.
 
-| ✅ Keypoints match | ❌ Keypoints do not match |
-|:-----:|:---------:|
-| ![Match 1](/images/projects/trout_identification/images/matches/match_1.webp) | ![Non Match 1](/images/projects/trout_identification/images/matches/non_match_1.webp) |
-| ![Match 2](/images/projects/trout_identification/images/matches/match_2.webp) | ![Non Match 2](/images/projects/trout_identification/images/matches/non_match_2.webp) |
-| ![Match 3](/images/projects/trout_identification/images/matches/match_3.webp) | ![Non Match 3](/images/projects/trout_identification/images/matches/non_match_3.webp) |
-| ![Match 4](/images/projects/trout_identification/images/matches/match_4.webp) | ![Non Match 4](/images/projects/trout_identification/images/matches/non_match_4.webp) |
+{{< gallery caption="A genuine match (left) — the spot keypoints line up across two photos of the same fish — and a non-match (right), where they don't." >}}
+  {{< gallery_image src="/images/projects/trout_identification/images/matches/match_1.webp" alt="Keypoints matching between two photos of the same trout" >}}
+  {{< gallery_image src="/images/projects/trout_identification/images/matches/non_match_1.webp" alt="Keypoints not matching between two different trout" >}}
+{{< /gallery >}}
 
 ## Conclusion
 

--- a/content/projects/trout_identification.md
+++ b/content/projects/trout_identification.md
@@ -1,6 +1,7 @@
 ---
 title: Trout Identification
 summary: Non-invasive technology for monitoring trout populations using computer vision to accurately identify individual fish.
+tagline: Recognising individual trout by their spot patterns — like fingerprints — without ever touching the fish.
 clients:
   - name: Lumax AI
     link: https://lumax.ai/
@@ -12,6 +13,19 @@ related_posts:
 tools:
   - Machine Learning
   - Computer Vision
+pressures:
+  - name: Habitat loss
+    desc: "Urban development, farming and logging strip away the streamside habitat and clean water these trout depend on."
+  - name: Fragmentation
+    desc: "Dams, roads and other barriers cut populations off from one another, blocking migration and eroding genetic diversity."
+  - name: Pollution
+    desc: "Runoff from farms, industry and towns degrades the water quality these sensitive fish need."
+  - name: Invasive species
+    desc: "Introduced brook and rainbow trout compete with, hybridise with, and prey on the native cutthroat."
+  - name: Climate change
+    desc: "Shifting temperatures and flows warm and reshape the cold, clear streams cutthroat rely on to spawn."
+  - name: Overfishing
+    desc: "Heavy or unsustainable fishing pressure thins local populations and their genetic diversity."
 status: completed
 pinned: true
 date: 2024-12-08
@@ -19,132 +33,68 @@ github_repo: https://github.com/earthtoolsmaker/trout-reid
 image: /images/projects/trout_identification/cover.png
 ---
 
-## Context
+Trout are freshwater members of the salmon family, prized for their vivid colours
+and markings. The **Westslope Cutthroat Trout** — named for the red-orange slash
+under its jaw — is native to the cold, clear streams of British Columbia and the
+northwestern US, and because it is so sensitive to water quality, its health is a
+barometer for the whole stream.
 
-Trouts are freshwater fish belonging to the family Salmonidae, which also
-includes salmon and char. They are found in various habitats, including rivers,
-lakes, and streams, and are known for their vibrant colors and distinctive
-markings.
+Every cutthroat carries something remarkable: a pattern of black spots as unique
+as a fingerprint, and stable for life. Together with [Lumax AI](https://lumax.ai/),
+we built a system that reads those spot patterns to **recognise individual trout
+from a photo** — no tags, no handling, no stress to the fish.
 
-![Westslope Cutthroat Trout](/images/projects/trout_identification/wct_example.png)
-*Gallery / Westslope Cutthroat Trout*
+![From a photo to an identity — normalize the trout, extract its spot-pattern keypoints, and match them against a database](/images/projects/trout_identification/diagrams/pipeline.svg)
+*A photo is straightened and cut out, the trout's unique spots become keypoints,
+and those keypoints are matched against a database of known fish.*
 
-The Westslope Cutthroat Trout (Oncorhynchus clarkii lewisi) is a unique
-subspecies of cutthroat trout native to the freshwater systems of British
-Columbia, Canada, and parts of the northwestern United States. It is one of
-only two cutthroat trout subspecies found naturally in Canada, with distinct
-populations located in Alberta and the Pacific region of British Columbia.
+{{< image_carousel id="trout-intro" items="2" >}}
+  {{< carousel_image src="/images/projects/trout_identification/wct_example.png" alt="Westslope Cutthroat Trout" caption="The Westslope Cutthroat Trout — note the golden body, black spots, and the red slash beneath the jaw that gives it its name." >}}
+  {{< carousel_image src="/images/projects/trout_identification/map_elk_river.png" alt="Map of the Elk River" caption="The Elk River, British Columbia, where this trout population is monitored." >}}
+{{< /image_carousel >}}
 
-Renowned for its striking appearance, the Westslope Cutthroat Trout boasts a
-vibrant golden-yellow body adorned with numerous small black spots,
-complemented by a characteristic red or orange slash beneath its jaw. This
-trout thrives in cold, clear streams, rivers, and lakes, where it plays a
-crucial role in the aquatic ecosystem. Due to its specific habitat
-requirements, the Westslope Cutthroat Trout is often regarded as an important
-indicator of ecosystem health.
+## Why this trout matters
 
-![Elk River](/images/projects/trout_identification/map_elk_river.png)
-*Gallery / Map of the Elk River where the trout population is monitored*
+A native species in cold, clear water, the Westslope Cutthroat is woven through
+the health of its whole stream.
 
-One fascinating aspect of trouts is their stable and unique spot patterns. Just
-like human fingerprints, these patterns can be used to identify individual
-fish. Each trout has a distinct arrangement of spots, which remain consistent
-throughout its life. Researchers and biologists utilize these unique markings
-to study trout populations, monitor their health, and track their movements in
-the wild. This method of identification not only aids in conservation efforts
-but also enhances our understanding of trout behavior and ecology, highlighting
-the importance of these remarkable fish in freshwater ecosystems.
+<div class="support__grid">
 
-![Stable Spot patterns](/images/projects/trout_identification/lightglue/lightglue_matching.png)
-*Gallery / Unique spot patterns are like fingerprints*
+  <div class="support__card">
+    <h3 class="support__card-title">Food-web role</h3>
+    <p class="support__card-description">Both predator and prey — it eats insects and smaller fish, and in turn feeds birds, bears and larger fish, helping keep the web in balance.</p>
+  </div>
 
-## A vital role for the ecosystems
+  <div class="support__card">
+    <h3 class="support__card-title">Indicator species</h3>
+    <p class="support__card-description">Sensitive to water quality and habitat, healthy cutthroat populations signal a healthy stream — and warn early when something is wrong.</p>
+  </div>
 
-The Westslope Cutthroat Trout plays a crucial role in its ecosystem for several reasons:
+  <div class="support__card">
+    <h3 class="support__card-title">Culture &amp; habitat</h3>
+    <p class="support__card-description">It anchors recreational fishing and local economies, cycles nutrients, and its spawning even helps shape the streambed for other species.</p>
+  </div>
 
-- __Biodiversity Support__: As a native species, the Westslope Cutthroat Trout
-contributes to the overall biodiversity of freshwater ecosystems. Its presence
-helps maintain a balanced food web.
-- __Prey and Predator Dynamics__: This trout serves as both a predator and prey
-within its habitat. It feeds on insects, crustaceans, and smaller fish, helping
-to control these populations. In turn, it is a food source for larger
-predators, such as birds of prey, bears, and other fish species.
-- __Nutrient Cycling__: The Westslope Cutthroat Trout contributes to nutrient
-cycling in aquatic ecosystems. As it feeds and excretes waste, it helps to
-recycle nutrients that support the growth of aquatic plants and microorganisms.
-- __Indicator Species__: The health of Westslope Cutthroat Trout populations
-can indicate the overall health of freshwater ecosystems. Their sensitivity to
-changes in water quality and habitat conditions makes them valuable indicators
-for environmental monitoring.
-- __Cultural and Economic Importance__: This trout is significant for local
-communities, particularly for recreational fishing and tourism. Healthy
-populations can support local economies and promote conservation efforts.
-- __Habitat Formation__: The activities of Westslope Cutthroat Trout, such as
-spawning, can influence the physical characteristics of their habitats. Their
-nesting behaviors can help create and maintain suitable environments for other
-aquatic organisms.
+</div>
 
-Overall, the Westslope Cutthroat Trout is vital for maintaining the ecological
-balance and health of freshwater ecosystems in British Columbia and beyond.
+## Under pressure
 
-## Conservation concerns
+In many areas the Westslope Cutthroat is a species of concern, with populations
+in decline. Tap each pressure to learn more.
 
-In some regions, the Westslope Cutthroat Trout is considered a species
-of concern or is listed as threatened or endangered.
+{{< threats "pressures" >}}
 
-Many populations of Westslope Cutthroat Trout have experienced
-significant declines, leading to concerns about their long-term
-viability. The species faces several conservation threats that impact
-its populations and habitats:
+## How the system works
 
-- __Habitat Loss and Degradation__: Urban development, agriculture, and
-logging can lead to the destruction and alteration of natural habitats.
-This includes the loss of riparian zones, which are crucial for
-maintaining water quality and providing shelter.
-- __Habitat Fragmentation__: Habitat fragmentation caused by dams,
-roads, and other barriers can isolate populations, making it difficult
-for them to migrate, breed, and maintain genetic diversity.
-- __Pollution__: Runoff from agricultural practices, industrial
-activities, and urban areas can introduce pollutants into waterways,
-negatively affecting water quality and the health of trout populations.
-- __Invasive Species__: The introduction of non-native fish species,
-such as brook trout and rainbow trout, can lead to competition for
-resources, hybridization, and predation, which threaten the survival of
-Westslope Cutthroat Trout.
-- __Climate Change__: Changes in temperature and precipitation patterns
-can alter stream flows and water temperatures, impacting the habitats
-that Westslope Cutthroat Trout rely on for spawning and growth.
-- __Overfishing__: Unsustainable fishing practices can deplete local
-populations, particularly in areas where fishing pressure is high. This
-can lead to reduced genetic diversity and population declines.
+Recognising a trout takes two steps: prepare the photo, then match the spots.
 
-Overall, addressing these threats and concerns is essential for the
-conservation of the Westslope Cutthroat Trout and the health of the
-ecosystems they inhabit.
+### Prepare the photo
 
-## Developed Tools
+Each raw photo is **normalized** — the fish is cut out from its background and
+straightened into a standard pose — and its unique spots are extracted as
+**keypoints**. Getting this right is what makes the later matching accurate.
 
-### Pipeline Overview
-
-Throughout this project, a variety of tools were developed to
-effectively utilize the unique biomarkers of trouts for enhanced
-identification and monitoring.
-
-![ML Pipeline for Trout Identification](/images/projects/trout_identification/pipeline.png)
-*Gallery / Overview of the ML pipeline developed to identify trouts*
-
-### Preprocessing Stage
-
-The preprocessing stage is meticulously designed to transform a raw
-image of a trout into a normalized, segmented representation of the
-fish. This critical step ensures high accuracy during the subsequent
-identification phase of the pipeline.
-
-The table below illustrates how the preprocessing stage transforms the original
-image into a normalized representation of the trout, allowing for the
-extraction of its unique markings.
-
-| Original Picture | Normalized Trout | Extracted Keypoints |
+| Original photo | Normalized trout | Extracted keypoints |
 |:-------:|:----------:|:---------:|
 | ![Picture 1](/images/projects/trout_identification/images/raw/1.jpg) | ![Normalized 1](/images/projects/trout_identification/images/normalized/1.webp) | ![Keypoints 1](/images/projects/trout_identification/images/keypoints/1.webp) |
 | ![Picture 2](/images/projects/trout_identification/images/raw/2.jpg) | ![Normalized 2](/images/projects/trout_identification/images/normalized/2.webp) | ![Keypoints 2](/images/projects/trout_identification/images/keypoints/2.webp) |
@@ -152,20 +102,13 @@ extraction of its unique markings.
 | ![Picture 4](/images/projects/trout_identification/images/raw/4.jpg) | ![Normalized 4](/images/projects/trout_identification/images/normalized/4.webp) | ![Keypoints 4](/images/projects/trout_identification/images/keypoints/4.webp) |
 | ![Picture 5](/images/projects/trout_identification/images/raw/5.jpg) | ![Normalized 5](/images/projects/trout_identification/images/normalized/5.webp) | ![Keypoints 5](/images/projects/trout_identification/images/keypoints/5.webp) |
 
-### Identification Stage
+### Match the spots
 
-Once the trout image is normalized, the algorithm extracts key
-biomarkers, specifically the unique spot patterns of the trout, and
-compares them against a comprehensive database of known trout. If the
-comparison yields a sufficiently high score, the system identifies the
-fish as a match and retrieves its associated PIT tag and name.
-Conversely, if the comparison score is low, it indicates that the trout
-does not correspond to any entries in the database, and the system
-classifies it as a new individual.
-
-The table below demonstrates the functionality of the matching algorithm using
-the extracted keypoints. On the left, you will find examples of matching pairs,
-while the right side displays examples of non-matching pairs.
+The keypoints from a new photo are compared against a database of known trout. A
+strong enough match returns that individual — and its PIT tag and name; a weak
+match means it is a fish we have not seen before, ready to be registered. The
+pairs below show the matcher at work: genuine matches on the left, where the
+spot patterns line up, and non-matches on the right, where they don't.
 
 | ✅ Keypoints match | ❌ Keypoints do not match |
 |:-----:|:---------:|
@@ -176,18 +119,10 @@ while the right side displays examples of non-matching pairs.
 
 ## Conclusion
 
-In conclusion, a non-invasive trout identification system represents a
-transformative approach to monitoring trout populations effectively and
-sustainably. By utilizing unique spot patterns and other distinguishing
-features, researchers can gather critical data without disturbing the
-fish or their habitats. The advancement of these techniques not only
-enhances our understanding of trout ecology but also supports targeted
-conservation efforts. As we strive to protect and preserve aquatic
-ecosystems worldwide, such innovative methods will play a vital role in
-ensuring the long-term survival of trout species and the health of the
-environments they inhabit.
-
-One can try out the model from the [live demo]({{< ref
-"/demos/trout_identification" >}}).
+Reading a trout by its spots turns population monitoring into something fast,
+repeatable and completely non-invasive — gathering the data researchers need
+without ever disturbing the fish or their habitat. As pressure on freshwater
+ecosystems grows, methods like this help track individual trout over time and
+target conservation where it matters most.
 
 {{< demo_cta >}}

--- a/docs/specs/2026-06-15-trout-page-revamp-design.md
+++ b/docs/specs/2026-06-15-trout-page-revamp-design.md
@@ -1,0 +1,39 @@
+# Trout Identification — Page Revamp
+
+**Date:** 2026-06-15
+**Status:** Approved
+**Base:** latest `origin/main` (worktree `worktree-trout-revamp`). One PR per project page.
+
+## Goal
+
+Bring the trout re-identification page in line with the other project pages: tightened non-technical copy, card grids + interactive pills for the bullet sections, one new animated SVG overview diagram. **Keep the strong real image tables** (raw → normalized → keypoints, and the match / non-match keypoint pairs) — they're compelling actual results, like the smolt page's real figures.
+
+## Front matter
+
+Add `tagline` only (no stats band — the source has no strong numbers). Tagline: *"Recognising individual trout by their spot patterns — like fingerprints — without ever touching the fish."*
+
+## Body structure
+
+1. **Lede** (tighten the Context: trout / Westslope Cutthroat as an indicator species / spots are unique like fingerprints) + **Diagram A** + keep the WCT photo and Elk River map woven in.
+2. **Why this trout matters** ("A vital role", 6 bullets) → 3-card grid (food-web role · indicator species · cultural & habitat value).
+3. **Under pressure** (conservation concerns, 6 bullets) → interactive **pills** (`{{< threats "pressures" >}}`): habitat loss · fragmentation (dams) · pollution · invasive species · climate change · overfishing.
+4. **How the system works** — short intro + Diagram A reference, then keep the real **preprocessing table** (raw → normalized → keypoints) and the real **match / non-match** keypoint table; tighten the copy around them.
+5. **Conclusion** + `demo_cta` (drop the redundant "try the live demo" line).
+
+## Diagram (new animated SVG, house teal/coral)
+
+New primitive: a **trout** (olive-gold body, black spots denser toward the tail, the cutthroat's red throat slash). Plus a **keypoint constellation** overlay and a **database match** panel (reuse the seal re-ID pattern).
+
+- **Diagram A — `pipeline.svg` "From a photo to an identity"** — 4 cards: **Photo** (a raw trout photo) → **Normalize** (straightened & cut out on a clean background) → **Keypoints** (its spot pattern extracted as keypoints) → **Match** (compared against the database → a known individual, or a new one).
+
+Positioning transform on an outer `<g>`, animation on an inner `<g>`; `prefers-reduced-motion` guard.
+
+## Reuse / non-goals
+
+- Reuse `threats` pills, `support__grid`, `demo_cta`, and the existing markdown image tables.
+- Keep all the real trout imagery (raw/normalized/keypoints, match/non-match, WCT photo, Elk River map). The existing `pipeline.png` is superseded by Diagram A.
+- No template/shortcode changes.
+
+## Verification
+
+- `hugo` builds clean; screenshot hero, Diagram A, pills, card grids, the real image tables; diagram animates + degrades with reduced motion.


### PR DESCRIPTION
## Summary

Revamps the **Trout Identification** page (spot-pattern re-identification of Westslope Cutthroat Trout) into the established project-page system — non-technical copy, a card grid and interactive pills for the bullet sections, and one new animated SVG overview diagram. The strong **real** image tables are kept.

## What changed

- **New animated SVG re-ID pipeline** — Photo → Normalize (straightened & cut out) → Keypoints (spot pattern extracted) → Match (against a database → a known individual, with score). Features a spotted cutthroat trout (red throat slash and all).
- `tagline` added; **no stats band** (the source has no strong numbers — kept the hero clean).
- Non-technical copy pass; tightened the long bullet sections.
- **Card grid** for why-this-trout-matters (3); **interactive pills** for the conservation pressures (6).
- **Kept the real image tables**: raw → normalized → keypoints, and the match / non-match keypoint pairs (actual results). The WCT photo + Elk River map are now an intro carousel.

`hugo` builds clean. The old `pipeline.png` is superseded by the diagram (left in the bundle, unused).
