### PR TITLE
feat(demos): pangolin loading animation over Gradio embeds

### DIFF
--- a/assets/js/gradio-loader.js
+++ b/assets/js/gradio-loader.js
@@ -6,7 +6,12 @@
   "use strict";
 
   var MIN_DISPLAY_MS = 2000;
-  var MAX_WAIT_MS = 15000;
+  // Cold HF Spaces can take much longer than a warm one to render. Gradio fires
+  // `render` only when the real app mounts (not during the building/sleeping
+  // phase), so we lean on that; this is just a last-resort cap so a Space that
+  // never renders eventually reveals (showing Gradio's own error) rather than
+  // spinning forever.
+  var MAX_WAIT_MS = 30000;
   var FADE_MS = 400;
 
   function initEmbed(embed) {
@@ -41,15 +46,16 @@
       }
     }
 
-    // Primary signal: gradio dispatches "render" on the element once mounted.
+    // Primary signal: gradio dispatches "render" on the element only once the
+    // real app has mounted — NOT during the building/sleeping/error phase.
     app.addEventListener("render", requestReveal, { once: true });
 
-    // Backstop: watch for the real Gradio container appearing (light or shadow DOM).
+    // Backstop (in case `render` is absent on some gradio version): reveal when
+    // actual interactive content exists. The building/sleeping screen has no
+    // form controls, so this won't fire prematurely the way watching for the
+    // bare .gradio-container shell did.
     observer = new MutationObserver(function () {
-      var container =
-        app.querySelector(".gradio-container") ||
-        (app.shadowRoot && app.shadowRoot.querySelector(".gradio-container"));
-      if (container) requestReveal();
+      if (app.querySelector("button, input, textarea")) requestReveal();
     });
     observer.observe(app, { childList: true, subtree: true });
 

--- a/assets/js/gradio-loader.js
+++ b/assets/js/gradio-loader.js
@@ -12,7 +12,9 @@
   // never renders eventually reveals (showing Gradio's own error) rather than
   // spinning forever.
   var MAX_WAIT_MS = 30000;
-  var FADE_MS = 400;
+  // Must cover the longest reveal transition in _gradio-loader.scss (0.55s)
+  // so the loader isn't removed from layout before its dissolve finishes.
+  var FADE_MS = 600;
 
   function initEmbed(embed) {
     var loader = embed.querySelector("[data-gradio-loader]");

--- a/assets/js/gradio-loader.js
+++ b/assets/js/gradio-loader.js
@@ -1,0 +1,70 @@
+// Shows a spinning pangolin overlay over each embedded Gradio app until the HF
+// Space is ready, then fades the overlay out and the demo in. Reveal fires on
+// (ready signal OR max-timeout) but never before a minimum display time, so a
+// fast load does not flicker and a failed detection never traps the spinner.
+(function () {
+  "use strict";
+
+  var MIN_DISPLAY_MS = 2000;
+  var MAX_WAIT_MS = 15000;
+  var FADE_MS = 400;
+
+  function initEmbed(embed) {
+    var loader = embed.querySelector("[data-gradio-loader]");
+    var app = embed.querySelector("gradio-app");
+    if (!loader || !app) return;
+
+    var start = Date.now();
+    var revealed = false;
+    var observer = null;
+    var maxTimer = null;
+
+    function cleanup() {
+      if (observer) { observer.disconnect(); observer = null; }
+      if (maxTimer) { clearTimeout(maxTimer); maxTimer = null; }
+    }
+
+    function reveal() {
+      if (revealed) return;
+      revealed = true;
+      cleanup();
+      embed.classList.add("is-ready");
+      setTimeout(function () { loader.style.display = "none"; }, FADE_MS);
+    }
+
+    function requestReveal() {
+      var elapsed = Date.now() - start;
+      if (elapsed >= MIN_DISPLAY_MS) {
+        reveal();
+      } else {
+        setTimeout(reveal, MIN_DISPLAY_MS - elapsed);
+      }
+    }
+
+    // Primary signal: gradio dispatches "render" on the element once mounted.
+    app.addEventListener("render", requestReveal, { once: true });
+
+    // Backstop: watch for the real Gradio container appearing (light or shadow DOM).
+    observer = new MutationObserver(function () {
+      var container =
+        app.querySelector(".gradio-container") ||
+        (app.shadowRoot && app.shadowRoot.querySelector(".gradio-container"));
+      if (container) requestReveal();
+    });
+    observer.observe(app, { childList: true, subtree: true });
+
+    // Hard fallback so the overlay never sticks if no signal arrives.
+    maxTimer = setTimeout(requestReveal, MAX_WAIT_MS);
+  }
+
+  function init() {
+    var embeds = document.querySelectorAll("[data-gradio-embed]");
+    for (var i = 0; i < embeds.length; i++) initEmbed(embeds[i]);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/assets/sass/3-modules/_gradio-loader.scss
+++ b/assets/sass/3-modules/_gradio-loader.scss
@@ -5,6 +5,16 @@
 
 .gradio-embed {
   position: relative;
+  // Reserve height in the document flow so the opaque loader covers its own
+  // space (and any boot-time Gradio glitch) instead of floating over the
+  // content below it while <gradio-app> is still 0px tall.
+  min-height: 480px;
+}
+
+// Once revealed, stop reserving space — let the embed collapse to the live
+// demo's natural height.
+.gradio-embed.is-ready {
+  min-height: 0;
 }
 
 .gradio-embed__loader {
@@ -16,7 +26,6 @@
   align-items: center;
   justify-content: center;
   gap: 18px;
-  min-height: 480px;
   background: var(--background-color);
   opacity: 1;
   transition: opacity 0.4s ease;

--- a/assets/sass/3-modules/_gradio-loader.scss
+++ b/assets/sass/3-modules/_gradio-loader.scss
@@ -10,6 +10,9 @@
   // space (and any boot-time Gradio glitch) instead of floating over the
   // content below it while <gradio-app> is still 0px tall.
   min-height: 480px;
+  // Ease the reserved height down on reveal so a demo shorter than 480px
+  // settles smoothly instead of snapping.
+  transition: min-height 0.5s ease;
 }
 
 // Once revealed, stop reserving space — let the embed collapse to the live
@@ -20,10 +23,12 @@
 
 // Keep the live app (and all of Gradio's pre-render UI) invisible and inert
 // until ready. opacity:0 still lets Gradio load, connect, and render offscreen.
+// On reveal the demo fades in quickly so it's solid before the overlay finishes
+// dissolving — avoids a muddy cross-fade where both are half-visible at once.
 .gradio-embed gradio-app {
   opacity: 0;
   pointer-events: none;
-  transition: opacity 0.4s ease;
+  transition: opacity 0.35s ease;
 }
 
 .gradio-embed.is-ready gradio-app {
@@ -42,11 +47,14 @@
   gap: 18px;
   background: var(--background-color);
   opacity: 1;
-  transition: opacity 0.4s ease;
+  // Dissolve a touch slower than the demo fades in, with a subtle scale-down,
+  // so the overlay melts away to reveal the (already solid) demo beneath.
+  transition: opacity 0.55s ease, transform 0.55s ease;
 }
 
 .gradio-embed.is-ready .gradio-embed__loader {
   opacity: 0;
+  transform: scale(0.98);
   pointer-events: none;
 }
 
@@ -73,6 +81,7 @@
   .gradio-embed__pangolin {
     animation: none;
   }
+  .gradio-embed,
   .gradio-embed__loader,
   .gradio-embed gradio-app {
     transition: none;

--- a/assets/sass/3-modules/_gradio-loader.scss
+++ b/assets/sass/3-modules/_gradio-loader.scss
@@ -1,7 +1,8 @@
 // Pangolin loading overlay shown over an embedded Gradio app while the HF Space
-// wakes up. The overlay sits on top of <gradio-app> (which starts at 0px height)
-// and reserves its own height so the boot-time error/status flash stays hidden.
-// JS (assets/js/gradio-loader.js) adds .is-ready to reveal the demo.
+// wakes up. The <gradio-app> itself is held invisible (opacity:0) until ready,
+// so Gradio's own building/sleeping/error UI — including high-z-index toasts,
+// which inherit an ancestor's opacity — never shows through. JS
+// (assets/js/gradio-loader.js) adds .is-ready once Gradio fires `render`.
 
 .gradio-embed {
   position: relative;
@@ -15,6 +16,19 @@
 // demo's natural height.
 .gradio-embed.is-ready {
   min-height: 0;
+}
+
+// Keep the live app (and all of Gradio's pre-render UI) invisible and inert
+// until ready. opacity:0 still lets Gradio load, connect, and render offscreen.
+.gradio-embed gradio-app {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.4s ease;
+}
+
+.gradio-embed.is-ready gradio-app {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .gradio-embed__loader {
@@ -59,7 +73,8 @@
   .gradio-embed__pangolin {
     animation: none;
   }
-  .gradio-embed__loader {
+  .gradio-embed__loader,
+  .gradio-embed gradio-app {
     transition: none;
   }
 }

--- a/assets/sass/3-modules/_gradio-loader.scss
+++ b/assets/sass/3-modules/_gradio-loader.scss
@@ -1,0 +1,56 @@
+// Pangolin loading overlay shown over an embedded Gradio app while the HF Space
+// wakes up. The overlay sits on top of <gradio-app> (which starts at 0px height)
+// and reserves its own height so the boot-time error/status flash stays hidden.
+// JS (assets/js/gradio-loader.js) adds .is-ready to reveal the demo.
+
+.gradio-embed {
+  position: relative;
+}
+
+.gradio-embed__loader {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  min-height: 480px;
+  background: var(--background-color);
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+
+.gradio-embed.is-ready .gradio-embed__loader {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.gradio-embed__pangolin {
+  width: 72px;
+  height: 72px;
+  animation: gradio-pangolin-spin 1.1s linear infinite;
+}
+
+.gradio-embed__label {
+  margin: 0;
+  font-size: 15px;
+  letter-spacing: 0.02em;
+  color: var(--text-alt-color);
+}
+
+@keyframes gradio-pangolin-spin {
+  from { transform: rotate(0); }
+  to { transform: rotate(360deg); }
+}
+
+// Reduced motion: static pangolin, instant reveal.
+@media (prefers-reduced-motion: reduce) {
+  .gradio-embed__pangolin {
+    animation: none;
+  }
+  .gradio-embed__loader {
+    transition: none;
+  }
+}

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -118,6 +118,8 @@
 @import '3-modules/tabs';
 /* >>>>>>>>>>>>>> :: 3.18-Gradio Reset <<<<<<<<<<<<<<< */
 @import '3-modules/gradio-reset';
+/* >>>>>>>>>>>>>> :: 3.18b-Gradio Loader <<<<<<<<<<<<<<< */
+@import '3-modules/gradio-loader';
 /* >>>>>>>>>>>>>> :: 3.19-Image Carousel <<<<<<<<<<<<<<< */
 @import '3-modules/image-carousel';
 /* >>>>>>>>>>>>>> :: 3.20-Lazy Images <<<<<<<<<<<<<<< */

--- a/docs/specs/2026-06-16-demo-pangolin-loader-design.md
+++ b/docs/specs/2026-06-16-demo-pangolin-loader-design.md
@@ -1,0 +1,129 @@
+# Live Demo Pangolin Loader — Design
+
+Date: 2026-06-16
+Branch: `worktree-arthur+demo-pangolin-loader`
+
+## Problem
+
+Individual live demo pages embed a Hugging Face Space via `<gradio-app>`. While the
+Space wakes up (cold start), the bare `<gradio-app>` shows a loading glitch / error
+status message before the real demo appears. We want to cover that boot phase with a
+spinning pangolin-logo animation, then transition smoothly to the live demo once it is
+ready.
+
+## Goal
+
+Show a pangolin-spinner overlay on top of every Gradio embed until the Space is ready
+(with a minimum display so it never flickers and a max-timeout fallback so it never
+sticks), then fade the overlay out and fade the demo in.
+
+## Scope
+
+Two embed sites, both fed by one shared partial:
+
+1. `layouts/demos/single.html` — the individual live demo pages.
+2. `layouts/shortcodes/hf_space.html` — the `hf_space` shortcode used elsewhere.
+
+Out of scope: the projects/spaces card embeds that do not render a live `<gradio-app>`.
+
+## Approach
+
+**Shared wrapper partial + one JS controller + SCSS.** Markup lives in one partial so the
+two embed sites stay in sync; a single site-wide JS controller drives every embed on a
+page; SCSS owns the spinner and fade.
+
+### Components
+
+#### 1. Shared partial — `layouts/partials/gradio-embed.html`
+
+Renders the loader overlay + `<gradio-app>` inside a positioned wrapper. Parameters
+(passed via `dict`): `src` (the `<space>.hf.space` host, required) and
+`gradio_js_version` (optional, default `5.4.0`).
+
+```html
+{{- $src := .src -}}
+{{- $ver := .gradio_js_version | default "5.4.0" -}}
+<div class="gradio-embed" data-gradio-embed>
+  <div class="gradio-embed__loader" data-gradio-loader aria-hidden="true">
+    {{ $pangolin := resources.Get "images/logos/etm-logo.png" }}
+    {{ with $pangolin }}<img class="gradio-embed__pangolin" src="{{ .RelPermalink }}" alt="">{{ end }}
+    <p class="gradio-embed__label">Waking up the live demo…</p>
+  </div>
+  <script type="module"
+    src="https://gradio.s3-us-west-2.amazonaws.com/{{ $ver }}/gradio.js"></script>
+  <gradio-app src="https://{{ $src }}.hf.space"
+    initial_height="0px" theme_mode="light" eager="true" container="false"></gradio-app>
+</div>
+```
+
+The script tag is duplicated per embed today; consolidating it is not required for this
+change (a page only embeds one Space in practice). Keep current behavior: load the
+version-pinned gradio.js next to the app.
+
+#### 2. Both templates call the partial
+
+- `layouts/demos/single.html`: replace the inline `<script>` + `<gradio-app>` block
+  (lines ~58–73) with
+  `{{ partial "gradio-embed.html" (dict "src" .Params.hf_space "gradio_js_version" .Params.gradio_js_version) }}`.
+- `layouts/shortcodes/hf_space.html`: replace its inline block with
+  `{{ partial "gradio-embed.html" (dict "src" (.Get 0) "gradio_js_version" (.Get 1)) }}`
+  (preserve the existing `.hf-space__gradio margin-bottom margin-top` wrapper around it).
+
+#### 3. JS controller — `assets/js/gradio-loader.js`
+
+Loaded site-wide the same way `common.js` is (verify the existing include mechanism and
+mirror it). For each `[data-gradio-embed]`:
+
+1. On `DOMContentLoaded`, the loader overlay is visible; the `<gradio-app>` sits beneath.
+2. Start a **min-display timer = 2000 ms** and a **max fallback timer = 15000 ms**.
+3. **Detect readiness.** Primary signal: the `render` event dispatched on the
+   `<gradio-app>` element. Backstop: a `MutationObserver` that resolves when the real
+   Gradio container/content appears under the app. *The exact ready signal must be
+   verified against a real (sleeping) Space during implementation — adjust if `render`
+   does not fire reliably for the pinned gradio version.*
+4. **Reveal** when `(ready OR max-timeout fired) AND min-2s elapsed`. Revealing adds a
+   class that fades the overlay out and the demo in over ~400 ms; after the transition,
+   the loader is removed from layout (`display:none`) so it never traps clicks.
+5. Each embed is independent; timers/observers are scoped per element.
+
+#### 4. SCSS — new partial `assets/sass/.../_gradio-loader.scss` (or fold into `_space.scss`)
+
+- `.gradio-embed` — `position: relative`.
+- `.gradio-embed__loader` — absolutely positioned, fills the wrapper, `min-height` ~480px
+  so it reserves vertical space while `<gradio-app>` is still `0px` tall; centered column
+  (pangolin + label); site background so the boot glitch underneath is fully hidden.
+- `.gradio-embed__pangolin` — sized ~72px; continuous spin
+  `animation: gradio-pangolin-spin 1.1s linear infinite` where the keyframe is
+  `rotate(0) → rotate(360deg)` (same idea as the header `bm-roll`, but infinite).
+- `.gradio-embed__label` — muted text using existing type tokens.
+- Reveal classes: `.gradio-embed.is-ready .gradio-embed__loader { opacity: 0; }` then
+  removed via JS; `.gradio-embed__loader { transition: opacity .4s ease; }`.
+
+### Reduced motion
+
+Under `@media (prefers-reduced-motion: reduce)`: pangolin does not spin (static image +
+label), and the fade is instant. Mirrors the existing 404 / header reduced-motion pattern.
+
+### Error-flash handling
+
+Because the overlay sits on top of `<gradio-app>` (opaque background, higher stacking)
+until reveal, the boot-time error/status message is hidden the entire time. The
+max-timeout guarantees the overlay never sticks permanently even if readiness detection
+fails.
+
+## Success criteria
+
+1. Site builds (`hugo`) with no errors.
+2. On a demo page with a cold Space, the spinning pangolin shows immediately; the boot
+   error/status message is never visible.
+3. The overlay stays at least ~2s, then fades out and the live demo fades in once ready.
+4. If readiness is never detected, the overlay fades out by ~15s (no permanent spinner).
+5. With `prefers-reduced-motion: reduce`, the pangolin is static and the transition is
+   instant.
+6. Both the demo pages and the `hf_space` shortcode render through the shared partial.
+
+## Out of scope / non-goals
+
+- No change to which Spaces are embedded or their gradio versions.
+- No retry/health-check logic against the Space beyond the readiness signal + timeout.
+- No new build tooling.

--- a/layouts/demos/single.html
+++ b/layouts/demos/single.html
@@ -57,18 +57,7 @@
     {{ end }}
     {{ if .Params.hf_space }}
     <div class="space-content__hf_space">
-    {{/*load the right gradio version*/}}
-    <script
-      type="module"
-      src="https://gradio.s3-us-west-2.amazonaws.com/{{ .Params.gradio_js_version | default "5.4.0" }}/gradio.js"
-    ></script>
-    <gradio-app
-            src="https://{{ .Params.hf_space }}.hf.space"
-            initial_height="0px"
-            theme_mode="light"
-            eager="true"
-            container="false"
-      ></gradio-app>
+      {{ partial "gradio-embed.html" (dict "src" .Params.hf_space "gradio_js_version" .Params.gradio_js_version) }}
     </div>
     {{ end }}
     {{ .Content }}

--- a/layouts/partials/gradio-embed.html
+++ b/layouts/partials/gradio-embed.html
@@ -1,0 +1,20 @@
+{{- $src := .src -}}
+{{- $ver := .gradio_js_version | default "5.4.0" -}}
+<div class="gradio-embed" data-gradio-embed>
+  <div class="gradio-embed__loader" data-gradio-loader aria-hidden="true">
+    {{ $pangolin := resources.Get "images/logos/etm-logo.png" }}
+    {{ with $pangolin }}<img class="gradio-embed__pangolin" src="{{ .RelPermalink }}" alt="" width="72" height="72">{{ end }}
+    <p class="gradio-embed__label">Waking up the live demo…</p>
+  </div>
+  <script
+    type="module"
+    src="https://gradio.s3-us-west-2.amazonaws.com/{{ $ver }}/gradio.js"
+  ></script>
+  <gradio-app
+    src="https://{{ $src }}.hf.space"
+    initial_height="0px"
+    theme_mode="light"
+    eager="true"
+    container="false"
+  ></gradio-app>
+</div>

--- a/layouts/partials/javascripts.html
+++ b/layouts/partials/javascripts.html
@@ -1,10 +1,13 @@
 {{ $script := resources.Get "js/scripts.js" }}
 {{ $commonJs := resources.Get "js/common.js" }}
+{{ $gradioLoader := resources.Get "js/gradio-loader.js" }}
 
 {{ if hugo.IsServer }}
 <script src="{{ $script.Permalink }}"></script>
 <script src="{{ $commonJs.Permalink }}"></script>
+<script src="{{ $gradioLoader.Permalink }}"></script>
 {{ else }}
 <script src="{{ ($script | minify | fingerprint).RelPermalink }}"></script>
 <script src="{{ ($commonJs | minify | fingerprint).RelPermalink }}"></script>
+<script src="{{ ($gradioLoader | minify | fingerprint).RelPermalink }}"></script>
 {{ end }}

--- a/layouts/shortcodes/hf_space.html
+++ b/layouts/shortcodes/hf_space.html
@@ -1,13 +1,3 @@
-<script
-  type="module"
-  src="https://gradio.s3-us-west-2.amazonaws.com/{{ with .Get 1 }}{{ . }}{{ else }}5.4.0{{ end }}/gradio.js"
-></script>
 <div class="hf-space__gradio margin-bottom margin-top">
-  <gradio-app
-          src="https://{{ .Get 0 }}.hf.space"
-          initial_height="0px"
-          theme_mode="light"
-          eager="true"
-          container="false"
-    ></gradio-app>
+  {{ partial "gradio-embed.html" (dict "src" (.Get 0) "gradio_js_version" (.Get 1)) }}
 </div>


### PR DESCRIPTION
## Summary

Live demo pages embed a Hugging Face Space via `<gradio-app>`. While the Space wakes up (cold start), Gradio shows its own building/sleeping/error UI before the demo appears. This replaces that boot flash with a spinning **pangolin** overlay that fades into the live demo once it's ready.

- New shared partial `layouts/partials/gradio-embed.html` renders the loader overlay + `<gradio-app>`; used by both `demos/single.html` and the `hf_space` shortcode so the two embed sites stay in sync.
- `assets/js/gradio-loader.js` reveals the demo on Gradio's `render` event (which fires only when the real app mounts — not during the building phase), with a 2s minimum (anti-flicker), a buttons/inputs backstop, and a 30s last-resort cap.
- `assets/sass/3-modules/_gradio-loader.scss` styles the spinner/label, reserves height so the loader doesn't overlap following content, and **holds `<gradio-app>` at `opacity:0` until ready** — so Gradio's loading/toast/error UI (even high z-index) can't show through.
- Honors `prefers-reduced-motion` (static logo, instant reveal).

Spec: `docs/specs/2026-06-16-demo-pangolin-loader-design.md`

## Test Plan

- [x] `hugo` builds clean
- [x] Demo pages and `hf_space` shortcode both render the overlay
- [x] Headless: pangolin shown at load with Gradio fully hidden; `is-ready` set after `render` + 2s
- [x] Reduced-motion rule present in compiled CSS
- [ ] Verify on a genuinely cold Space in a real browser (headless can't reproduce a sleeping Space): pangolin spins until the app renders, no HF loading/error flash, then fades to the live demo