### PR TITLE
Revamp Biowatch project page

### DIFF
--- a/assets/images/projects/biowatch-app/diagrams/workflow.svg
+++ b/assets/images/projects/biowatch-app/diagrams/workflow.svg
@@ -1,0 +1,117 @@
+<svg viewBox="0 0 1062 380" xmlns="http://www.w3.org/2000/svg" font-family="Mulish, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="forest" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#3f5a3a"/><stop offset="100%" stop-color="#243a26"/></linearGradient>
+  <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0e3a4a"/><stop offset="100%" stop-color="#176074"/></linearGradient>
+  <radialGradient id="heat" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#e29578" stop-opacity="0.85"/><stop offset="60%" stop-color="#e29578" stop-opacity="0.35"/><stop offset="100%" stop-color="#e29578" stop-opacity="0"/></radialGradient>
+  <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 1 L9 5 L0 9 Z" fill="#e29578"/></marker>
+  <filter id="cardshadow" x="-20%" y="-20%" width="140%" height="150%"><feDropShadow dx="0" dy="5" stdDeviation="9" flood-color="#1c2b28" flood-opacity="0.08"/></filter>
+  <style>
+    .title { font-family: Newsreader, Georgia, 'Times New Roman', serif; font-size: 26px; font-weight: 600; fill: #161616; }
+    .desc  { font-size: 15px; fill: #60626a; }
+    .step  { font-size: 13px; font-weight: 700; letter-spacing: 0.12em; fill: #e29578; }
+    .chip  { font-size: 11px; font-weight: 700; fill: #fff; }
+    .drop  { transform-box: fill-box; transform-origin: 50% 50%; animation: drop 3s ease-in-out infinite; }
+    .box   { animation: boxp 2.2s ease-in-out infinite; }
+    .ping  { transform-box: fill-box; transform-origin: 50% 50%; animation: ping 2.6s ease-out infinite; }
+    .glow  { animation: glow 2.4s ease-in-out infinite; }
+    @keyframes drop { 0%{opacity:0;transform:translateY(-14px)} 18%{opacity:1} 76%{opacity:1;transform:translateY(0)} 100%{opacity:0;transform:translateY(0)} }
+    @keyframes boxp { 0%,100%{opacity:0.55} 50%{opacity:1} }
+    @keyframes ping { 0%{transform:scale(0.4);opacity:0.8} 100%{transform:scale(2);opacity:0} }
+    @keyframes glow { 0%,100%{opacity:0.6} 50%{opacity:1} }
+    @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+  </style>
+  <!-- camera-trap photo thumbnail -->
+  <g id="tile">
+    <rect x="-26" y="-19" width="52" height="38" rx="5" fill="#dfe9e2" stroke="#b9c6bf" stroke-width="1.5"/>
+    <rect x="-23" y="-16" width="46" height="21" rx="2" fill="#4a6b44"/>
+    <rect x="-23" y="3" width="46" height="13" rx="2" fill="#2f4a2e"/>
+    <ellipse cx="3" cy="9" rx="9" ry="4" fill="#2a1d15"/><circle cx="11" cy="5" r="3.2" fill="#2a1d15"/>
+  </g>
+  <!-- fox-like critter (faces right) -->
+  <g id="fox">
+    <path d="M-22 2 C -36 4 -40 -10 -34 -16 C -33 -8 -28 -4 -22 -4 Z" fill="#b15e26"/>
+    <ellipse cx="0" cy="0" rx="21" ry="9" fill="#c4742f"/>
+    <circle cx="18" cy="-6" r="7.5" fill="#c4742f"/>
+    <path d="M11 -12 L9 -22 L17 -16 Z" fill="#b15e26"/><path d="M24 -12 L27 -22 L18 -17 Z" fill="#b15e26"/>
+    <path d="M24 -5 L31 -3 L24 -1 Z" fill="#8a4f20"/>
+    <circle cx="20" cy="-6" r="1.5" fill="#2a1810"/>
+    <rect x="-16" y="7" width="4" height="12" rx="2" fill="#8a4f20"/><rect x="-4" y="8" width="4" height="12" rx="2" fill="#8a4f20"/><rect x="8" y="8" width="4" height="11" rx="2" fill="#8a4f20"/>
+  </g>
+  <!-- mini folder glyph -->
+  <g id="folder"><path d="M-10 -7 h6 l2 2 h11 a2 2 0 0 1 2 2 v8 a2 2 0 0 1 -2 2 h-19 a2 2 0 0 1 -2 -2 v-10 a2 2 0 0 1 2 -2 z" fill="#e8b84b"/></g>
+  <!-- map pin -->
+  <g id="pin"><path d="M0 6 C -6 -2 -7 -7 -3 -10 C 1 -13 6 -10 6 -5 C 6 -1 3 2 0 6 Z" fill="#e29578"/><circle cx="1" cy="-6" r="2.2" fill="#fff"/></g>
+</defs>
+
+<g stroke="#e29578" stroke-width="3.5" fill="none" stroke-linecap="round">
+  <line x1="250" y1="134" x2="291" y2="134" marker-end="url(#arrow)"/>
+  <line x1="509" y1="134" x2="550" y2="134" marker-end="url(#arrow)"/>
+  <line x1="768" y1="134" x2="809" y2="134" marker-end="url(#arrow)"/>
+</g>
+
+<!-- CARD 1 — IMPORT -->
+<rect x="36" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(142,118)">
+  <g transform="translate(-16,4) rotate(-10)"><use href="#tile"/></g>
+  <g transform="translate(10,-2) rotate(8)"><use href="#tile"/></g>
+  <g transform="translate(-3,-14) rotate(-2)"><g class="drop"><use href="#tile"/></g></g>
+  <g transform="translate(0,52)"><rect x="-78" y="-11" width="156" height="22" rx="11" fill="#006d77"/><text class="chip" x="0" y="3.5" text-anchor="middle" font-size="9">folder · GBIF · Camtrap DP</text></g>
+</g>
+<text class="step" x="142" y="280" text-anchor="middle">01</text>
+<text class="title" x="142" y="312" text-anchor="middle">Import</text>
+<text class="desc"  x="142" y="338" text-anchor="middle">Images or datasets</text>
+
+<!-- CARD 2 — IDENTIFY -->
+<rect x="295" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(401,128)">
+  <rect x="-78" y="-58" width="156" height="116" rx="12" fill="url(#forest)"/>
+  <clipPath id="c2"><rect x="-78" y="-58" width="156" height="116" rx="12"/></clipPath>
+  <g clip-path="url(#c2)">
+    <g stroke="#5d7a52" stroke-width="6" opacity="0.45" stroke-linecap="round"><path d="M-52 58 V-6"/><path d="M50 58 V8"/></g>
+    <path d="M-78 40 Q0 30 78 40 L78 58 L-78 58 Z" fill="#1c3320"/>
+    <g transform="translate(-4,28) scale(1.0)"><use href="#fox"/></g>
+  </g>
+  <rect class="box" x="-40" y="6" width="74" height="40" rx="3" fill="none" stroke="#e29578" stroke-width="3"/>
+  <g transform="translate(-14,-2)"><rect x="-26" y="-10" width="52" height="18" rx="9" fill="#e29578"/><text class="chip" x="0" y="3.5" text-anchor="middle" font-size="10">fox 0.97</text></g>
+  <g transform="translate(48,-46)"><rect x="-24" y="-11" width="48" height="20" rx="6" fill="#006d77"/><text class="chip" x="0" y="3.5" text-anchor="middle" font-size="9">on-device</text></g>
+</g>
+<text class="step" x="401" y="280" text-anchor="middle">02</text>
+<text class="title" x="401" y="312" text-anchor="middle">Identify</text>
+<text class="desc"  x="401" y="338" text-anchor="middle">Species, on your machine</text>
+
+<!-- CARD 3 — EXPLORE -->
+<rect x="554" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(660,128)">
+  <rect x="-78" y="-58" width="156" height="116" rx="12" fill="#e3ece4"/>
+  <clipPath id="c3"><rect x="-78" y="-58" width="156" height="116" rx="12"/></clipPath>
+  <g clip-path="url(#c3)">
+    <path d="M-78 -20 C -40 -30 -20 -8 10 -16 C 44 -25 60 -6 78 -14 L78 58 L-78 58 Z" fill="#cfe0d2"/>
+    <path d="M-30 -58 C -24 -20 -36 6 -20 34 C -8 54 -14 58 -14 58" stroke="#a9cfcf" stroke-width="5" fill="none" opacity="0.8"/>
+    <circle cx="-34" cy="22" r="26" fill="url(#heat)"/>
+    <!-- ping ring on a marker -->
+    <g transform="translate(-34,18)"><g class="ping"><circle r="12" fill="none" stroke="#e29578" stroke-width="2.5"/></g></g>
+  </g>
+  <g transform="translate(-34,18) scale(1.5)"><use href="#pin"/></g>
+  <g transform="translate(18,-26) scale(1.1)"><use href="#pin"/></g>
+  <g transform="translate(44,28) scale(1.1)"><use href="#pin"/></g>
+  <!-- species pie-chart, bottom-right -->
+  <g transform="translate(52,40)"><circle r="13" fill="#fff" stroke="#cdd4d6" stroke-width="1"/><path d="M0 0 L0 -13 A13 13 0 0 1 11 7 Z" fill="#006d77"/><path d="M0 0 L11 7 A13 13 0 0 1 -11 7 Z" fill="#83c5be"/><path d="M0 0 L-11 7 A13 13 0 0 1 0 -13 Z" fill="#e29578"/></g>
+</g>
+<text class="step" x="660" y="280" text-anchor="middle">03</text>
+<text class="title" x="660" y="312" text-anchor="middle">Explore</text>
+<text class="desc"  x="660" y="338" text-anchor="middle">Maps &amp; activity charts</text>
+
+<!-- CARD 4 — EXPORT -->
+<rect x="813" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(919,128)">
+  <rect x="-80" y="-64" width="160" height="128" rx="12" fill="url(#panel)"/>
+  <text class="chip" x="-66" y="-46" font-size="10" fill="#cfe9e0" letter-spacing="0.08em">ONE FOLDER / SPECIES</text>
+  <g transform="translate(0,-24)"><rect x="-66" y="-12" width="132" height="22" rx="6" fill="#0a4a55"/><g transform="translate(-48,0)"><use href="#folder"/></g><text class="chip" x="56" y="3" text-anchor="end" font-size="11" fill="#cfe9e0">fox/</text></g>
+  <g transform="translate(0,4)"><rect x="-66" y="-12" width="132" height="22" rx="6" fill="#0a4a55"/><g transform="translate(-48,0)"><use href="#folder"/></g><text class="chip" x="56" y="3" text-anchor="end" font-size="11" fill="#cfe9e0">deer/</text></g>
+  <g transform="translate(0,32)"><rect x="-66" y="-12" width="132" height="22" rx="6" fill="#0a4a55"/><g transform="translate(-48,0)"><use href="#folder"/></g><text class="chip" x="56" y="3" text-anchor="end" font-size="11" fill="#cfe9e0">wild boar/</text></g>
+  <g transform="translate(0,54)" class="glow"><rect x="-60" y="-11" width="120" height="22" rx="11" fill="#0a7d86" stroke="#3fd07a" stroke-width="2"/><text class="chip" x="0" y="3.5" text-anchor="middle" font-size="10.5">Publish to GBIF</text></g>
+</g>
+<text class="step" x="919" y="280" text-anchor="middle">04</text>
+<text class="title" x="919" y="312" text-anchor="middle">Export</text>
+<text class="desc"  x="919" y="338" text-anchor="middle">GBIF &amp; tidy folders</text>
+</svg>

--- a/content/projects/biowatch-app.md
+++ b/content/projects/biowatch-app.md
@@ -1,6 +1,14 @@
 ---
 title: "Biowatch: Camera Trap Data, Visualized"
 summary: A free, open-source desktop application for visualizing camera trap data to support conservation efforts.
+tagline: A free, open-source desktop app that turns a folder of camera-trap images into living ecological insight — entirely offline.
+stats:
+  - value: "Free"
+    label: "& open-source"
+  - value: "100%"
+    label: offline
+  - value: "Win / macOS / Linux"
+    label: desktop app
 tools:
   - Computer Vision
   - Machine Learning
@@ -22,11 +30,11 @@ aliases:
   - /projects/observation_visualisations_app/
 ---
 
-## 🦊 Biowatch is Here
+## Biowatch is Here
 
 What started as a prototype is now **[Biowatch](/tools/biowatch/)** — a free, open-source desktop application that lets conservationists analyze, visualize, and explore camera trap datasets entirely offline. It runs on Windows, macOS, and Linux, and your sensitive wildlife data never leaves your computer.
 
-<div style="display: flex; gap: 1em; flex-wrap: wrap; margin: 1.5em 0;">
+<div style="display: flex; gap: 1em; flex-wrap: wrap; justify-content: center; margin: 1.5em 0;">
   <a class="link-no-decoration" href="/tools/biowatch/">
     <button class="button button--cta">Download Biowatch</button>
   </a>
@@ -41,17 +49,48 @@ Camera traps have transformed wildlife monitoring: they gather huge volumes of d
 
 Most tools stop at classification, or live on the web behind accounts and uploads. Biowatch is different. It's a desktop app that keeps your data private, handles large datasets without lengthy uploads, and works in remote field locations. Installation is a simple double-click—no technical expertise required—and unlike web platforms such as [Wildlife Insights](https://www.wildlifeinsights.org/), nothing ever leaves your machine.
 
+![How Biowatch works — import images or datasets, identify species on-device, explore the results on maps and activity charts, then export to GBIF or tidy per-species folders](/images/projects/biowatch-app/diagrams/workflow.svg)
+*From raw images to a published study: import from anywhere, identify species on
+your own machine, explore patterns in space and time, then export to open
+standards — all without your data leaving your computer.*
+
 ## What Biowatch Does
 
-Biowatch turns a folder of raw camera trap images, or a published dataset, into an interactive study you can explore:
+Biowatch turns a folder of raw camera trap images, or a published dataset, into an interactive study you can explore.
 
-- **Import from anywhere** — scan a folder of your own images, open a [Camtrap DP](https://camtrap-dp.tdwg.org/) package, or pull curated datasets straight from [GBIF](https://www.gbif.org/) and [LILA BC](https://lila.science/). Wildlife Insights and DeepFaune CSV exports are supported too.
-- **On-device species identification** — run AI models locally to detect and identify animals as a study is built. SpeciesNet (Google, 2,000+ species worldwide), MegaDetector (Microsoft), DeepFaune (CNRS, Europe), and Manas (snow leopards in the Himalayas) are available, with a coverage map to pick the right one for your region.
-- **Interactive spatio-temporal analysis** — an Explore tab with camera locations rendered as species pie charts, abundance markers, density heatmaps, or hex grids, alongside daily-activity clocks and seasonal timelines.
-- **Species filtering** — select species to compare their distributions and activity patterns, with consistent colors across maps and charts.
-- **Review and correct** — step through images in a gallery viewer, adjust bounding boxes, and fix AI predictions before they become observations.
-- **Deployment insights** — per-deployment activity timelines, heatmaps, and editable metadata you can export and re-import as CSV.
-- **Standards-based export** — publish to GBIF as a Camtrap DP package, or export media organized into one folder per species.
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Import from anywhere</h3>
+    <p class="support__card-description">Scan a folder of your own images, open a <a href="https://camtrap-dp.tdwg.org/">Camtrap DP</a> package, or pull curated datasets straight from <a href="https://www.gbif.org/">GBIF</a> and <a href="https://lila.science/">LILA BC</a> — Wildlife Insights and DeepFaune CSV exports included.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">On-device species ID</h3>
+    <p class="support__card-description">Run AI models locally to detect and identify animals as a study builds: SpeciesNet (Google, 2,000+ species), MegaDetector (Microsoft), DeepFaune (CNRS, Europe) and Manas (Himalayan snow leopards), with a coverage map to pick the right one for your region.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Explore in space &amp; time</h3>
+    <p class="support__card-description">See camera locations as species pie-charts, abundance, density heatmaps or hex grids, alongside daily-activity clocks and seasonal timelines — and filter species to compare their distributions and patterns.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Review &amp; correct</h3>
+    <p class="support__card-description">Step through images in a gallery viewer, adjust bounding boxes, and fix AI predictions before they ever become observations.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Deployment insights</h3>
+    <p class="support__card-description">Per-camera activity timelines and heatmaps, with editable metadata you can export and re-import as CSV.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Standards-based export</h3>
+    <p class="support__card-description">Publish to GBIF as a Camtrap DP package, or export media organized into one tidy folder per species.</p>
+  </div>
+
+</div>
 
 Everything runs locally. No cloud uploads, no accounts, no tracking—ideal for the sensitive location data of endangered species.
 
@@ -70,7 +109,7 @@ Everything runs locally. No cloud uploads, no accounts, no tracking—ideal for 
 
 Biowatch is free to download for Windows, macOS, and Linux, and the full source is on [GitHub](https://github.com/earthtoolsmaker/biowatch) for anyone to inspect, use, or improve. Built together with conservation partners, it closes the gap between AI classification and practical insight—making wildlife monitoring more effective, more private, and more accessible.
 
-<div style="display: flex; gap: 1em; flex-wrap: wrap; margin: 1.5em 0;">
+<div style="display: flex; gap: 1em; flex-wrap: wrap; justify-content: center; margin: 1.5em 0;">
   <a class="link-no-decoration" href="/tools/biowatch/">
     <button class="button button--cta">Download Biowatch</button>
   </a>

--- a/docs/specs/2026-06-15-biowatch-app-page-revamp-design.md
+++ b/docs/specs/2026-06-15-biowatch-app-page-revamp-design.md
@@ -1,0 +1,45 @@
+# Biowatch App — Page Revamp
+
+**Date:** 2026-06-15
+**Status:** Approved
+**Base:** latest `origin/main` (worktree `worktree-biowatch-revamp`). One PR per project page.
+
+## Goal
+
+Bring the Biowatch project page in line with the other revamped project pages.
+Unlike the species pages, this is a **product page** — it already has strong
+copy, real product screenshots, and download CTAs. So the revamp is light-touch:
+add the house tagline + stats band, one animated workflow diagram, convert the
+feature bullet list to a card grid, and remove the section-title emoji.
+
+## Front matter
+
+- Add `tagline`: *"A free, open-source desktop app that turns a folder of camera-trap images into living ecological insight — entirely offline."*
+- Add `stats`: **Free & open-source** · **100% offline** · **Win / macOS / Linux**.
+
+## Body structure
+
+1. **Biowatch is Here** — keep, **remove the 🦊 emoji** from the heading (section titles are emoji-free site-wide). Keep CTA buttons + intro.
+2. **From Raw Footage to Real Insight** — keep prose; add the **workflow diagram** here (it shows how Biowatch bridges classification → insight).
+3. **What Biowatch Does** — keep the short intro line, convert the 7 feature bullets to a 6-card `support__grid` (Import from anywhere · On-device species ID · Explore in space & time · Review & correct · Deployment insights · Standards-based export — species-filtering folded into Explore). Keep the screenshot carousel + its caption right after. **AI models stay as prose** (no pills, per request).
+4. **Free, Open Source, and Built in the Open** — keep + CTAs.
+
+## Diagram (new animated SVG, house teal/coral)
+
+`workflow.svg` (1062×380, 4 cards) — **Import → Identify → Explore → Export**:
+- **Import** — a stack of camera-trap photo tiles dropping in; chip "folder · GBIF · Camtrap DP".
+- **Identify** — a forest camera-trap frame, a fox boxed with a "fox 0.97" label and an "on-device" chip.
+- **Explore** — a map with location pins, a density heatmap blob, a pinging marker, and a species pie-chart.
+- **Export** — a teal panel listing one folder per species (fox/ deer/ wild boar/) with a glowing "Publish to GBIF" chip.
+
+New primitives: camera-trap `tile`, `fox`, mini `folder`, map `pin`. Animation classes on inner `<g>`, positioning on outer `<g>`; `prefers-reduced-motion` guard.
+
+## Reuse / non-goals
+
+- Reuse `support__grid`, `image_carousel`, existing button styles.
+- Keep all 6 real product screenshots and both CTA button blocks.
+- No template/shortcode/SCSS changes. No threats pills on this page.
+
+## Verification
+
+- `hugo` builds clean; rendered HTML has the diagram, the 6 cards, the carousel, both CTA blocks; no emoji in headings; diagram animates and degrades under reduced motion.


### PR DESCRIPTION
Brings the **Biowatch** project page in line with the other revamped project pages. Biowatch is a *product* page (strong copy, real screenshots, download CTAs already), so this is a lighter-touch revamp than the species pages.

## Changes
- **New animated diagram** `diagrams/workflow.svg` — *Import → Identify → Explore → Export* in the house teal/coral style with a `prefers-reduced-motion` guard. Captures the whole app at a glance: import images/datasets, identify species on-device, explore on maps & activity charts, export to GBIF / per-species folders.
- **Tagline + stats band** in the hero (*Free & open-source · 100% offline · Win / macOS / Linux*).
- **Feature list → card grid**: the "What Biowatch Does" bullets become a 6-card `support__grid` (Import · On-device species ID · Explore in space & time · Review & correct · Deployment insights · Standards-based export). The AI models stay as prose.
- **Dropped the 🦊 emoji** from the "Biowatch is Here" heading (section titles are emoji-free site-wide).
- **Centered the CTA buttons** (Download Biowatch / Read the Manual) on large screens.
- Kept all 6 real product screenshots, the carousel, and both download CTA blocks.

Reuses existing shortcodes/SCSS only; no template or infra changes. `hugo` builds clean. Design notes in `docs/specs/2026-06-15-biowatch-app-page-revamp-design.md`.