### PR TITLE
feat(404): sticky footer + pangolin-as-zero animation

### DIFF
--- a/assets/sass/2-base/_base.scss
+++ b/assets/sass/2-base/_base.scss
@@ -7,6 +7,12 @@ body {
   font-size: $base-font-size;
   line-height: $base-line-height !important;
   overflow-x: clip; // clip (not hidden) so it doesn't break position:sticky on .header
+  // Sticky footer: full-height flex column so the footer sinks to the bottom of the
+  // viewport on short pages (e.g. 404). The hero image (position:absolute, home-only)
+  // and load curtain (position:fixed) are out of flow, so they ignore the flex layout.
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
   color: var(--text-color);
   background-color: var(--background-color);
   -webkit-font-smoothing: antialiased;
@@ -41,6 +47,12 @@ body {
   @media (max-width: $mobile) {
     font-size: 16px;
   }
+}
+
+// Main content region grows to absorb leftover height, pushing the footer down
+// (sticky footer). Pairs with the flex column on `body` above.
+.content {
+  flex: 1 0 auto;
 }
 
 h1,

--- a/assets/sass/4-layouts/_post.scss
+++ b/assets/sass/4-layouts/_post.scss
@@ -511,18 +511,70 @@ html {
 }
 
 /* 404 */
+// Vertically centre the 404 content in the space between header and footer.
+// Scoped via :has() so only the error page turns <main> into a flex column —
+// every other page is untouched.
+.content:has(.error-page) {
+  display: flex;
+}
+
+.error-page {
+  flex: 1 0 auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 60px 0;
+}
+
 .error {
   text-align: center;
 
+  // "404" with the pangolin mascot standing in for the middle 0.
   .error__title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.04em;
     margin-bottom: 24px;
     font-size: 120px;
     line-height: 1;
   }
-  
+
+  // The pangolin-as-zero: sized in em so it tracks the responsive title size and
+  // sits at the digits' visual height. Rolls in on load (it IS a rolling ball),
+  // then settles into a slow gentle bob.
+  .error__zero {
+    display: inline-flex;
+
+    img {
+      height: 0.82em;
+      width: auto;
+      animation:
+        error-pangolin-rollin 0.9s ease-out both,
+        error-pangolin-bob 3s ease-in-out 0.9s infinite;
+    }
+  }
+
   @media (max-width: $mobile) {
     .error__title {
       font-size: 100px;
     }
+  }
+}
+
+@keyframes error-pangolin-rollin {
+  from { transform: translateX(-0.6em) rotate(-360deg); opacity: 0; }
+  to   { transform: translateX(0)      rotate(0);        opacity: 1; }
+}
+
+@keyframes error-pangolin-bob {
+  0%, 100% { transform: translateY(0)     rotate(0); }
+  50%      { transform: translateY(-0.05em) rotate(4deg); }
+}
+
+// Honour reduced-motion: show the pangolin static, no roll-in, no bob.
+@media (prefers-reduced-motion: reduce) {
+  .error .error__zero img {
+    animation: none;
   }
 }

--- a/docs/specs/2026-06-15-404-footer-pangolin-design.md
+++ b/docs/specs/2026-06-15-404-footer-pangolin-design.md
@@ -1,0 +1,85 @@
+# 404 page: sticky footer + animated pangolin
+
+Date: 2026-06-15
+
+## Problem
+
+1. On short pages (the 404 page being the clearest case), the footer is not pinned
+   to the bottom of the viewport — it floats up directly under the sparse content,
+   leaving empty space below it.
+2. The 404 page is plain. Adding the site's pangolin mascot (the brandmark logo),
+   animated, makes the dead-end page feel intentional and on-brand.
+
+## Part 1 — Sticky footer (all short pages)
+
+`layouts/_default/baseof.html` lays the body out as
+`header → main.content → subscribe → footer` with no mechanism to push the footer
+down when content is short.
+
+**Fix** (`assets/sass/2-base/_base.scss`):
+
+```scss
+body { display: flex; flex-direction: column; min-height: 100vh; }
+.content { flex: 1 0 auto; } // <main class="content"> absorbs the slack
+```
+
+Safe because the two non-flow siblings are unaffected by flex layout:
+- `.hero__image` is `position: absolute; z-index: -1` (home-only, out of flow).
+- The body load curtain (`body::after`) is `position: fixed`.
+
+Footer and subscribe remain natural last children; the growing `main` pushes the
+footer to the bottom on short pages and behaves normally on tall ones.
+
+## Part 2 — Animated pangolin on the 404 page
+
+The pangolin mascot stands in for the middle **0** of "404", reusing the existing
+brandmark asset `assets/images/logos/etm-logo.png` (its round earth-globe reads
+naturally as a zero). No new asset, no JS.
+
+**Markup** (`layouts/404.html`) — the title is `4` + pangolin + `4`:
+
+```
+.error
+  h2.error__title  "4" <span.error__zero><img etm-logo.png alt="0"></span> "4"
+  p.error__text
+  a.button "Back to home"
+```
+
+The image carries `alt="0"` so the heading still reads "404" to assistive tech. A
+Hugo `{{ with }}`/`{{ else }}` falls back to a literal `0` if the asset is missing.
+
+**Styles** (extend the existing `.error` block in
+`assets/sass/4-layouts/_post.scss`):
+
+- `.error__title` becomes a centered flex row (`4`, pangolin, `4`) with a small gap.
+- `.error__zero img` height `0.82em` — sized in `em` so it tracks the responsive
+  title font-size and matches the digits' visual height on every breakpoint (no
+  separate mobile size rule needed).
+- **Roll-in entrance** `@keyframes error-pangolin-rollin`: on load, translateX from
+  the left + `rotate(360deg)` → settles in place (it *is* a rolling ball). ~0.9s
+  ease-out, runs once.
+- **Gentle bob** `@keyframes error-pangolin-bob`: subtle `translateY` with a tiny
+  rotate, ~3s ease-in-out, infinite. Chained after the roll-in via the `animation`
+  shorthand list with a 0.9s delay so the bob starts once the entrance ends.
+- **Reduced motion**: inside `@media (prefers-reduced-motion: reduce)`, set
+  `animation: none` and show the pangolin static — matching the existing guard in
+  `common.js` and the header brandmark.
+
+The existing `bm-roll` keyframe (header/footer logo) is untouched; the 404
+keyframes are uniquely named to avoid collision.
+
+## Out of scope (YAGNI)
+
+- No changes to header/footer brandmark behavior.
+- No new JavaScript.
+- No new image assets.
+
+## Success criteria
+
+- `hugo` builds clean.
+- On the built `404.html`, the footer sits at the bottom of the viewport with the
+  short error content (no footer floating mid-page).
+- The pangolin stands in for the middle 0 of "404", rolls in on load, then bobs
+  gently; static under `prefers-reduced-motion: reduce`. Heading reads "404" to
+  assistive tech via `alt="0"`.
+- Tall pages (home, a blog post) are visually unchanged.

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,14 +1,13 @@
 {{ define "main" }}
 
 <!-- begin page -->
-<div class="container">
-  <div class="page">
-    <div class="page__content">
-      <div class="error">
-        <h2 class="error__title">404</h2>
-        <p class="error__text">The requested page could not be found.</p>
-        <p><a href="/" class="button">Back to the blog</a></p>
-      </div>
+<div class="error-page">
+  <div class="container">
+    <div class="error">
+      {{ $pangolin := resources.Get "images/logos/etm-logo.png" }}
+      <h2 class="error__title">4{{ with $pangolin }}<span class="error__zero"><img src="{{ .RelPermalink }}" alt="0"></span>{{ else }}0{{ end }}4</h2>
+      <p class="error__text">The requested page could not be found.</p>
+      <p><a href="/" class="button">Back to home</a></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## What

Two fixes for the 404 / short-page experience:

### 1. Sticky footer (all short pages)
On short pages the footer floated up mid-viewport with empty space below it. `body` is now a `min-height:100vh` flex column and `main.content` grows to absorb the slack, so the footer sinks to the bottom. The hero image (`position:absolute`, home-only) and load curtain (`position:fixed`) are out of flow and unaffected.

### 2. Animated pangolin on the 404 page
The pangolin brandmark now stands in for the **middle 0 of "404"** (its round earth-globe reads as a zero). It:
- is sized in `em` so it tracks the responsive title at every breakpoint,
- carries `alt="0"` so the heading still reads "404" to assistive tech,
- **rolls in** on load, then settles into a slow **gentle bob**,
- is **static under `prefers-reduced-motion: reduce`** (matching the existing header brandmark guard).

The error block is **vertically centred** between header and footer, scoped to the 404 via `:has(.error-page)` so no other page is affected. Existing `bm-roll` keyframe (header/footer logo) is untouched; the new keyframes are uniquely named.

## Verification
- `hugo` builds clean.
- Verified on the built `404.html` at desktop (1280px) and mobile (390px): pangolin-as-zero renders, content vertically centred, footer at the bottom.
- Home page (tall, with absolute hero) visually unchanged — no regression from the flex-column body.

Design doc: `docs/specs/2026-06-15-404-footer-pangolin-design.md`