### PR TITLE
Animated GIF + reef carousel on coral reef page

### DIFF
--- a/assets/sass/4-layouts/_post.scss
+++ b/assets/sass/4-layouts/_post.scss
@@ -212,6 +212,17 @@
     line-height: 1.5;
     color: #80838b;
   }
+
+  /* Center standalone images (e.g. an animated GIF published at its native
+     size) so they don't sit flush left in the reading column. Full-width
+     images are unaffected — they already fill the column. The #wide bleed
+     rule has higher specificity and keeps its own positioning. */
+  p > img,
+  p > picture {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 .post,

--- a/content/projects/coral_reef_health_monitoring.md
+++ b/content/projects/coral_reef_health_monitoring.md
@@ -139,12 +139,13 @@ against the camera.
 Models are trained on reef imagery from around the world to cope with this
 variety:
 
-{{< gallery caption="Coral reefs photographed in different regions across the world" >}}
-  {{< gallery_image src="/images/projects/coral_reef_segmentation/reefs/reef1.jpg" alt="Reef 1 sample" >}}
-  {{< gallery_image src="/images/projects/coral_reef_segmentation/reefs/reef2.jpg" alt="Reef 2 sample" >}}
-  {{< gallery_image src="/images/projects/coral_reef_segmentation/reefs/reef3.jpg" alt="Reef 3 sample" >}}
-  {{< gallery_image src="/images/projects/coral_reef_segmentation/reefs/reef4.jpg" alt="Reef 4 sample" >}}
-{{< /gallery >}}
+{{< image_carousel id="coral-reefs" items="2" >}}
+  {{< carousel_image src="/images/projects/coral_reef_segmentation/reefs/reef1.jpg" alt="A coral reef sample" caption="A coral reef photographed in the field." >}}
+  {{< carousel_image src="/images/projects/coral_reef_segmentation/reefs/reef2.jpg" alt="A coral reef sample" caption="A coral reef photographed in the field." >}}
+  {{< carousel_image src="/images/projects/coral_reef_segmentation/reefs/reef3.jpg" alt="A coral reef sample" caption="A coral reef photographed in the field." >}}
+  {{< carousel_image src="/images/projects/coral_reef_segmentation/reefs/reef4.jpg" alt="A coral reef sample" caption="A coral reef photographed in the field." >}}
+{{< /image_carousel >}}
+<p class="media-caption">Coral reefs photographed in different regions across the world.</p>
 
 ## Conclusion
 

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -32,6 +32,18 @@
     {{ with $class }}class="{{ . }}"{{ end }}
     loading="lazy"
     decoding="async">
+{{ else if and $image (strings.HasSuffix (lower $imgPath) ".gif") }}
+  {{/* GIF: Hugo's resize keeps only the first frame, so an animated GIF would
+       render as a static image. Publish as-is to preserve the animation. */}}
+  <img
+    src="{{ $image.RelPermalink }}"
+    alt="{{ $alt }}"
+    {{ with $title }}title="{{ . }}"{{ end }}
+    {{ with $class }}class="{{ . }}"{{ end }}
+    width="{{ $image.Width }}"
+    height="{{ $image.Height }}"
+    loading="lazy"
+    decoding="async">
 {{ else if $image }}
   {{/* Generate responsive image with WebP */}}
   {{ $widths := slice 400 600 800 1200 }}


### PR DESCRIPTION
## What

On the **Coral Reefs Health Monitoring** project page:

1. **Animated GIF now plays.** The page already referenced `coral_ai.gif`, but the image render hook (`render-image.html`) ran every non-SVG image through `$image.Resize`, and Hugo's resize keeps only the *first frame* of a GIF (and converts to WebP) — so it rendered as a static image. GIFs are now passed through the pipeline unprocessed (same treatment SVGs already get), preserving the animation.
2. **Reef gallery → carousel.** The "Coral reefs photographed in different regions across the world" gallery now uses the `image_carousel` shortcode, consistent with the bear / other project pages.
3. **Standalone images centered.** Content images that are narrower than the reading column (like the native-size GIF) are now centered instead of sitting flush left. Full-width images are unaffected; the `#wide` bleed rule keeps its own positioning.

## Verify

- `hugo` build: the rendered `<img>` points at the original `coral_ai.gif` (3.0 MB, unmodified) — no resized WebP frame.
- Carousel markup present (`data-carousel-id="coral-reefs"`), old gallery markup gone.
- Centering rule compiled into the referenced stylesheet.