### PR TITLE
Better next reads: theme tags + curated related posts

### DIFF
--- a/content/posts/a-visual-guide-to-metric-learning/index.md
+++ b/content/posts/a-visual-guide-to-metric-learning/index.md
@@ -4,6 +4,9 @@ description: An intuition-first, visual guide to metric learning — how machine
 date: 2026-06-16
 image: /images/posts/a-visual-guide-to-metric-learning/cover.png
 tags: ["AI", "vision", "metric learning", "identification"]
+related_posts:
+  - bear-identification-with-metric-learning-guide
+  - local-feature-matching-lightglue
 distances:
   - name: Euclidean
     desc: "Straight-line distance between two vectors. Intuitive, but sensitive to length — two embeddings can point the same way yet sit far apart if their magnitudes differ."

--- a/content/posts/bear-face-segmentation-guide/index.md
+++ b/content/posts/bear-face-segmentation-guide/index.md
@@ -5,7 +5,10 @@ date: 2024-04-11
 params:
   math: true
 image: /images/posts/bear-face-segmentation-guide/cover.png 
-tags: ["AI", "vision", "camera traps"]
+tags: ["AI", "vision", "camera traps", "bear"]
+related_posts:
+  - bear-identification-with-metric-learning-guide
+  - how-to-prepare-data-for-identification
 ---
 
 In this post we'll walk through the technical development of a bear face

--- a/content/posts/bear-identification-with-metric-learning-guide/index.md
+++ b/content/posts/bear-identification-with-metric-learning-guide/index.md
@@ -3,7 +3,10 @@ title: A guide to designing a bear face recognition system
 description: Identify bears with Metric Learning.
 date: 2024-04-12
 image: /images/posts/bear-identification-with-metric-learning-guide/cover.png 
-tags: ["AI", "vision", "metric learning", "identification"]
+tags: ["AI", "vision", "metric learning", "identification", "bear"]
+related_posts:
+  - bear-face-segmentation-guide
+  - a-visual-guide-to-metric-learning
 metric_losses:
   - name: Contrastive
     desc: "Pulls similar pairs together and pushes dissimilar pairs apart in the embedding space."

--- a/content/posts/how-to-analyze-elephant-rumbles-at-scale/index.md
+++ b/content/posts/how-to-analyze-elephant-rumbles-at-scale/index.md
@@ -5,7 +5,10 @@ date: 2024-06-29
 params:
   math: true
 image: /images/posts/how-to-detect-elephant-rumbles-at-scale/cover.png
-tags: ["AI", "audio"]
+tags: ["AI", "audio", "acoustics"]
+related_posts:
+  - how-to-build-a-benthic-coral-reefs-analyser
+  - tracking-the-journey-how-to-monitor-wild-salmon-migrations
 spectrogram_reasons:
   - name: Frequency–time view
     desc: "A spectrogram shows which frequencies are present and how they change over time — exactly what tasks like sound-event detection need."

--- a/content/posts/how-to-build-a-benthic-coral-reefs-analyser/index.md
+++ b/content/posts/how-to-build-a-benthic-coral-reefs-analyser/index.md
@@ -5,7 +5,10 @@ date: 2024-04-10
 params:
   math: true
 image: /images/posts/how-to-build-a-benthic-coral-reefs-analyser/cover.png
-tags: ["AI", "vision"]
+tags: ["AI", "vision", "marine"]
+related_posts:
+  - tracking-the-journey-how-to-monitor-wild-salmon-migrations
+  - how-to-build-a-real-time-bear-detection-system
 ---
 
 In this post we explore the development of a benthic coral reef analyzer, built

--- a/content/posts/how-to-build-a-real-time-bear-detection-system/index.md
+++ b/content/posts/how-to-build-a-real-time-bear-detection-system/index.md
@@ -3,7 +3,10 @@ title: How to build a real time bear detection system
 description: Detecting bears in real time using low-power technology.
 date: 2024-04-09
 image: /images/posts/how-to-build-a-real-time-bear-detection-system/cover.png 
-tags: ["AI", "vision", "low power", "camera traps"]
+tags: ["AI", "vision", "low power", "camera traps", "bear", "edge"]
+related_posts:
+  - bear-face-segmentation-guide
+  - protecting-the-forest-early-forest-fire-detector
 ---
 
 In this post, we'll walk through the development of a real-time bear detection

--- a/content/posts/how-to-prepare-data-for-identification/index.md
+++ b/content/posts/how-to-prepare-data-for-identification/index.md
@@ -4,6 +4,9 @@ description: An in-depth look at the common preprocessing stages required to per
 date: 2024-12-08
 image: /images/posts/how-to-prepare-data-for-identification/cover.png
 tags: ["AI", "vision", "identification"]
+related_posts:
+  - a-visual-guide-to-metric-learning
+  - local-feature-matching-lightglue
 augmentations:
   - name: Random Scaling
     desc: "Varying the size of the images to simulate different distances from the camera."

--- a/content/posts/local-feature-matching-lightglue/index.md
+++ b/content/posts/local-feature-matching-lightglue/index.md
@@ -3,7 +3,10 @@ title: "Identify individuals with Local Feature Matching"
 description: A comprehensive examination of using local feature matching for individual identification.
 date: 2024-12-09
 image: /images/posts/local-feature-matching-lightglue/cover.png
-tags: ["AI", "vision", "identification", "local feature"]
+tags: ["AI", "vision", "identification", "local feature", "marine"]
+related_posts:
+  - a-visual-guide-to-metric-learning
+  - how-to-prepare-data-for-identification
 feature_matchers:
   - name: Brute-Force
     desc: "Computes the distance between every pair of descriptors and keeps the closest. Exact and simple, but the cost grows quickly with the number of keypoints."

--- a/content/posts/protecting-the-forest-early-forest-fire-detector/index.md
+++ b/content/posts/protecting-the-forest-early-forest-fire-detector/index.md
@@ -5,7 +5,10 @@ date: 2024-08-21
 params:
   math: true
 image: /images/posts/protecting-the-forest-early-forest-fire-detector/cover.png
-tags: ["AI", "vision", "low power"]
+tags: ["AI", "vision", "low power", "wildfire", "edge"]
+related_posts:
+  - smoke-is-a-behavior
+  - racing-models-not-opinions
 ---
 
 In this post, we’ll walk through the development of an early forest fire

--- a/content/posts/racing-models-not-opinions/index.md
+++ b/content/posts/racing-models-not-opinions/index.md
@@ -3,7 +3,10 @@ title: "Racing Models, Not Opinions: How We Ran Wildfire ML R&D for Pyronear"
 description: How a literature survey, self-contained experiments, and a shared leaderboard turned 28 research papers into a production smoke verifier with 4x fewer false alarms.
 date: 2026-06-12
 image: /images/posts/racing-models-not-opinions/cover.png
-tags: ["AI", "vision", "MLOps", "temporal models"]
+tags: ["AI", "vision", "MLOps", "temporal models", "wildfire"]
+related_posts:
+  - smoke-is-a-behavior
+  - protecting-the-forest-early-forest-fire-detector
 ---
 
 In 2024, we wrote about [building an early forest fire detector]({{< ref

--- a/content/posts/smoke-is-a-behavior/index.md
+++ b/content/posts/smoke-is-a-behavior/index.md
@@ -3,7 +3,10 @@ title: "Smoke Is a Behavior: Inside Pyronear's Temporal Wildfire Detection Model
 description: How the temporal smoke verifier works, step by step — detection boxes become tubes, stabilized crops make motion legible, and a vision transformer plus a tiny temporal head learn that smoke grows and drifts.
 date: 2026-06-12
 image: /images/posts/smoke-is-a-behavior/cover.png
-tags: ["AI", "vision", "temporal models", "transformers"]
+tags: ["AI", "vision", "temporal models", "transformers", "wildfire"]
+related_posts:
+  - racing-models-not-opinions
+  - protecting-the-forest-early-forest-fire-detector
 ---
 
 In [the previous post]({{< ref "/posts/racing-models-not-opinions" >}}) we

--- a/content/posts/tracking-the-journey-how-to-monitor-wild-salmon-migrations/index.md
+++ b/content/posts/tracking-the-journey-how-to-monitor-wild-salmon-migrations/index.md
@@ -3,7 +3,10 @@ title: "Tracking the Journey: How to Monitor Wild Salmon Migrations"
 description: An in-depth look at the systems developed and deployed to track the journey of wild salmon as they return to their natal streams.
 date: 2024-08-30
 image: /images/posts/tracking-the-journey-how-to-monitor-wild-salmon-migrations/cover.png
-tags: ["AI", "vision", "low power", "camera traps"]
+tags: ["AI", "vision", "low power", "camera traps", "marine", "edge"]
+related_posts:
+  - how-to-build-a-benthic-coral-reefs-analyser
+  - how-to-build-a-real-time-bear-detection-system
 ---
 
 In this post, we will dive into the development of a wild salmon monitoring

--- a/content/posts/volunteering_wildlife_rescue_centers/index.md
+++ b/content/posts/volunteering_wildlife_rescue_centers/index.md
@@ -4,6 +4,9 @@ description: Our experiences at various Wildlife Rescue Centers
 date: 2025-05-20
 image: /images/posts/volunteering_wildlife_rescue_centers/cover.png
 tags: ["wildlife", "illegal wildlife trade", "volunteering"]
+related_posts:
+  - how-to-analyze-elephant-rumbles-at-scale
+  - tracking-the-journey-how-to-monitor-wild-salmon-migrations
 ---
 
 

--- a/data/tags.yaml
+++ b/data/tags.yaml
@@ -37,3 +37,18 @@ tags:
 
   volunteering:
     emoji: "\U0001F91D"  # Handshake - community
+
+  wildfire:
+    emoji: "\U0001F525"  # Fire - wildfire / smoke detection
+
+  bear:
+    emoji: "\U0001F43B"  # Bear - bear projects
+
+  marine:
+    emoji: "\U0001F30A"  # Water wave - aquatic species
+
+  edge:
+    emoji: "\U0001F4DF"  # Pager - on-device / low-power deployment
+
+  acoustics:
+    emoji: "\U0001F50A"  # Loud speaker - audio / bioacoustics

--- a/docs/specs/2026-06-18-related-posts-recommendations-design.md
+++ b/docs/specs/2026-06-18-related-posts-recommendations-design.md
@@ -1,0 +1,160 @@
+# Better "Next Reads": Theme Tags + Curated Related Posts
+
+**Date:** 2026-06-18
+**Status:** Approved design, ready for implementation plan
+
+## Problem
+
+The site already shows a "You may also like" section at the bottom of each blog
+post (`layouts/partials/related-posts.html`). It picks the 2 most-recent posts
+that share *any* tag with the current post.
+
+But the tag vocabulary is too coarse: 12 of 13 posts carry both `AI` and
+`vision`. Tag-intersection therefore matches nearly every post to every other
+post, so the recommendations collapse to "the 2 newest posts" rather than the
+*semantically closest* ones. There is no real notion of relatedness.
+
+## Goals
+
+1. Recommendations at the bottom of a post should be genuinely related to that
+   post (same topic cluster), not just the newest posts.
+2. The tag system should differentiate posts so the `/tags/` browse pages and
+   the on-post tag chips are meaningful, and so the automatic fallback is
+   relevant.
+3. Stay within the existing Hugo mechanisms; no new build tooling or external
+   dependencies.
+
+## Non-goals
+
+- No embeddings / similarity scripts / build-time computation (revisit only if
+  the corpus grows large enough that manual curation stops scaling).
+- No redesign of the card markup or the sidebar widget.
+- No change to existing `/tags/` URLs for tags that already exist.
+
+## Approach
+
+Two complementary layers, both using mechanisms already present in the repo:
+
+1. **Theme tags** — a small controlled vocabulary of differentiating tags added
+   on top of the existing tags. These create tight clusters and power the
+   *fallback*.
+2. **Manual curation** — per-post `related_posts:` frontmatter (ordered,
+   best-match first). This is the primary, highest-quality signal.
+
+The bottom-of-post section becomes **curated-first, then tag-fill**: show the
+hand-picked posts in order, then fill any remaining slots (up to N=2, matching
+today) with tag-intersection matches, excluding self and already-shown posts.
+
+### Why this approach
+
+Manual curation gives the best quality for a 13-post corpus and reuses the
+`related_posts:` field the sidebar widget already understands. Theme tags make
+the automatic fallback relevant and improve tag-browsing as a side benefit.
+Together they mean every post always shows good recommendations with full
+editorial control.
+
+## Detailed Design
+
+### Component 1 — Theme tags (`data/tags.yaml` + post frontmatter)
+
+Introduce 5 new theme tags. Each gets an emoji entry in `data/tags.yaml` so the
+"Explore Topics" / tag chips render consistently:
+
+| Theme tag   | Meaning                          | Suggested emoji |
+| ----------- | -------------------------------- | --------------- |
+| `wildfire`  | smoke / forest-fire detection    | 🔥              |
+| `bear`      | bear-focused projects            | 🐻              |
+| `marine`    | aquatic species (coral, salmon, trout/whales/seals) | 🌊 |
+| `edge`      | on-device / low-power deployment | 📟              |
+| `acoustics` | audio / bioacoustic analysis     | 🔊              |
+
+The existing `metric learning` and `identification` tags already serve the
+individual-ID cluster and are reused rather than duplicated.
+
+### Component 2 — Per-post frontmatter (theme tags + `related_posts`)
+
+`related_posts` values are directory slugs, ordered best-match first. Apply to
+each post's `content/posts/<slug>/index.md`:
+
+| Post (slug)                                          | Add theme tags    | `related_posts` (in order)                                                        |
+| ---------------------------------------------------- | ----------------- | --------------------------------------------------------------------------------- |
+| smoke-is-a-behavior                                  | `wildfire`        | racing-models-not-opinions, protecting-the-forest-early-forest-fire-detector      |
+| racing-models-not-opinions                           | `wildfire`        | smoke-is-a-behavior, protecting-the-forest-early-forest-fire-detector             |
+| protecting-the-forest-early-forest-fire-detector     | `wildfire`, `edge`| smoke-is-a-behavior, racing-models-not-opinions                                   |
+| bear-face-segmentation-guide                         | `bear`            | bear-identification-with-metric-learning-guide, how-to-prepare-data-for-identification |
+| bear-identification-with-metric-learning-guide       | `bear`            | bear-face-segmentation-guide, a-visual-guide-to-metric-learning                   |
+| how-to-build-a-real-time-bear-detection-system       | `bear`, `edge`    | bear-face-segmentation-guide, protecting-the-forest-early-forest-fire-detector    |
+| a-visual-guide-to-metric-learning                    | — (reuse existing)| bear-identification-with-metric-learning-guide, local-feature-matching-lightglue  |
+| local-feature-matching-lightglue                     | `marine`          | a-visual-guide-to-metric-learning, how-to-prepare-data-for-identification         |
+| how-to-prepare-data-for-identification               | — (reuse existing)| a-visual-guide-to-metric-learning, local-feature-matching-lightglue               |
+| how-to-build-a-benthic-coral-reefs-analyser          | `marine`          | tracking-the-journey-how-to-monitor-wild-salmon-migrations, how-to-build-a-real-time-bear-detection-system |
+| tracking-the-journey-how-to-monitor-wild-salmon-migrations | `marine`, `edge` | how-to-build-a-benthic-coral-reefs-analyser, how-to-build-a-real-time-bear-detection-system |
+| how-to-analyze-elephant-rumbles-at-scale             | `acoustics`       | how-to-build-a-benthic-coral-reefs-analyser, tracking-the-journey-how-to-monitor-wild-salmon-migrations |
+| volunteering_wildlife_rescue_centers                 | — (no AI cluster) | how-to-analyze-elephant-rumbles-at-scale, tracking-the-journey-how-to-monitor-wild-salmon-migrations |
+
+Rationale for edge cases:
+- **elephant rumbles** is the only acoustics post; its curated links lean on the
+  nearest conservation-monitoring neighbors so it is not isolated.
+- **volunteering** has no AI/vision overlap; it links to the most human/field
+  oriented monitoring posts so it is not a dead end.
+
+### Component 3 — Template change (`layouts/partials/related-posts.html`)
+
+This is the only code change. Today line 2 computes `$related` as pure
+tag-intersection. Replace that single computation with curated-first logic; the
+render loop (the card markup) is unchanged.
+
+New logic for `$related`:
+
+1. Resolve `.Params.related_posts` slugs (in order) to pages. A slug is matched
+   against post directory slugs; resolve via `.Site.GetPage` or by matching
+   `.File.ContentBaseName` / path. Keep only slugs that resolve to a real,
+   published post. This ordered list comes **first**.
+2. Compute the existing tag-intersection set (most-recent-first), excluding self
+   and any page already in the curated list.
+3. Concatenate curated + tag-fill, then take `first 2`.
+
+Constant: N = 2 (unchanged from today).
+
+### Data flow
+
+```
+post index.md frontmatter ──┐
+   related_posts: [...]      ├─► related-posts.html
+   tags: [...]               │      1. resolve curated slugs → pages (ordered)
+                             │      2. tag-intersection fill (dedup, exclude self)
+data/tags.yaml ──────────────┘      3. first 2 → render existing cards
+   (emoji per theme tag)
+```
+
+### Error handling
+
+- A `related_posts` slug that does not resolve to a published post is silently
+  skipped — no broken card, no build error.
+- If a post ends up with zero recommendations (should not happen given
+  curation), the section renders nothing, matching today's empty state
+  (`{{ if $related }}`).
+- Self-reference is excluded (existing `Permalink != .Permalink` guard kept).
+
+## Testing / Verification
+
+Hugo has no unit-test harness in this repo, so verification is a local build:
+
+1. `hugo` (or `hugo server`) builds clean with no errors/warnings.
+2. Spot-check three representative posts in the browser:
+   - a wildfire post (e.g. `smoke-is-a-behavior`) → shows the two curated
+     wildfire posts, in order.
+   - a bear post (e.g. `bear-face-segmentation-guide`) → shows curated bear
+     posts in order.
+   - `volunteering_wildlife_rescue_centers` → shows its curated links (verifies
+     a post with no shared AI/vision tags still gets curated cards).
+3. Confirm the new theme tags appear as chips on posts and render with their
+   emoji on the relevant `/tags/<tag>/` pages.
+
+## Files Touched
+
+- `data/tags.yaml` — add 5 theme-tag emoji entries.
+- `layouts/partials/related-posts.html` — curated-first + tag-fill logic (line 2
+  region only).
+- `content/posts/*/index.md` — 13 files: add theme tags (12 of them) and
+  `related_posts` (all 13).

--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -1,5 +1,23 @@
 <!-- begin related posts -->
-{{ $related := first 2 ( where ( where .Site.Pages.ByDate.Reverse ".Params.tags" "intersect" .Params.tags ) "Permalink" "!=" .Permalink ) }}
+{{ $limit := 2 }}
+{{/* 1. Curated picks, in frontmatter order; skip slugs that don't resolve. */}}
+{{ $curated := slice }}
+{{ range .Params.related_posts }}
+  {{ $p := site.GetPage "posts" . }}
+  {{ if and $p (ne $p.Permalink $.Permalink) }}
+    {{ $curated = $curated | append $p }}
+  {{ end }}
+{{ end }}
+{{/* 2. Tag-intersection fallback, newest first, excluding self and curated picks. */}}
+{{ $tagMatches := where ( where .Site.Pages.ByDate.Reverse ".Params.tags" "intersect" .Params.tags ) "Permalink" "!=" .Permalink }}
+{{ $fill := slice }}
+{{ range $tagMatches }}
+  {{ if not (in $curated .) }}
+    {{ $fill = $fill | append . }}
+  {{ end }}
+{{ end }}
+{{/* 3. Curated first, then fill, capped at $limit. */}}
+{{ $related := first $limit ( $curated | append $fill ) }}
 {{ if $related }}
 <div class="container">
   <section class="section related-posts">


### PR DESCRIPTION
## Why

The bottom-of-post "You may also like" section used pure tag-intersection, but 12 of 13 posts carry both `AI` and `vision`, so it collapsed to "the 2 newest posts" rather than genuinely related ones.

## What

- **Theme tags** — adds 5 differentiating tags (`wildfire`, `bear`, `marine`, `edge`, `acoustics`) with emoji in `data/tags.yaml`, creating tight topic clusters and improving `/tags/` browsing.
- **Curated `related_posts`** — every post now declares ordered, hand-picked related reads in frontmatter.
- **Curated-first template** — `related-posts.html` shows curated picks first (in order), then fills remaining slots (up to 2) with tag-intersection matches, deduped and excluding self. Card markup unchanged. Unresolved slugs are skipped safely.

## Verification

- `hugo --gc --minify` builds clean.
- Spot-checked the generated HTML for three posts:
  - `smoke-is-a-behavior` → Racing Models, then Protecting the Forest (curated wildfire order)
  - `bear-face-segmentation-guide` → bear recognition, then data-prep (curated order)
  - `volunteering_wildlife_rescue_centers` → elephant rumbles, then salmon (a post with no shared AI/vision tags now gets curated cards instead of weak fallbacks)

Design spec: `docs/specs/2026-06-18-related-posts-recommendations-design.md`