### PR TITLE
feat(home): move build-technology CTA to bottom of homepage

### DIFF
--- a/assets/sass/3-modules/_tools.scss
+++ b/assets/sass/3-modules/_tools.scss
@@ -482,20 +482,3 @@
   flex-wrap: wrap;
 }
 
-/* homepage tools section — the CTA band ends the section in its own .container.
-   The following section (the partners/testimonials band) carries 96px of its
-   own top padding, which stacked with the section margins left an oversized gap
-   below the CTA. Drop this section's bottom margin and trim the next section's
-   top spacing for this adjacency so the gap matches the page rhythm. */
-.tools-section {
-  margin-bottom: 0;
-
-  .build-cta {
-    margin-bottom: 0;
-  }
-}
-
-.tools-section + .section {
-  margin-top: 0;
-  padding-top: 48px;
-}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -12,4 +12,8 @@
 
 {{ partial "section-tags.html" . }}
 
+<section class="section build-cta-section animate">
+  {{ partial "build-cta.html" (dict "class" "build-cta--home") }}
+</section>
+
 {{ end }}

--- a/layouts/partials/section-tools.html
+++ b/layouts/partials/section-tools.html
@@ -31,8 +31,6 @@
     </div>
   </div>
 
-  {{ partial "build-cta.html" (dict "class" "build-cta--home") }}
-
 </section>
 <!-- end home tools -->
 {{ end }}


### PR DESCRIPTION
## Summary

Moves the **"Help us build technology that matters"** CTA band from the end of the home tools section to the very bottom of the homepage, after the tags section.

## Changes
- `layouts/partials/section-tools.html` — remove the in-section CTA partial
- `layouts/index.html` — render the CTA in its own `.build-cta-section` as the final section before the footer
- `assets/sass/3-modules/_tools.scss` — drop the now-orphaned `.tools-section` adjacency spacing rules that only existed to tidy the gap below the in-section CTA

## Verification
- `hugo` builds cleanly
- Rendered `public/index.html` shows the CTA as the last section, immediately before `</main>` and the footer