### PR TITLE
Revamp Tropical Bat Call Detection page

### DIFF
--- a/assets/images/projects/bat_calls_classification/diagrams/pipeline.svg
+++ b/assets/images/projects/bat_calls_classification/diagrams/pipeline.svg
@@ -1,0 +1,112 @@
+<svg viewBox="0 0 804 380" xmlns="http://www.w3.org/2000/svg" font-family="Mulish, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="night" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#1d2c44"/><stop offset="100%" stop-color="#26384f"/></linearGradient>
+  <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0e3a4a"/><stop offset="100%" stop-color="#176074"/></linearGradient>
+  <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 1 L9 5 L0 9 Z" fill="#e29578"/></marker>
+  <filter id="cardshadow" x="-20%" y="-20%" width="140%" height="150%"><feDropShadow dx="0" dy="5" stdDeviation="9" flood-color="#1c2b28" flood-opacity="0.08"/></filter>
+  <style>
+    .title { font-family: Newsreader, Georgia, 'Times New Roman', serif; font-size: 26px; font-weight: 600; fill: #161616; }
+    .desc  { font-size: 15px; fill: #60626a; }
+    .step  { font-size: 13px; font-weight: 700; letter-spacing: 0.12em; fill: #e29578; }
+    .chip  { font-size: 11px; font-weight: 700; fill: #fff; }
+    .bob   { transform-box: fill-box; transform-origin: 50% 50%; animation: bob 3.4s ease-in-out infinite; }
+    .wave  { transform-box: fill-box; transform-origin: 50% 50%; animation: wave 2.6s ease-out infinite; }
+    .w2    { animation-delay: -0.9s; } .w3 { animation-delay: -1.8s; }
+    .sweep { animation: sweep 3s linear infinite; }
+    .blink { animation: blink 1.1s steps(1,end) infinite; }
+    .match { animation: glow 2.4s ease-in-out infinite; }
+    @keyframes bob  { 0%,100%{transform:translateY(0)} 50%{transform:translateY(-5px)} }
+    @keyframes wave { 0%{transform:scale(0.4);opacity:0.85} 100%{transform:scale(1.7);opacity:0} }
+    @keyframes sweep{ 0%{transform:translateX(-66px)} 100%{transform:translateX(66px)} }
+    @keyframes blink{ 0%,49%{opacity:1} 50%,100%{opacity:0.25} }
+    @keyframes glow { 0%,100%{opacity:0.6} 50%{opacity:1} }
+    @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+  </style>
+  <!-- flying bat silhouette -->
+  <g id="bat" fill="#241d30">
+    <path d="M0 -5 C -5 -9 -9 -9 -13 -5 C -19 -13 -29 -13 -37 -7 C -31 -7 -29 -1 -33 5 C -25 1 -21 3 -17 7 C -13 3 -9 5 -5 9 C -2 3 -1 1 0 -1 C 1 1 2 3 5 9 C 9 5 13 3 17 7 C 21 3 25 1 33 5 C 29 -1 31 -7 37 -7 C 29 -13 19 -13 13 -5 C 9 -9 5 -9 0 -5 Z"/>
+    <circle cx="0" cy="-7" r="3.6"/>
+    <path d="M-3 -10 L-5 -15 L0 -12 Z M3 -10 L5 -15 L0 -12 Z"/>
+  </g>
+  <!-- mini bat glyph for rows -->
+  <g id="batmini" fill="#cfe9e0">
+    <path d="M0 -2 C -3 -4 -5 -4 -7 -2 C -10 -6 -14 -6 -17 -3 C -14 -3 -13 0 -15 3 C -11 0 -9 1 -7 4 C -4 0 -2 1 0 2 C 2 1 4 0 7 4 C 9 1 11 0 15 3 C 13 0 14 -3 17 -3 C 14 -6 10 -6 7 -2 C 5 -4 3 -4 0 -2 Z"/>
+    <circle cx="0" cy="-3" r="2"/>
+  </g>
+</defs>
+
+<g stroke="#e29578" stroke-width="3.5" fill="none" stroke-linecap="round">
+  <line x1="251" y1="134" x2="292" y2="134" marker-end="url(#arrow)"/>
+  <line x1="510" y1="134" x2="551" y2="134" marker-end="url(#arrow)"/>
+</g>
+
+<!-- CARD 1 — RECORD -->
+<rect x="37" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(143,128)">
+  <rect x="-78" y="-58" width="156" height="116" rx="12" fill="url(#night)"/>
+  <clipPath id="c1"><rect x="-78" y="-58" width="156" height="116" rx="12"/></clipPath>
+  <g clip-path="url(#c1)">
+    <circle cx="54" cy="-44" r="8" fill="#cfe0d6" opacity="0.85"/>
+    <g fill="#fff" opacity="0.5"><circle cx="-48" cy="-46" r="1.1"/><circle cx="-20" cy="-50" r="0.9"/><circle cx="16" cy="-48" r="1.1"/><circle cx="-58" cy="-30" r="0.9"/></g>
+    <!-- bat + sound waves -->
+    <g transform="translate(-16,-20)">
+      <g transform="translate(0,0)"><g class="wave"><circle r="10" fill="none" stroke="#83c5be" stroke-width="2.2"/></g></g>
+      <g transform="translate(0,0)"><g class="wave w2"><circle r="10" fill="none" stroke="#83c5be" stroke-width="2.2"/></g></g>
+      <g transform="translate(0,0)"><g class="wave w3"><circle r="10" fill="none" stroke="#83c5be" stroke-width="2.2"/></g></g>
+      <g class="bob"><use href="#bat"/></g>
+    </g>
+    <!-- handheld bat detector, bottom-right -->
+    <g transform="translate(40,30)">
+      <rect x="-13" y="-20" width="26" height="44" rx="5" fill="#15463f" stroke="#0c5a51" stroke-width="1.5"/>
+      <rect x="-9" y="-16" width="18" height="14" rx="2" fill="#83c5be"/>
+      <g stroke="#0e3a4a" stroke-width="1" opacity="0.6"><path d="M-6 -12 q6 -4 12 0"/><path d="M-6 -8 q6 -4 12 0"/></g>
+      <circle class="blink" cx="0" cy="6" r="2.6" fill="#e8232a"/>
+      <g fill="#9fc3c0"><circle cx="-5" cy="14" r="1.4"/><circle cx="0" cy="14" r="1.4"/><circle cx="5" cy="14" r="1.4"/></g>
+      <rect x="-1.5" y="-30" width="3" height="11" rx="1.5" fill="#0c5a51"/>
+    </g>
+  </g>
+  <g transform="translate(-44,-44)"><rect x="-22" y="-10" width="56" height="18" rx="9" fill="#006d77"/><text class="chip" x="6" y="3.5" text-anchor="middle" font-size="9.5">ultrasound</text></g>
+</g>
+<text class="step" x="143" y="280" text-anchor="middle">01</text>
+<text class="title" x="143" y="312" text-anchor="middle">Record</text>
+<text class="desc"  x="143" y="338" text-anchor="middle">A bat call, in the field</text>
+
+<!-- CARD 2 — SPECTROGRAM -->
+<rect x="296" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(402,128)">
+  <rect x="-78" y="-58" width="156" height="116" rx="12" fill="#0c2630"/>
+  <clipPath id="c2"><rect x="-78" y="-58" width="156" height="116" rx="12"/></clipPath>
+  <g clip-path="url(#c2)">
+    <g stroke="#244a52" stroke-width="1" opacity="0.7"><path d="M-78 -28 H78 M-78 2 H78 M-78 32 H78 M-44 -58 V58 M-10 -58 V58 M24 -58 V58 M58 -58 V58"/></g>
+    <!-- bat FM-sweep chirps (high -> low) -->
+    <g fill="none" stroke-linecap="round">
+      <path d="M-56 -42 q5 14 6 30 q1 10 5 18" stroke="#9be8d6" stroke-width="3"/>
+      <path d="M-36 -38 q5 14 6 28 q1 9 5 16" stroke="#ffd9a0" stroke-width="3"/>
+      <path d="M-12 -44 q5 15 6 32 q1 10 5 18" stroke="#9be8d6" stroke-width="3"/>
+      <path d="M14 -36 q5 13 6 26 q1 9 5 15" stroke="#f0a978" stroke-width="3"/>
+      <path d="M40 -42 q5 14 6 30 q1 10 5 17" stroke="#9be8d6" stroke-width="3"/>
+    </g>
+    <!-- scanning playhead -->
+    <g class="sweep"><rect x="-1" y="-58" width="2" height="116" fill="#dff3ec" opacity="0.65"/></g>
+  </g>
+  <text x="-72" y="-46" font-size="9" font-weight="700" fill="#7fb3ad" opacity="0.9">kHz</text>
+  <text x="70" y="52" font-size="9" font-weight="700" fill="#7fb3ad" opacity="0.9" text-anchor="end">time</text>
+</g>
+<text class="step" x="402" y="280" text-anchor="middle">02</text>
+<text class="title" x="402" y="312" text-anchor="middle">Spectrogram</text>
+<text class="desc"  x="402" y="338" text-anchor="middle">The call as a picture</text>
+
+<!-- CARD 3 — CLASSIFY -->
+<rect x="555" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(661,128)">
+  <rect x="-80" y="-64" width="160" height="128" rx="12" fill="url(#panel)"/>
+  <text class="chip" x="-66" y="-46" font-size="10" fill="#cfe9e0" letter-spacing="0.08em">LIKELY SPECIES</text>
+  <g transform="translate(0,-22)" class="match"><rect x="-68" y="-13" width="136" height="24" rx="6" fill="#0a7d86" stroke="#3fd07a" stroke-width="2.5"/><g transform="translate(-52,0)"><use href="#batmini"/></g><text class="chip" x="-30" y="3" text-anchor="start" font-size="10.5">Myotis</text><text class="chip" x="56" y="3" text-anchor="end" font-size="9.5">0.94</text></g>
+  <g transform="translate(0,8)"><rect x="-66" y="-12" width="132" height="22" rx="6" fill="#0a4a55"/><g transform="translate(-52,0)"><use href="#batmini"/></g><text x="-30" y="3" text-anchor="start" font-size="9.5" font-weight="700" fill="#9fc3c0">Hipposideros</text><text x="56" y="3" text-anchor="end" font-size="9.5" font-weight="700" fill="#9fc3c0">0.71</text></g>
+  <g transform="translate(0,34)"><rect x="-66" y="-12" width="132" height="22" rx="6" fill="#0a4a55"/><g transform="translate(-52,0)"><use href="#batmini"/></g><text x="-30" y="3" text-anchor="start" font-size="9.5" font-weight="700" fill="#9fc3c0">Rhinolophus</text><text x="56" y="3" text-anchor="end" font-size="9.5" font-weight="700" fill="#9fc3c0">0.55</text></g>
+  <g transform="translate(0,56)"><rect x="-52" y="-10" width="104" height="20" rx="10" fill="#15463f"/><text class="chip" x="0" y="4" text-anchor="middle" font-size="10">top match: Myotis</text></g>
+</g>
+<text class="step" x="661" y="280" text-anchor="middle">03</text>
+<text class="title" x="661" y="312" text-anchor="middle">Classify</text>
+<text class="desc"  x="661" y="338" text-anchor="middle">Which species, and how sure</text>
+</svg>

--- a/content/projects/bat_calls_classification.md
+++ b/content/projects/bat_calls_classification.md
@@ -91,9 +91,9 @@ ultrasonic calls bats use to navigate in the dark.
 *Each recording is turned into a spectrogram — a picture of sound — and a model
 reads that picture to identify the species behind the call.*
 
-Together with **Citibats Cambodia**, we're building bioacoustics tools — as part
-of Pytorch-Wildlife — that turn those recordings into species. The model lets
-researchers classify the huge volume of calls the community gathers, and share
+Together with **Citibats Cambodia**, we're building bioacoustics tools that turn
+those recordings into species. The model lets researchers classify the huge
+volume of calls the community gathers, and share
 the results openly on
 [iNaturalist](https://www.inaturalist.org/projects/citibats-cambodia) for further
 research by anyone, anywhere.

--- a/content/projects/bat_calls_classification.md
+++ b/content/projects/bat_calls_classification.md
@@ -1,6 +1,14 @@
 ---
 title: "Tropical Bat Call Detection and Classification"
 summary: Transforming bat population monitoring in Cambodia through advanced bio-acoustic analysis driven by Machine Learning algorithms.
+tagline: Teaching machines to recognise bats by their calls — so citizen scientists across Cambodia can map species no one has counted.
+stats:
+  - value: "70+"
+    label: species recorded
+  - value: "5"
+    label: new to science
+  - value: "Citizen-science"
+    label: powered
 clients: 
   - name: Citibats Cambodia
     link: https://www.inaturalist.org/projects/citibats-cambodia
@@ -9,55 +17,87 @@ clients:
 tools:
   - Machine Learning
   - Bio Acoustics
+pressures:
+  - name: Habitat loss
+    desc: "Rapidly disappearing roosts and foraging grounds shrink the spaces bats need to feed, breed and shelter."
+  - name: Pesticides
+    desc: "Heavy pesticide use poisons the insects bats feed on — and the bats themselves."
+  - name: Hunting &amp; trade
+    desc: "Bats are taken for the illegal bushmeat and traditional-medicine trades, thinning already fragile populations."
+  - name: Knowledge gap
+    desc: "With so little research published, species can decline — or vanish — before they are ever documented."
 status: fundraising
 date: 2024-04-23
 image: /images/projects/bat_calls_classification/cover.png
 ---
 
-## Context
+Bats are a familiar sight across Cambodia — colonies of fruit bats such as
+**Lyle's flying fox**, one of 31 species endemic to southeast Asia, roost in the
+trees of pagodas and national monuments. Cambodia is even the only country in the
+world with a living tradition of bat-guano cultivation. Yet for all their
+visibility, bats are among the country's least-studied animals — and that gap in
+knowledge makes them hard to protect.
 
-Bats are common throughout Cambodia, and are highly visible features of various
-pagoda and national monuments, which often host colonies of fruit bats such as
-Lyle’s flying fox, one of 31 species endemic to southeast Asia.
+## Why bats matter
 
-Bats play critical roles within their ecosystems, particularly in pest control,
-seed dispersal, and pollination of various plants including many fruit trees.
+As pollinators, seed-dispersers and pest-controllers, bats quietly keep tropical
+ecosystems — and the farms that depend on them — running.
 
-Cambodia is the only known country with an ancient tradition of bat cultivation
-for guano production, which remains in practice today. The lack of reliable
-data and limited number of studies have left a dearth of knowledge of these
-important creatures and hampers conservation efforts. The use of bats for
-illegal bush meat and traditional medicine trade as well as rapidly
-disappearing habitat and use of pesticides are causing declines in bat
-population and put several species at risk of extinction. Cambodia’s
-biodiversity remains understudied, and this is particularly true for bats, with
-very limited research published. 
+<div class="support__grid">
 
-While the neighboring countries of Thailand and Vietnam both have over 100 bat
-species recorded, ten years ago Cambodia only had 30 species recorded. Today,
-Cambodia is known to have over 70 species of bat, with five of those new to
-science. Just last year a new species of bat—the Hayes' thick-thumbed
-myotis—was identified after being caught in the capital city of Phnom Penh. 
+  <div class="support__card">
+    <h3 class="support__card-title">Pest control</h3>
+    <p class="support__card-description">A single colony devours vast numbers of insects every night, protecting rice and other crops — naturally, without pesticides.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Seed dispersal</h3>
+    <p class="support__card-description">Fruit bats carry seeds far across the landscape as they forage, helping regenerate forests and the fruit trees people rely on.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Pollination</h3>
+    <p class="support__card-description">Many tropical plants — including valuable fruit trees — depend on bats to pollinate their night-blooming flowers.</p>
+  </div>
+
+</div>
+
+## Under pressure
+
+Cambodia's bats face mounting pressure, and a shortage of data leaves them
+especially exposed. Tap each to learn more.
+
+{{< threats "pressures" >}}
+
+## Hidden diversity
+
+Just ten years ago, only 30 bat species were recorded in Cambodia — against more
+than 100 each in neighbouring Thailand and Vietnam. Today the count is over
+**70**, five of them new to science. One, the Hayes' thick-thumbed myotis, was
+identified only recently after being caught in the heart of Phnom Penh.
 
 > What more is waiting to be found?
 >
 > <cite>– Cambodian Urban Bat Project</cite>
 
-The __Cambodia Urban Bat Project__ will use __citizen science__ volunteers to
-make acoustic recordings of the bats while walking and riding transects in a
-diversity of urban spaces, but particularly those known to be frequented by
-bats. Citizen scientists will also do stationary recordings in hotspots that
-are identified by the surveys.
+## From a call to a species
 
-## Project Scope and Objectives
+The **Cambodian Urban Bat Project** puts that question to citizen scientists.
+Volunteers walk and ride transects through a diversity of urban spaces — and run
+stationary recordings in the hotspots their surveys reveal — capturing the
+ultrasonic calls bats use to navigate in the dark.
 
-Our partnership is focused on developing
-Pytorch-Wildlife bioacoustics features for
-classification of
-bat calls. This would enable better understanding and
-protection of bats by enabling researchers to
-easily visualize and classification the large number of
-bat call recordings gathered by the citizen
-science community and shared made publicly available to all for further
-research on iNaturalist as well as potentially other platforms or research
-publications. 
+![How it works — a bat's ultrasonic call is recorded in the field, rendered as a spectrogram, then classified to species by a machine-learning model](/images/projects/bat_calls_classification/diagrams/pipeline.svg)
+*Each recording is turned into a spectrogram — a picture of sound — and a model
+reads that picture to identify the species behind the call.*
+
+Together with **Citibats Cambodia**, we're building bioacoustics tools — as part
+of Pytorch-Wildlife — that turn those recordings into species. The model lets
+researchers classify the huge volume of calls the community gathers, and share
+the results openly on
+[iNaturalist](https://www.inaturalist.org/projects/citibats-cambodia) for further
+research by anyone, anywhere.
+
+It's a blueprint for community-powered conservation: low-cost recorders,
+volunteer effort and open data adding up to a clearer picture of Cambodia's
+bats — and a faster route to protecting them.

--- a/docs/specs/2026-06-15-bat-calls-page-revamp-design.md
+++ b/docs/specs/2026-06-15-bat-calls-page-revamp-design.md
@@ -1,0 +1,45 @@
+# Tropical Bat Call Detection — Page Revamp
+
+**Date:** 2026-06-15
+**Status:** Approved
+**Base:** latest `origin/main` (worktree `worktree-bat-calls-revamp`). One PR per project page.
+
+## Goal
+
+Bring the bat-call page in line with the other revamped project pages: tightened
+non-technical copy, a card grid + interactive threat pills for the bullet/prose
+sections, and one animated SVG diagram of the bioacoustics pipeline. The page is
+**fundraising** status and has no photo assets beyond the cover, so the diagram
++ cards + pills carry the visuals.
+
+## Front matter
+
+- Add `tagline`: *"Teaching machines to recognise bats by their calls — so citizen scientists across Cambodia can map species no one has counted."*
+- Add `stats`: **70+** species recorded · **5** new to science · **Citizen-science** powered.
+- Keep `status: fundraising` (status-aware CTA band stays).
+
+## Body structure
+
+1. **Lede** — tighten the "Context" prose into a strong intro (Cambodia's bats, the data gap), keep the "What more is waiting to be found?" quote and the discovery story (30 → 70+ species).
+2. **Why bats matter** → 3-card `support__grid`: pest control · seed dispersal · pollination.
+3. **Under pressure** → interactive pills (`{{< threats "pressures" >}}`): habitat loss · pesticides · bushmeat & medicine trade · the knowledge gap.
+4. **From a call to a species** (Project Scope, non-technical pass; fixes the "visualize and classification" typo) → short intro + the **diagram**; explain the citizen-science recording → spectrogram → classification → open data on iNaturalist flow in prose.
+5. Keep the citizen-science framing and the iNaturalist link.
+
+## Diagram (new animated SVG, house teal/coral + night palette)
+
+`pipeline.svg` (804×380, 3 cards) — **Record → Spectrogram → Classify**:
+- **Record** — night scene, a bat with expanding ultrasonic sound-waves, a handheld bat detector catching it; "ultrasound" chip.
+- **Spectrogram** — a dark spectrogram with FM-sweep chirps and a sweeping playhead; kHz / time axes.
+- **Classify** — a results panel of likely species (Myotis 0.94 highlighted · Hipposideros · Rhinolophus — real SE-Asian echolocating genera) with a "top match" chip.
+
+New primitives: flying `bat`, mini `batmini`. Animation classes on inner `<g>`, positioning on outer `<g>`; `prefers-reduced-motion` guard.
+
+## Reuse / non-goals
+
+- Reuse `threats` pills + `pressures` front matter, `support__grid`.
+- No new photos (none exist); keep the cover. No template/shortcode/SCSS changes.
+
+## Verification
+
+- `hugo` builds clean; rendered HTML has the diagram, 3 cards, pills; diagram animates and degrades under reduced motion.


### PR DESCRIPTION
Brings the **Tropical Bat Call Detection and Classification** page (Citibats Cambodia / Cambodian Urban Bat Project) in line with the other revamped project pages. This is a fundraising-status page with no photo assets beyond the cover, so the new diagram, cards and pills carry the visuals.

## Changes
- **New animated diagram** `diagrams/pipeline.svg` — *Record → Spectrogram → Classify* (3-card, house teal/coral + night palette, `prefers-reduced-motion` guard): a bat's ultrasonic call recorded in the field → rendered as a spectrogram with a sweeping playhead → classified to species. The "likely species" use real SE-Asian echolocating genera (Myotis, Hipposideros, Rhinolophus).
- **Tagline + stats band** in the hero (*70+ species recorded · 5 new to science · Citizen-science powered*).
- **Why bats matter** → 3-card `support__grid` (pest control · seed dispersal · pollination).
- **Conservation pressures** → interactive `{{< threats >}}` pills (habitat loss · pesticides · hunting & trade · the knowledge gap).
- **Copy pass**: tightened the lede, surfaced the 30 → 70+ species discovery story under "Hidden diversity", and reworked the technical "Project Scope" into a non-technical *"From a call to a species"* section (also fixing the "visualize and classification" wording and a duplicate iNaturalist link). Kept the "What more is waiting to be found?" quote and the citizen-science / open-data framing.

Reuses existing shortcodes/SCSS only; no template or infra changes. `hugo` builds clean. Design notes in `docs/specs/2026-06-15-bat-calls-page-revamp-design.md`.