### PR TITLE
fix(footer): stop cropping Recent Posts thumbnails

### DIFF
--- a/assets/sass/3-modules/_footer.scss
+++ b/assets/sass/3-modules/_footer.scss
@@ -104,10 +104,12 @@
   position: relative;
   display: block;
   transform: translate(0);
-  height: 100%;
+  width: 100px;
   min-width: 100px;
+  flex-shrink: 0;
   margin-right: 16px;
   border-radius: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
   overflow: hidden;
   background: var(--background-alt-color);
 
@@ -118,7 +120,9 @@
   &::after {
     content: "";
     display: table;
-    padding-top: 90%;
+    // Match the 1500×1050 (70%) cover aspect ratio so object-fit: cover
+    // fills the box without cropping the title text on the left edge.
+    padding-top: 70%;
   }
 
   img {


### PR DESCRIPTION
## Problem

The **Recent Posts** thumbnails in the footer were cropped on the left edge, cutting off the title text baked into each cover image (e.g. "Metric Learning" → "etric Learning", "Racing Models" → "acing Models", "Smoke Is a Behavior" → "moke Is a Behavior").

## Cause

The `.recent-posts__image` box relied on `height: 100%` (no resolvable parent height) plus only a `min-width`, and used a `padding-top: 90%` aspect-ratio spacer that made the box nearly square. The cover images are authored at **1500×1050 (70% / ratio 1.43)**, so `object-fit: cover` scaled them up to fill the squarish box and cropped the overflow off the left and right — clipping the title text.

## Fix

- Fixed box width to `100px` with `flex-shrink: 0` (removed the ambiguous `height: 100%`).
- Set the aspect-ratio spacer to `padding-top: 70%` to match the authored cover ratio, so the full image fits with no horizontal crop.
- Added a `1px` hairline border (`rgba(0,0,0,0.08)`) so the thumbnails read clearly against the beige footer background.

`box-sizing: border-box` is global, so the border draws inside the box and does not shift the surrounding layout/spacing.

## Verification

Confirmed in the rendered footer that all three Recent Posts titles are now fully visible with no left-edge clipping, and spacing between thumbnail and text is unchanged.