### PR TITLE
fix(carousel): stop hover scale and shadow being clipped

### DIFF
--- a/assets/sass/3-modules/_image-carousel.scss
+++ b/assets/sass/3-modules/_image-carousel.scss
@@ -6,9 +6,23 @@
   &__wrapper {
     position: relative;
 
+    // Off-screen slides are clipped here (not on .tns-ovh) so the hover scale
+    // and box-shadow of the visible images can bleed into this padding instead
+    // of being cut off at the slider viewport edge. Horizontal padding is kept
+    // below the gutter width (20px) so the cloned/off-screen slides stay hidden
+    // and don't peek in at the edges; vertical room is generous for hover.
+    overflow: hidden;
+    padding: 20px 8px;
+
     // Vertically center items of different heights
     .tns-horizontal.tns-subpixel > .tns-item {
       vertical-align: middle;
+    }
+
+    // Let the slider viewport overflow so the hover scale + shadow show;
+    // clipping of off-screen slides is handled by the padded wrapper above.
+    .tns-ovh {
+      overflow: visible;
     }
   }
 
@@ -143,16 +157,13 @@
     display: none;
   }
 
-  // Contained mode - keeps images within bounds (for pages with sidebars)
+  // Contained mode - keeps images within bounds (for pages with sidebars).
+  // The padded, overflow-hidden wrapper above already keeps slides within the
+  // column, so we only tighten the padding here (shadows still get room to show).
   &--contained {
     .image-carousel__wrapper {
       margin: 0;
-
-      .tns-ovh,
-      .tns-outer,
-      .tns-inner {
-        overflow: hidden;
-      }
+      padding: 12px 8px;
     }
 
     .image-carousel__slide {


### PR DESCRIPTION
## Problem
Image carousels clipped the hover effect: on hover the `scale(1.02)` growth and the larger `0 8px 24px` box-shadow got cut off at the edges (e.g. the Wadden Sea map's right edge on the seal monitoring page). Affected all carousels site-wide.

## Root cause
The shared `_image-carousel.scss` relied on tiny-slider's inner `.tns-ovh { overflow: hidden }` viewport to clip off-screen slides — but that same box also clips anything a *visible* image paints beyond its slot (hover scale + shadow).

## Fix
Move clipping off the inner viewport onto a padded wrapper:
- `.image-carousel__wrapper`: `overflow: hidden` + `padding: 20px 8px` — generous **vertical** room for hover scale/shadow; **horizontal** padding kept at 8px (below the 20px gutter) so cloned/off-screen slides don't peek in at the edges.
- `.tns-ovh { overflow: visible }` — lets the visible images' hover/shadow render.
- `--contained` mode: simplified to `padding: 12px 8px`; the padded wrapper already keeps slides in-column, so its redundant re-clipping is removed.

## Verification (headless Chromium against production build)
- Intro carousel: all 3 images (incl. the previously-clipped map) show full shadows ✓
- Webapp carousel: full shadows, no cloned slide peeking on the left ✓
- `--contained` carousels (snow leopard): render cleanly, no regression ✓
- No horizontal page overflow introduced ✓