### PR TITLE
feat(hero): broaden audience copy to researchers and rangers

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -161,7 +161,7 @@ pagerSize = 6
   [params.hero]
     enable = true
     hero_title = "Open tools for the people <span><i>protecting nature</i></span>" # Add the "span" tag to highlight text.
-    hero_description = "We build open source technology that helps conservation scientists monitor wildlife, detect threats, and protect ecosystems."
+    hero_description = "We build open source technology that helps researchers and rangers monitor wildlife, detect threats, and protect ecosystems."
     hero_button_contact = "Get In Touch"
     hero_button_work = "Our Work"
 


### PR DESCRIPTION
## What

Updates the homepage hero description to broaden the audience wording.

**Before:**
> We build open source technology that helps **conservation scientists** monitor wildlife, detect threats, and protect ecosystems.

**After:**
> We build open source technology that helps **researchers and rangers** monitor wildlife, detect threats, and protect ecosystems.

## Why

"Conservation scientists" was too narrow and clashed with the broader framing already used in the hero title ("the people protecting nature") and the About page ("conservation teams", "researchers and rangers"). The new wording matches that voice and reflects the field teams we actually build for.

## Scope

Single-line change to `config.toml:164` (`params.hero.hero_description`).