### PR TITLE
Revamp Bird Flu Monitoring page

### DIFF
--- a/assets/images/projects/bird_flu_monitoring/diagrams/pipeline.svg
+++ b/assets/images/projects/bird_flu_monitoring/diagrams/pipeline.svg
@@ -1,0 +1,123 @@
+<svg viewBox="0 0 1062 380" xmlns="http://www.w3.org/2000/svg" font-family="Mulish, Helvetica, Arial, sans-serif">
+<defs>
+  <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#bfe0e6"/><stop offset="55%" stop-color="#dceee9"/><stop offset="55%" stop-color="#cfe0d6"/><stop offset="100%" stop-color="#e6dcbf"/></linearGradient>
+  <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#0e3a4a"/><stop offset="100%" stop-color="#176074"/></linearGradient>
+  <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 1 L9 5 L0 9 Z" fill="#e29578"/></marker>
+  <filter id="cardshadow" x="-20%" y="-20%" width="140%" height="150%"><feDropShadow dx="0" dy="5" stdDeviation="9" flood-color="#1c2b28" flood-opacity="0.08"/></filter>
+  <style>
+    .title { font-family: Newsreader, Georgia, 'Times New Roman', serif; font-size: 26px; font-weight: 600; fill: #161616; }
+    .desc  { font-size: 15px; fill: #60626a; }
+    .step  { font-size: 13px; font-weight: 700; letter-spacing: 0.12em; fill: #e29578; }
+    .chip  { font-size: 11px; font-weight: 700; fill: #fff; }
+    .hover { transform-box: fill-box; transform-origin: 50% 50%; animation: hover 3.4s ease-in-out infinite; }
+    .beam  { animation: beam 2.4s ease-in-out infinite; }
+    .drop  { transform-box: fill-box; transform-origin: 50% 50%; animation: drop 3s ease-in-out infinite; }
+    .box   { animation: boxp 2.2s ease-in-out infinite; }
+    .glow  { animation: glow 2.4s ease-in-out infinite; }
+    @keyframes hover { 0%,100%{transform:translateY(0)} 50%{transform:translateY(-5px)} }
+    @keyframes beam  { 0%,100%{opacity:0.12} 50%{opacity:0.32} }
+    @keyframes drop  { 0%{opacity:0;transform:translateY(-14px)} 18%{opacity:1} 76%{opacity:1;transform:translateY(0)} 100%{opacity:0;transform:translateY(0)} }
+    @keyframes boxp  { 0%,100%{opacity:0.55} 50%{opacity:1} }
+    @keyframes glow  { 0%,100%{opacity:0.6} 50%{opacity:1} }
+    @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+  </style>
+  <!-- gull, top-down (wings spread); stroke set by the <use> -->
+  <g id="gull"><path d="M-9 1 Q-4 -4 0 -1 Q4 -4 9 1" fill="none" stroke-width="2.6" stroke-linecap="round"/></g>
+  <!-- quadcopter drone -->
+  <g id="drone" fill="#28323d">
+    <g stroke="#28323d" stroke-width="2.5" stroke-linecap="round"><path d="M-9 -2 L-17 -8 M9 -2 L17 -8 M-9 2 L-17 8 M9 2 L17 8"/></g>
+    <ellipse cx="-17" cy="-8" rx="7.5" ry="2.2" fill="#6b7c88"/><ellipse cx="17" cy="-8" rx="7.5" ry="2.2" fill="#6b7c88"/>
+    <ellipse cx="-17" cy="8" rx="7.5" ry="2.2" fill="#6b7c88"/><ellipse cx="17" cy="8" rx="7.5" ry="2.2" fill="#6b7c88"/>
+    <rect x="-11" y="-4" width="22" height="8" rx="3"/>
+    <rect x="-3.5" y="3" width="7" height="5" rx="1.5" fill="#0c5a51"/>
+  </g>
+</defs>
+
+<g stroke="#e29578" stroke-width="3.5" fill="none" stroke-linecap="round">
+  <line x1="250" y1="134" x2="291" y2="134" marker-end="url(#arrow)"/>
+  <line x1="509" y1="134" x2="550" y2="134" marker-end="url(#arrow)"/>
+  <line x1="768" y1="134" x2="809" y2="134" marker-end="url(#arrow)"/>
+</g>
+
+<!-- CARD 1 — SURVEY -->
+<rect x="36" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(142,128)">
+  <rect x="-78" y="-58" width="156" height="116" rx="12" fill="url(#sky)"/>
+  <clipPath id="c1"><rect x="-78" y="-58" width="156" height="116" rx="12"/></clipPath>
+  <g clip-path="url(#c1)">
+    <path d="M-78 8 Q-30 0 20 6 Q54 10 78 4 L78 18 Q40 24 0 20 Q-40 16 -78 22 Z" fill="#8fc0c9" opacity="0.8"/>
+    <path d="M-78 22 Q-20 14 40 20 Q60 22 78 18 L78 58 L-78 58 Z" fill="#e0d2a8"/>
+    <g fill="#fff" opacity="0.85"><circle cx="-46" cy="34" r="1.6"/><circle cx="-30" cy="40" r="1.6"/><circle cx="-14" cy="36" r="1.6"/><circle cx="2" cy="42" r="1.6"/><circle cx="20" cy="36" r="1.6"/><circle cx="36" cy="42" r="1.6"/><circle cx="-38" cy="46" r="1.4"/><circle cx="10" cy="48" r="1.4"/><circle cx="-6" cy="30" r="1.4"/><circle cx="28" cy="48" r="1.4"/></g>
+    <g transform="translate(-6,-30)">
+      <path class="beam" d="M-4 6 L-20 40 L20 40 L4 6 Z" fill="#0c5a51"/>
+      <g class="hover"><use href="#drone"/></g>
+    </g>
+  </g>
+  <g transform="translate(46,-46)"><rect x="-22" y="-10" width="44" height="18" rx="9" fill="#006d77"/><text class="chip" x="0" y="3.5" text-anchor="middle" font-size="9.5">drone</text></g>
+</g>
+<text class="step" x="142" y="280" text-anchor="middle">01</text>
+<text class="title" x="142" y="312" text-anchor="middle">Survey</text>
+<text class="desc"  x="142" y="338" text-anchor="middle">Fly over the colony</text>
+
+<!-- CARD 2 — MAP -->
+<rect x="295" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(401,128)">
+  <rect x="-78" y="-58" width="156" height="116" rx="12" fill="#e0d2a8"/>
+  <clipPath id="c2"><rect x="-78" y="-58" width="156" height="116" rx="12"/></clipPath>
+  <g clip-path="url(#c2)">
+    <path d="M-78 -40 Q-20 -50 30 -38 Q70 -30 78 -44 L78 58 L-78 58 Z" fill="#d8c79a"/>
+    <path d="M-78 -58 L-78 -28 Q-30 -40 20 -30 Q-30 -18 -78 -22 Z" fill="#8fc0c9" opacity="0.85"/>
+    <g fill="#7a6a44" opacity="0.85"><circle cx="-40" cy="18" r="1.6"/><circle cx="-22" cy="26" r="1.6"/><circle cx="-4" cy="14" r="1.6"/><circle cx="14" cy="24" r="1.6"/><circle cx="34" cy="16" r="1.6"/><circle cx="48" cy="30" r="1.6"/><circle cx="-30" cy="40" r="1.4"/><circle cx="6" cy="38" r="1.4"/><circle cx="28" cy="42" r="1.4"/></g>
+    <!-- stitched orthomosaic tiles -->
+    <g fill="#ffffff" fill-opacity="0.05" stroke="#ffffff" stroke-width="1.4" stroke-opacity="0.8">
+      <rect x="-78" y="-58" width="52" height="58"/><rect x="-26" y="-58" width="52" height="58"/>
+      <rect x="-78" y="0" width="52" height="58"/><rect x="-26" y="0" width="52" height="58"/><rect x="26" y="0" width="52" height="58"/>
+    </g>
+    <g class="drop"><rect x="26" y="-58" width="52" height="58" fill="#ffffff" fill-opacity="0.08" stroke="#ffffff" stroke-width="1.4" stroke-opacity="0.95"/>
+      <g stroke="#0c5a51" stroke-width="2" fill="none" stroke-linecap="round"><path d="M32 -52 H40 M32 -52 V-44"/><path d="M72 -6 H64 M72 -6 V-14"/></g></g>
+  </g>
+  <g transform="translate(36,-46)"><rect x="-34" y="-10" width="68" height="18" rx="9" fill="#006d77"/><text class="chip" x="0" y="3.5" text-anchor="middle" font-size="9">orthomosaic</text></g>
+</g>
+<text class="step" x="401" y="280" text-anchor="middle">02</text>
+<text class="title" x="401" y="312" text-anchor="middle">Map</text>
+<text class="desc"  x="401" y="338" text-anchor="middle">Stitched into one map</text>
+
+<!-- CARD 3 — DETECT & COUNT -->
+<rect x="554" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(660,128)">
+  <rect x="-78" y="-58" width="156" height="116" rx="12" fill="#ddcb9c"/>
+  <clipPath id="c3"><rect x="-78" y="-58" width="156" height="116" rx="12"/></clipPath>
+  <g clip-path="url(#c3)">
+    <path d="M-78 -34 Q0 -44 78 -32 L78 58 L-78 58 Z" fill="#d3c08f"/>
+    <!-- adults (live) -->
+    <g transform="translate(-44,-22)"><use href="#gull" stroke="#0a7d86"/><rect class="box" x="-12" y="-10" width="24" height="20" rx="2" fill="none" stroke="#0a7d86" stroke-width="2"/></g>
+    <g transform="translate(16,-30)"><use href="#gull" stroke="#0a7d86"/><rect x="-12" y="-10" width="24" height="20" rx="2" fill="none" stroke="#0a7d86" stroke-width="2"/></g>
+    <g transform="translate(50,-6)"><use href="#gull" stroke="#0a7d86"/><rect x="-12" y="-10" width="24" height="20" rx="2" fill="none" stroke="#0a7d86" stroke-width="2"/></g>
+    <!-- chicks (live, smaller) -->
+    <g transform="translate(-18,-2)"><use href="#gull" stroke="#0a7d86" transform="scale(0.6)"/><rect x="-9" y="-8" width="18" height="15" rx="2" fill="none" stroke="#3fd07a" stroke-width="1.8"/></g>
+    <g transform="translate(30,16)"><use href="#gull" stroke="#0a7d86" transform="scale(0.6)"/><rect x="-9" y="-8" width="18" height="15" rx="2" fill="none" stroke="#3fd07a" stroke-width="1.8"/></g>
+    <!-- dead (coral box) -->
+    <g transform="translate(-46,18)"><use href="#gull" stroke="#9aa0a4" transform="rotate(28)"/><rect class="box" x="-12" y="-10" width="24" height="20" rx="2" fill="none" stroke="#e29578" stroke-width="2.4"/></g>
+  </g>
+  <g transform="translate(0,46)"><rect x="-58" y="-9" width="116" height="18" rx="9" fill="#1c3320" opacity="0.88"/>
+    <rect x="-48" y="-3.5" width="9" height="7" rx="1.5" fill="none" stroke="#3fd07a" stroke-width="1.6"/><text class="chip" x="-35" y="3" font-size="9.5">live</text>
+    <rect x="6" y="-3.5" width="9" height="7" rx="1.5" fill="none" stroke="#e29578" stroke-width="1.6"/><text class="chip" x="20" y="3" font-size="9.5">dead</text></g>
+</g>
+<text class="step" x="660" y="280" text-anchor="middle">03</text>
+<text class="title" x="660" y="312" text-anchor="middle">Detect &amp; count</text>
+<text class="desc"  x="660" y="338" text-anchor="middle">Live or dead, adult or chick</text>
+
+<!-- CARD 4 — ASSESS -->
+<rect x="813" y="28" width="212" height="212" rx="20" fill="#fbf6f6" stroke="#ede0d4" stroke-width="2" filter="url(#cardshadow)"/>
+<g transform="translate(919,128)">
+  <rect x="-80" y="-64" width="160" height="128" rx="12" fill="url(#panel)"/>
+  <text class="chip" x="-66" y="-46" font-size="10" fill="#cfe9e0" letter-spacing="0.08em">COLONY COUNT</text>
+  <g transform="translate(0,-24)"><rect x="-66" y="-12" width="132" height="22" rx="6" fill="#0a4a55"/><circle cx="-52" cy="-1" r="4" fill="#0a7d86"/><text x="-40" y="3" text-anchor="start" font-size="11" font-weight="700" fill="#cfe9e0">Adults</text><text class="chip" x="56" y="3" text-anchor="end" font-size="11">1,240</text></g>
+  <g transform="translate(0,4)"><rect x="-66" y="-12" width="132" height="22" rx="6" fill="#0a4a55"/><circle cx="-52" cy="-1" r="4" fill="#3fd07a"/><text x="-40" y="3" text-anchor="start" font-size="11" font-weight="700" fill="#cfe9e0">Chicks</text><text class="chip" x="56" y="3" text-anchor="end" font-size="11">380</text></g>
+  <g transform="translate(0,32)"><rect x="-66" y="-12" width="132" height="22" rx="6" fill="#0a4a55"/><circle cx="-52" cy="-1" r="4" fill="#e29578"/><text x="-40" y="3" text-anchor="start" font-size="11" font-weight="700" fill="#cfe9e0">Dead</text><text class="chip" x="56" y="3" text-anchor="end" font-size="11">56</text></g>
+  <g transform="translate(0,56)" class="glow"><rect x="-56" y="-11" width="112" height="22" rx="11" fill="#0a7d86" stroke="#3fd07a" stroke-width="2"/><text class="chip" x="0" y="3.5" text-anchor="middle" font-size="10.5">97% survival</text></g>
+</g>
+<text class="step" x="919" y="280" text-anchor="middle">04</text>
+<text class="title" x="919" y="312" text-anchor="middle">Assess</text>
+<text class="desc"  x="919" y="338" text-anchor="middle">Survival &amp; flu impact</text>
+</svg>

--- a/content/projects/bird_flu_monitoring.md
+++ b/content/projects/bird_flu_monitoring.md
@@ -1,6 +1,14 @@
 ---
 title: Bird Flu Monitoring
 summary: Utilize drones for precise monitoring of breeding seabird colonies by detection of live and dead adults and chicks to determine survival and reproduction and asses the impact of avian influenza.
+tagline: Counting every bird in a seabird colony — alive or lost — from a drone overhead, to measure avian flu's toll without setting foot inside.
+stats:
+  - value: "Aerial"
+    label: drone survey
+  - value: "Adults & chicks"
+    label: counted apart
+  - value: "Non-invasive"
+    label: no colony disturbance
 clients:
   - name: Lumax AI
     link: https://lumax.ai/
@@ -10,50 +18,87 @@ tools:
   - Machine Learning
   - Photogrammetry
   - Drones
+impacts:
+  - name: Mortality
+    desc: "Infected birds sicken and die — and in a densely packed colony, losses can climb fast."
+  - name: Breeding disruption
+    desc: "Sick adults abandon nests or stop feeding their young, so few chicks make it through the season."
+  - name: Spread to chicks
+    desc: "Adults pass the virus to their offspring, putting the colony's next generation at risk."
+  - name: Population decline
+    desc: "Where highly pathogenic strains take hold, a colony can shrink year after year."
+  - name: Ecological ripple
+    desc: "Colonies anchor food webs and nutrient cycling, so their collapse reaches far beyond the birds."
 status: fundraising
 date: 2024-06-23
 image: /images/projects/bird_flu_monitoring/cover.png
 ---
 
-## Context
+Many seabirds breed in dense colonies on low-lying sandbanks, beaches and
+isolated islands — out of reach of ground predators, but increasingly exposed to
+erosion, flooding and a fast-moving new threat: **avian influenza**. To protect
+these colonies, conservationists need accurate, up-to-date counts of how many
+birds are there, and how they are faring. That has always been hard to do
+without disturbing the very birds you are trying to count.
 
-Many seabirds breed on low lying sandbanks and beaches, concentrated in
-colonies. The colonies are often located on isolated islands or peninsulas
-where they are out of reach of ground predators. Due to rising sea levels,
-these breeding areas are often subject to erosion and flooding which can cause
-the (partial) destruction of breeding colonies and leads to loss of breeding
-sites. Effective conservation of breeding seabirds requires accurate
-information about numbers and spatial distributions and their habitat.
+Together with [Lumax AI](https://lumax.ai/), we're building a system that surveys
+an entire colony **from the air** and turns the imagery into numbers — counting
+live and dead adults and chicks to track survival, reproduction, and the toll of
+bird flu, all without setting foot among the birds.
 
-Bird flu, also known as avian influenza, is a viral infection that primarily
-affects birds, including domestic poultry and wild birds. There are several
-strains of avian influenza viruses, some of which can cause mild to severe
-illness in birds. Infections can range from asymptomatic to highly contagious
-and deadly outbreaks.
+## The monitoring challenge
 
-When bird flu impacts breeding colonies of birds, such as those in waterfowl or
-seabird colonies, it can have significant effects:
+Seabird colonies are some of the hardest places in conservation to get good
+numbers from — and bird flu raises the stakes.
 
-- __Morbidity and Mortality:__ Bird flu can cause illness and death among
-infected birds. In breeding colonies, this can lead to a reduction in
-population size if a significant number of birds are affected.
-- __Disruption of Breeding:__ Severe outbreaks can disrupt breeding cycles.
-Infected birds may abandon nests or fail to care for their young, leading to
-decreased reproductive success.
-- __Transmission to Offspring:__ Infected birds can transmit the virus to their
-offspring, potentially affecting the next generation of birds in the colony.
-- __Population Dynamics:__ In cases of highly pathogenic avian influenza
-(HPAI), where mortality rates are high, breeding colonies may experience
-population declines over time if the virus persists or recurs.
-- __Ecological Impact:__ Breeding colonies play crucial roles in ecosystems,
-and declines due to disease can affect food webs, nutrient cycling, and other
-ecological processes.
+<div class="support__grid">
+
+  <div class="support__card">
+    <h3 class="support__card-title">Remote &amp; fragile sites</h3>
+    <p class="support__card-description">Colonies cluster on low-lying sandbanks and islands that rising seas increasingly erode and flood — remote, exposed, and easily damaged.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Counting harms them</h3>
+    <p class="support__card-description">Walking a colony to count by hand disturbs nesting birds, risks trampling eggs, and is slow, dangerous and rarely complete.</p>
+  </div>
+
+  <div class="support__card">
+    <h3 class="support__card-title">Flu moves fast</h3>
+    <p class="support__card-description">A highly pathogenic outbreak can tear through a colony in days, so counts have to be quick, repeatable and safe to gather often.</p>
+  </div>
+
+</div>
+
+## How bird flu hits a colony
+
+Avian influenza is a viral infection of birds that ranges from mild to highly
+contagious and deadly. When a severe strain reaches a breeding colony, the
+damage compounds. Tap each to learn more.
+
+{{< threats "impacts" >}}
+
+## How we monitor it
+
+Rather than send people in, we send a drone over the top.
+
+![How it works — a drone surveys the colony, its photos are stitched into one map, a model counts live and dead adults and chicks, and the totals reveal the colony's health](/images/projects/bird_flu_monitoring/diagrams/pipeline.svg)
+*A drone flies the colony, its overlapping photos are stitched into a single
+high-resolution map, a computer-vision model finds and classifies every bird,
+and the totals reveal how the colony is faring.*
+
+Flying a fixed grid, the drone captures hundreds of overlapping photos that are
+stitched into one high-resolution **orthomosaic** of the colony. A computer-vision
+model then finds and classifies every bird — **live or dead, adult or chick** —
+and the totals reveal both how many birds the colony holds and where an outbreak
+is biting hardest. Because a survey is fast and disturbs nothing, it can be
+repeated as often as needed to watch a colony through the breeding season.
 
 ## Conclusion
 
-Management strategies to mitigate the impact of bird flu on breeding colonies
-include surveillance, early detection, quarantine measures, vaccination (where
-applicable), and sometimes culling infected birds to prevent further spread.
-Monitoring and research are essential to understand the dynamics of avian
-influenza in breeding populations and to implement effective conservation
-measures when necessary.
+Managing bird flu in wild populations relies on surveillance and early detection,
+followed by measures like quarantine, vaccination where it's feasible, and
+occasionally culling to slow the spread. None of it works without good data.
+Fast, repeatable, non-invasive counts give conservationists the early warning and
+the population picture they need to act — and to understand how avian influenza
+moves through wild colonies over time.

--- a/docs/specs/2026-06-15-bird-flu-page-revamp-design.md
+++ b/docs/specs/2026-06-15-bird-flu-page-revamp-design.md
@@ -1,0 +1,47 @@
+# Bird Flu Monitoring — Page Revamp
+
+**Date:** 2026-06-15
+**Status:** Approved
+**Base:** latest `origin/main` (worktree `worktree-birdflu-revamp`). One PR per project page.
+
+## Goal
+
+Bring the bird-flu page in line with the other revamped project pages, and fix a
+content gap: the current body explains avian influenza in general but never
+describes the actual project (drones + computer vision counting seabirds). Add a
+tagline + stats band, a 4-card workflow diagram, a card grid + interactive pills
+for the prose sections, and a "how we monitor it" section. Fundraising status,
+cover image only — diagram + cards + pills carry the visuals.
+
+## Front matter
+
+- `tagline`: *"Counting every bird in a seabird colony — alive or lost — from a drone overhead, to measure avian flu's toll without setting foot inside."*
+- `stats`: **Aerial survey** · **Adults & chicks** · **Non-invasive**.
+- `impacts` list for the pills. Keep `status: fundraising`.
+
+## Body structure
+
+1. **Lede** — tighten the context; bring the drone solution up front (seabird colonies, why they're vulnerable, the flu threat).
+2. **The monitoring challenge** → 3-card `support__grid`: remote & fragile sites · counting by hand harms them · flu moves fast.
+3. **How bird flu hits a colony** → interactive pills (`{{< threats "impacts" >}}`): mortality · breeding disruption · spread to chicks · population decline · ecological ripple.
+4. **How we monitor it** → new section describing the drone + CV + photogrammetry approach + the **diagram**.
+5. **Conclusion** — management strategies, tightened, ending on the role of monitoring/data.
+
+## Diagram (new animated SVG, house teal/coral)
+
+`pipeline.svg` (1062×380, 4 cards) — **Survey → Map → Detect & count → Assess**:
+- **Survey** — a quadcopter drone hovering over a beach colony, downward scan beam; "drone" chip.
+- **Map** — drone photos stitched into one orthomosaic (tiled top-down map, one tile snapping in); "orthomosaic" chip.
+- **Detect & count** — top-down aerial with gulls boxed: live (teal), chicks (smaller, green), dead (coral); live/dead legend.
+- **Assess** — a colony-count panel (Adults 1,240 · Chicks 380 · Dead 56) with a glowing "97% survival" chip.
+
+New primitives: top-down `gull` (stroke set per `<use>`), `drone`. Animation classes on inner `<g>`, positioning on outer `<g>`; `prefers-reduced-motion` guard.
+
+## Reuse / non-goals
+
+- Reuse `threats` pills + `support__grid`. No new photos (none exist); keep the cover.
+- No template/shortcode/SCSS changes.
+
+## Verification
+
+- `hugo` builds clean; rendered HTML has the diagram, 3 cards, pills; diagram animates and degrades under reduced motion.


### PR DESCRIPTION
Brings the **Bird Flu Monitoring** page (Lumax AI) in line with the other revamped project pages — and fixes a content gap: the old body explained avian influenza in general but never described the actual project (drones + computer vision counting seabirds). Fundraising-status page with only a cover image, so the new diagram, cards and pills carry the visuals.

## Changes
- **New animated diagram** `diagrams/pipeline.svg` — *Survey → Map → Detect & count → Assess* (4-card, house teal/coral, `prefers-reduced-motion` guard): a drone surveys the colony → its photos are stitched into one orthomosaic → a CV model boxes and counts birds (live vs dead, adult vs chick) → a colony-count panel reports survival.
- **Tagline + stats band** in the hero (*Aerial survey · Adults & chicks · Non-invasive*).
- **The monitoring challenge** → 3-card `support__grid` (remote & fragile sites · counting by hand harms them · flu moves fast).
- **How bird flu hits a colony** → interactive `{{< threats >}}` pills (mortality · breeding disruption · spread to chicks · population decline · ecological ripple) — converted from the old bullet list.
- **Copy**: rewrote the lede to surface the drone solution up front, added a non-technical *"How we monitor it"* section explaining the drone + photogrammetry + CV approach, and tightened the conclusion.

Reuses existing shortcodes/SCSS only; no template or infra changes. `hugo` builds clean. Design notes in `docs/specs/2026-06-15-bird-flu-page-revamp-design.md`.