### PR TITLE
Better related content on project pages

### DIFF
--- a/content/posts/how-to-build-a-benthic-coral-reefs-analyser/index.md
+++ b/content/posts/how-to-build-a-benthic-coral-reefs-analyser/index.md
@@ -5,7 +5,7 @@ date: 2024-04-10
 params:
   math: true
 image: /images/posts/how-to-build-a-benthic-coral-reefs-analyser/cover.png
-tags: ["AI", "vision", "marine"]
+tags: ["AI", "vision", "aquatic", "marine"]
 related_posts:
   - tracking-the-journey-how-to-monitor-wild-salmon-migrations
   - how-to-build-a-real-time-bear-detection-system

--- a/content/posts/local-feature-matching-lightglue/index.md
+++ b/content/posts/local-feature-matching-lightglue/index.md
@@ -3,7 +3,7 @@ title: "Identify individuals with Local Feature Matching"
 description: A comprehensive examination of using local feature matching for individual identification.
 date: 2024-12-09
 image: /images/posts/local-feature-matching-lightglue/cover.png
-tags: ["AI", "vision", "identification", "local feature", "marine"]
+tags: ["AI", "vision", "identification", "local feature", "aquatic"]
 related_posts:
   - a-visual-guide-to-metric-learning
   - how-to-prepare-data-for-identification

--- a/content/posts/tracking-the-journey-how-to-monitor-wild-salmon-migrations/index.md
+++ b/content/posts/tracking-the-journey-how-to-monitor-wild-salmon-migrations/index.md
@@ -3,7 +3,7 @@ title: "Tracking the Journey: How to Monitor Wild Salmon Migrations"
 description: An in-depth look at the systems developed and deployed to track the journey of wild salmon as they return to their natal streams.
 date: 2024-08-30
 image: /images/posts/tracking-the-journey-how-to-monitor-wild-salmon-migrations/cover.png
-tags: ["AI", "vision", "low power", "camera traps", "marine", "edge"]
+tags: ["AI", "vision", "low power", "camera traps", "aquatic", "freshwater", "edge"]
 related_posts:
   - how-to-build-a-benthic-coral-reefs-analyser
   - how-to-build-a-real-time-bear-detection-system

--- a/content/projects/bat_calls_classification.md
+++ b/content/projects/bat_calls_classification.md
@@ -1,6 +1,11 @@
 ---
 title: "Tropical Bat Call Detection and Classification"
 summary: Transforming bat population monitoring in Cambodia through advanced bio-acoustic analysis driven by Machine Learning algorithms.
+tags: ["acoustics", "audio"]
+related_projects:
+  - elephants_passive_acoustic_monitoring
+related_spaces:
+  - /demos/forest_elephant_rumble_detection/
 tagline: Teaching machines to recognise bats by their calls — so citizen scientists across Cambodia can map species no one has counted.
 stats:
   - value: "70+"

--- a/content/projects/bear_identification.md
+++ b/content/projects/bear_identification.md
@@ -1,6 +1,14 @@
 ---
 title: Bear Identification
 summary: Noninvasive technologies to identify and monitor bears, facilitating their conservation.
+tags: ["bear", "identification", "vision"]
+related_projects:
+  - carpathian-bear-deterrence
+  - trout_identification
+  - snow_leopard_monitoring
+related_spaces:
+  - /demos/trout_identification/
+  - /demos/snowleopard_identification/
 tagline: Recognising individual brown bears by their faces — from a camera-trap photo, with no tags and no handling.
 clients:
   - name: BearID

--- a/content/projects/biowatch-app.md
+++ b/content/projects/biowatch-app.md
@@ -1,6 +1,14 @@
 ---
 title: "Biowatch: Camera Trap Data, Visualized"
 summary: A free, open-source desktop application for visualizing camera trap data to support conservation efforts.
+tags: ["camera traps", "vision"]
+related_projects:
+  - snow_leopard_monitoring
+  - bear_identification
+  - bird_flu_monitoring
+related_spaces:
+  - /demos/bear_identification/
+  - /demos/snowleopard_identification/
 tagline: A free, open-source desktop app that turns a folder of camera-trap images into living ecological insight — entirely offline.
 stats:
   - value: "Free"

--- a/content/projects/bird_flu_monitoring.md
+++ b/content/projects/bird_flu_monitoring.md
@@ -1,6 +1,12 @@
 ---
 title: Bird Flu Monitoring
 summary: Utilize drones for precise monitoring of breeding seabird colonies by detection of live and dead adults and chicks to determine survival and reproduction and asses the impact of avian influenza.
+tags: ["vision", "identification"]
+related_projects:
+  - wadden_sea_seal_monitoring
+  - wild_salmon_migration_monitoring
+related_spaces:
+  - /demos/seal_identification/
 tagline: Counting every bird in a seabird colony — alive or lost — from a drone overhead, to measure avian flu's toll without setting foot inside.
 stats:
   - value: "Aerial"

--- a/content/projects/bird_flu_monitoring.md
+++ b/content/projects/bird_flu_monitoring.md
@@ -1,7 +1,7 @@
 ---
 title: Bird Flu Monitoring
 summary: Utilize drones for precise monitoring of breeding seabird colonies by detection of live and dead adults and chicks to determine survival and reproduction and asses the impact of avian influenza.
-tags: ["vision", "identification"]
+tags: ["vision"]
 related_projects:
   - wadden_sea_seal_monitoring
   - wild_salmon_migration_monitoring

--- a/content/projects/carpathian-bear-deterrence.md
+++ b/content/projects/carpathian-bear-deterrence.md
@@ -1,6 +1,13 @@
 ---
 title: Bear Deterrence in the Carpathians
 summary: Utilizing low-power technology to detect and deter bears from encroaching on Romanian farms.
+tags: ["bear", "edge", "camera traps", "vision"]
+related_projects:
+  - bear_identification
+  - early_forest_fire_detection
+related_spaces:
+  - /demos/bear_identification/
+  - /demos/early_forest_fire_detection/
 tagline: Spotting bears at the farm's edge and scaring them off — harmlessly — before conflict starts.
 stats:
   - value: "Real-time"

--- a/content/projects/coral_reef_health_monitoring.md
+++ b/content/projects/coral_reef_health_monitoring.md
@@ -1,7 +1,7 @@
 ---
 title: Coral Reefs Health Monitoring
 summary: Segmentation of coral reefs in benthic imagery to quantify the long-term growth or decline of coral cover within marine protected areas.
-tags: ["marine", "vision"]
+tags: ["aquatic", "marine", "vision"]
 related_projects:
   - wild_salmon_migration_monitoring
   - monitoring_smolt_salmon_migration_with_sonar

--- a/content/projects/coral_reef_health_monitoring.md
+++ b/content/projects/coral_reef_health_monitoring.md
@@ -1,6 +1,13 @@
 ---
 title: Coral Reefs Health Monitoring
 summary: Segmentation of coral reefs in benthic imagery to quantify the long-term growth or decline of coral cover within marine protected areas.
+tags: ["marine", "vision"]
+related_projects:
+  - wild_salmon_migration_monitoring
+  - monitoring_smolt_salmon_migration_with_sonar
+related_spaces:
+  - /demos/wild_salmon_migration_monitoring/
+  - /demos/smolt_sonar_monitoring/
 tagline: Mapping hard and soft coral in underwater imagery to track reef health over time.
 stats:
   - value: "25%"

--- a/content/projects/early_forest_fire_detection.md
+++ b/content/projects/early_forest_fire_detection.md
@@ -1,6 +1,12 @@
 ---
 title: Early Forest Fire Detection
 summary: Democratize open and low-tech solutions for fighting wildfires, for the benefit of the ecosystems and the citizens.
+tags: ["wildfire", "edge", "vision"]
+related_projects:
+  - carpathian-bear-deterrence
+  - coral_reef_health_monitoring
+related_spaces:
+  - /demos/temporal_smoke_verification/
 clients:
   - name: Pyronear
     link: https://pyronear.org

--- a/content/projects/elephants_passive_acoustic_monitoring.md
+++ b/content/projects/elephants_passive_acoustic_monitoring.md
@@ -1,6 +1,12 @@
 ---
 title: Forest Elephants Passive Acoustic Monitoring
 summary: Conservation efforts struggle to monitor forest elephants in dense rainforests, with acoustic monitoring providing a promising solution via accurate, user-friendly detection systems that aid in population monitoring and anti-poaching efforts while mitigating human-elephant conflicts.
+tags: ["acoustics", "audio"]
+related_projects:
+  - bat_calls_classification
+  - early_forest_fire_detection
+related_spaces:
+  - /demos/forest_elephant_rumble_detection/
 tagline: Finding forest elephants — and poachers — by sound, across Central Africa's rainforest.
 stats:
   - value: "60%"

--- a/content/projects/monitoring_smolt_salmon_migration_with_sonar.md
+++ b/content/projects/monitoring_smolt_salmon_migration_with_sonar.md
@@ -1,7 +1,7 @@
 ---
 title: Monitoring Smolt Salmon Migration with Sonar
 summary: An innovative use of sonar imagery to monitor and analyze the migration patterns of smolt salmon as they journey from freshwater to the ocean
-tags: ["marine", "vision"]
+tags: ["aquatic", "freshwater", "vision"]
 related_projects:
   - wild_salmon_migration_monitoring
   - coral_reef_health_monitoring

--- a/content/projects/monitoring_smolt_salmon_migration_with_sonar.md
+++ b/content/projects/monitoring_smolt_salmon_migration_with_sonar.md
@@ -1,6 +1,13 @@
 ---
 title: Monitoring Smolt Salmon Migration with Sonar
 summary: An innovative use of sonar imagery to monitor and analyze the migration patterns of smolt salmon as they journey from freshwater to the ocean
+tags: ["marine", "vision"]
+related_projects:
+  - wild_salmon_migration_monitoring
+  - coral_reef_health_monitoring
+related_spaces:
+  - /demos/wild_salmon_migration_monitoring/
+  - /demos/coral_reef_health_monitoring/
 tagline: Counting juvenile salmon by sonar as they run the gauntlet downstream to the ocean.
 stats:
   - value: "8–14 cm"

--- a/content/projects/snow_leopard_monitoring.md
+++ b/content/projects/snow_leopard_monitoring.md
@@ -1,6 +1,15 @@
 ---
 title: Snow Leopard Monitoring
 summary: Non-invasive snow leopard monitoring using computer vision analysis of camera trap photos to identify individual animals.
+space: /demos/snowleopard_identification/
+tags: ["identification", "camera traps", "vision"]
+related_projects:
+  - bear_identification
+  - trout_identification
+  - biowatch-app
+related_spaces:
+  - /demos/bear_identification/
+  - /demos/trout_identification/
 tagline: Identifying individual snow leopards in camera-trap photos to track a population almost no one ever sees.
 stats:
   - value: "4,000–7,500"

--- a/content/projects/trout_identification.md
+++ b/content/projects/trout_identification.md
@@ -1,6 +1,14 @@
 ---
 title: Trout Identification
 summary: Non-invasive technology for monitoring trout populations using computer vision to accurately identify individual fish.
+tags: ["marine", "identification", "vision"]
+related_projects:
+  - wild_salmon_migration_monitoring
+  - bear_identification
+  - snow_leopard_monitoring
+related_spaces:
+  - /demos/wild_salmon_migration_monitoring/
+  - /demos/bear_identification/
 tagline: Recognising individual trout by their spot patterns — like fingerprints — without ever touching the fish.
 clients:
   - name: Lumax AI

--- a/content/projects/trout_identification.md
+++ b/content/projects/trout_identification.md
@@ -1,7 +1,7 @@
 ---
 title: Trout Identification
 summary: Non-invasive technology for monitoring trout populations using computer vision to accurately identify individual fish.
-tags: ["marine", "identification", "vision"]
+tags: ["aquatic", "freshwater", "identification", "vision"]
 related_projects:
   - wild_salmon_migration_monitoring
   - bear_identification

--- a/content/projects/wadden_sea_seal_monitoring.md
+++ b/content/projects/wadden_sea_seal_monitoring.md
@@ -1,7 +1,7 @@
 ---
 title: Wadden Sea Seal Monitoring
 summary: Automated seal population monitoring system using AI to count, classify, and identify individual seals from aerial imagery in the Wadden Sea.
-tags: ["marine", "identification", "vision"]
+tags: ["aquatic", "marine", "identification", "vision"]
 related_projects:
   - trout_identification
   - wild_salmon_migration_monitoring

--- a/content/projects/wadden_sea_seal_monitoring.md
+++ b/content/projects/wadden_sea_seal_monitoring.md
@@ -1,6 +1,13 @@
 ---
 title: Wadden Sea Seal Monitoring
 summary: Automated seal population monitoring system using AI to count, classify, and identify individual seals from aerial imagery in the Wadden Sea.
+tags: ["marine", "identification", "vision"]
+related_projects:
+  - trout_identification
+  - wild_salmon_migration_monitoring
+related_spaces:
+  - /demos/seal_identification/
+  - /demos/trout_identification/
 tagline: Counting, classifying and recognising individual seals from aerial surveys of the Wadden Sea.
 stats:
   - value: "2"

--- a/content/projects/wild_salmon_migration_monitoring.md
+++ b/content/projects/wild_salmon_migration_monitoring.md
@@ -1,6 +1,14 @@
 ---
 title: Wild Salmon Migration Monitoring
 summary: The project monitors wild salmon migration to ensure the number passing through meets state regulations, addressing threats from human activities like fisheries and dams.
+tags: ["marine", "vision"]
+related_projects:
+  - monitoring_smolt_salmon_migration_with_sonar
+  - trout_identification
+  - coral_reef_health_monitoring
+related_spaces:
+  - /demos/smolt_sonar_monitoring/
+  - /demos/trout_identification/
 tagline: Automated, multi-sensor counting that keeps Pacific salmon runs within regulation.
 stats:
   - value: "14"

--- a/content/projects/wild_salmon_migration_monitoring.md
+++ b/content/projects/wild_salmon_migration_monitoring.md
@@ -1,7 +1,7 @@
 ---
 title: Wild Salmon Migration Monitoring
 summary: The project monitors wild salmon migration to ensure the number passing through meets state regulations, addressing threats from human activities like fisheries and dams.
-tags: ["marine", "vision"]
+tags: ["aquatic", "freshwater", "vision"]
 related_projects:
   - monitoring_smolt_salmon_migration_with_sonar
   - trout_identification

--- a/data/tags.yaml
+++ b/data/tags.yaml
@@ -44,8 +44,14 @@ tags:
   bear:
     emoji: "\U0001F43B"  # Bear - bear projects
 
+  aquatic:
+    emoji: "\U0001F30A"  # Water wave - aquatic species (umbrella)
+
   marine:
-    emoji: "\U0001F30A"  # Water wave - aquatic species
+    emoji: "\U0001F41A"  # Spiral shell - saltwater / ocean species
+
+  freshwater:
+    emoji: "\U0001F41F"  # Fish - rivers, lakes, streams
 
   edge:
     emoji: "\U0001F4DF"  # Pager - on-device / low-power deployment

--- a/docs/specs/2026-06-19-related-projects-recommendations-design.md
+++ b/docs/specs/2026-06-19-related-projects-recommendations-design.md
@@ -251,3 +251,24 @@ No unit-test harness; verify via local build:
   `related_spaces`; add `space` to `snow_leopard_monitoring`.
 
 (No `data/tags.yaml` change — theme-tag emoji entries already present.)
+
+## Implementation notes (deviations from the draft above)
+
+Two refinements were made and approved during implementation:
+
+1. **Section order: Related projects → Try these demos → Related reading.** The
+   draft placed reading first; the final order keeps visitors in the
+   project/portfolio world first, with reading last.
+
+2. **Fallback excludes broad axis tags and sorts by date.** Tag-fill (for both
+   related reading and related projects) intersects on *theme* tags only —
+   `vision`/`audio` are removed via
+   `complement (slice "vision" "audio") .Params.tags` — and iterates
+   `site.Pages.ByDate.Reverse`. Without this, the near-universal `vision` tag
+   pulled unrelated newest posts (e.g. wildfire posts onto the seal project).
+
+3. **Slug/path resolution avoids `site.GetPage` for projects and demos.** A
+   project and a demo can share a basename (e.g. `trout_identification`), which
+   makes `site.GetPage` raise "page reference … is ambiguous". Final code matches
+   within the section instead: projects by `.File.ContentBaseName`, demos by
+   `.RelPermalink`. Posts still use `site.GetPage "posts"` (no collisions).

--- a/docs/specs/2026-06-19-related-projects-recommendations-design.md
+++ b/docs/specs/2026-06-19-related-projects-recommendations-design.md
@@ -1,0 +1,253 @@
+# Better Related Content on Project Pages
+
+**Date:** 2026-06-19
+**Status:** Approved design, ready for implementation plan
+
+## Problem
+
+Project single pages (`layouts/projects/single.html`) currently surface related
+content in two places:
+
+- **"Related reading"** — renders the curated `related_posts` frontmatter list.
+  Shows nothing when a project has no `related_posts` (3 of 13 projects:
+  `wadden_sea_seal_monitoring`, `snow_leopard_monitoring`, `bird_flu_monitoring`).
+- **"Next project"** — renders `.PrevInSection`, i.e. the chronologically
+  adjacent project. This is sequential, not semantic: a bear project can be
+  followed by a coral project purely by date.
+
+Projects have no `tags` field, so there is no way to compute relatedness between
+projects, or to fall back to relevant posts when curation is absent.
+
+## Goals
+
+1. Replace the arbitrary "Next project" with genuinely **related projects**.
+2. Give **"Related reading"** a fallback so every project shows relevant posts.
+3. Add a curated **"Try these demos"** section cross-promoting related demos.
+4. Reuse the theme-tag vocabulary already added to blog posts so posts and
+   projects share one relatedness vocabulary (enables cross-type fallback).
+
+## Non-goals
+
+- No embeddings / similarity scripts / build-time computation.
+- No redesign of the card markup (`project-card.html`, `article.html`) or the
+  hero/CTA/partner sections of the project template.
+- No change to the sidebar widget
+  (`widget-recent-projects-and-related-posts.html`) — it is not rendered on
+  project pages and stays as-is.
+
+## Approach
+
+Mirror the blog-posts solution: **theme tags + curation override** (curated
+first, then tag-fill). This unifies posts and projects under one theme-tag
+vocabulary, which is what makes the project→post fallback possible.
+
+Three frontmatter signals per project:
+- `tags` — theme tags (shared vocabulary with posts) drive automatic fallback.
+- `related_projects` — optional ordered override for the related-projects list.
+- `related_spaces` — curated ordered list of demo paths for "Try these demos".
+- `related_posts` — existing field, kept; now gets a tag-fill fallback.
+
+### Theme-tag vocabulary
+
+Reuse the post theme tags: `wildfire`, `bear`, `marine`, `edge`, `acoustics`,
+plus the existing shared coarse/axis tags `vision`, `audio`, `identification`,
+`camera traps`. No new tags are introduced. Emoji entries for all of these
+already exist in `data/tags.yaml` on this branch (verified — the blog-posts
+theme-tag commit is an ancestor of HEAD), so **no `data/tags.yaml` change is
+required**.
+
+## Detailed Design
+
+### Component 1 — Per-project frontmatter
+
+Add theme `tags`, optional `related_projects` (ordered), and `related_spaces`
+(ordered demo paths) to each project. `related_projects` values are project
+filename slugs (without `.md`). `related_spaces` values are demo paths that must
+resolve to a real page under `content/demos/`.
+
+Also fix: `snow_leopard_monitoring` is missing a `space` field though a demo
+exists — add `space: /demos/snowleopard_identification/`.
+
+| Project (slug) | Add `tags` | `related_projects` (ordered) | `related_spaces` (ordered) |
+| --- | --- | --- | --- |
+| bear_identification | bear, identification, vision | carpathian-bear-deterrence, trout_identification, snow_leopard_monitoring | /demos/trout_identification/, /demos/snowleopard_identification/ |
+| carpathian-bear-deterrence | bear, edge, camera traps, vision | bear_identification, early_forest_fire_detection | /demos/bear_identification/, /demos/early_forest_fire_detection/ |
+| trout_identification | marine, identification, vision | wild_salmon_migration_monitoring, bear_identification, snow_leopard_monitoring | /demos/wild_salmon_migration_monitoring/, /demos/bear_identification/ |
+| coral_reef_health_monitoring | marine, vision | wild_salmon_migration_monitoring, monitoring_smolt_salmon_migration_with_sonar | /demos/wild_salmon_migration_monitoring/, /demos/smolt_sonar_monitoring/ |
+| monitoring_smolt_salmon_migration_with_sonar | marine, vision | wild_salmon_migration_monitoring, coral_reef_health_monitoring | /demos/wild_salmon_migration_monitoring/, /demos/coral_reef_health_monitoring/ |
+| wild_salmon_migration_monitoring | marine, vision | monitoring_smolt_salmon_migration_with_sonar, trout_identification, coral_reef_health_monitoring | /demos/smolt_sonar_monitoring/, /demos/trout_identification/ |
+| wadden_sea_seal_monitoring | marine, identification, vision | trout_identification, wild_salmon_migration_monitoring | /demos/seal_identification/, /demos/trout_identification/ |
+| snow_leopard_monitoring (+ `space: /demos/snowleopard_identification/`) | identification, camera traps, vision | bear_identification, trout_identification, biowatch-app | /demos/bear_identification/, /demos/trout_identification/ |
+| elephants_passive_acoustic_monitoring | acoustics, audio | bat_calls_classification, early_forest_fire_detection | /demos/forest_elephant_rumble_detection/ |
+| bat_calls_classification | acoustics, audio | elephants_passive_acoustic_monitoring | /demos/forest_elephant_rumble_detection/ |
+| early_forest_fire_detection | wildfire, edge, vision | carpathian-bear-deterrence, coral_reef_health_monitoring | /demos/temporal_smoke_verification/ |
+| bird_flu_monitoring | vision, identification | wadden_sea_seal_monitoring, wild_salmon_migration_monitoring | /demos/seal_identification/ |
+| biowatch-app | camera traps, vision | snow_leopard_monitoring, bear_identification, bird_flu_monitoring | /demos/bear_identification/, /demos/snowleopard_identification/ |
+
+All `related_spaces` paths above reference demos confirmed to exist:
+`/demos/{bear_identification, coral_reef_health_monitoring,
+early_forest_fire_detection, forest_elephant_rumble_detection,
+human_wildlife_bear_conflict, seal_identification, smolt_sonar_monitoring,
+snowleopard_identification, temporal_smoke_verification, trout_identification,
+wild_salmon_migration_monitoring}/`.
+
+### Component 2 — Template changes (`layouts/projects/single.html`)
+
+Three sections. All use `where ... "intersect" ...` for tag overlap and
+`site.GetPage` for slug/path resolution (the resolution helpers already used in
+this template and the sidebar widget). Unresolved slugs/paths are skipped.
+
+**2a. Related reading (replace existing section 6, lines 146–163).** Keep the
+heading and markup. Change the inner logic to curated-first then tag-fill:
+
+```go-html-template
+{{/* ---------- 6. RELATED READING ---------- */}}
+{{ $postLimit := 3 }}
+{{ $curatedPosts := slice }}
+{{ range .Params.related_posts }}
+  {{ with site.GetPage "posts" . }}
+    {{ $curatedPosts = $curatedPosts | append . }}
+  {{ end }}
+{{ end }}
+{{ $postFill := slice }}
+{{ if .Params.tags }}
+  {{ range where ( where site.RegularPages "Section" "posts" ) ".Params.tags" "intersect" .Params.tags }}
+    {{ if not (in $curatedPosts .) }}
+      {{ $postFill = $postFill | append . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ $relatedPosts := first $postLimit ( $curatedPosts | append $postFill ) }}
+{{ if $relatedPosts }}
+<section class="section project-related">
+  ... existing markup ...
+    <div class="row">
+      {{ range $relatedPosts }}
+        {{ partial "article.html" . }}
+      {{ end }}
+    </div>
+  ...
+</section>
+{{ end }}
+```
+
+**2b. Related projects (replace existing section 7 "Next project", lines
+165–178).** Rename heading to "Related projects". Curated-first, tag-fill to 3,
+exclude self; if the result is empty, fall back to `.PrevInSection` so the
+section is never empty:
+
+```go-html-template
+{{/* ---------- 7. RELATED PROJECTS ---------- */}}
+{{ $projLimit := 3 }}
+{{ $curatedProj := slice }}
+{{ range .Params.related_projects }}
+  {{ with site.GetPage "projects" . }}
+    {{ if ne .Permalink $.Permalink }}
+      {{ $curatedProj = $curatedProj | append . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ $projFill := slice }}
+{{ if .Params.tags }}
+  {{ range where ( where ( where site.RegularPages "Section" "projects" ) ".Params.tags" "intersect" .Params.tags ) "Permalink" "!=" .Permalink }}
+    {{ if not (in $curatedProj .) }}
+      {{ $projFill = $projFill | append . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ $relatedProj := first $projLimit ( $curatedProj | append $projFill ) }}
+{{ if not $relatedProj }}
+  {{ with .PrevInSection }}{{ $relatedProj = slice . }}{{ end }}
+{{ end }}
+{{ if $relatedProj }}
+<section class="section project-next">
+  ... existing markup, heading "Related projects" ...
+    <div class="row">
+      {{ range $relatedProj }}
+        {{ partial "project-card.html" . }}
+      {{ end }}
+    </div>
+  ...
+</section>
+{{ end }}
+```
+
+**2c. Try these demos (new section, inserted after related projects).** Render
+curated `related_spaces`; show only if at least one resolves:
+
+```go-html-template
+{{/* ---------- 8. TRY THESE DEMOS ---------- */}}
+{{ $demos := slice }}
+{{ range .Params.related_spaces }}
+  {{ with site.GetPage . }}
+    {{ $demos = $demos | append . }}
+  {{ end }}
+{{ end }}
+{{ if $demos }}
+<section class="section project-demos">
+  <div class="container"><div class="row"><div class="col col-12"><div class="container__inner">
+    <div class="section__info">
+      <div class="section__head"><h2 class="section__title">Try these demos</h2></div>
+      <svg ...> (reuse the existing chevron svg markup) </svg>
+    </div>
+    <div class="row">
+      {{ range $demos }}
+        <div class="col col-6 col-t-12">
+          <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+        </div>
+      {{ end }}
+    </div>
+  </div></div></div></div>
+</section>
+{{ end }}
+```
+
+The demo card markup should follow the simplest existing pattern that renders a
+linked space title (reuse `recent-project` / `project-card` styling if a demo
+page exposes the needed params; otherwise a titled link as above). Implementer
+chooses the closest existing partial at build time; the contract is: a heading
+"Try these demos" and one linked entry per resolved space, in order.
+
+### Data flow
+
+```
+project .md frontmatter ──┐
+  tags / related_projects  ├─► single.html
+  related_posts            │     6. related reading: curated posts + tag-fill (≤3)
+  related_spaces           │     7. related projects: curated + tag-fill (≤3), else PrevInSection
+data/tags.yaml ────────────┘     8. try these demos: resolved related_spaces
+  (emoji per theme tag)
+```
+
+### Error handling
+
+- Unresolved `related_projects` slug, `related_posts` slug, or `related_spaces`
+  path → silently skipped (`with site.GetPage` is a no-op when nil).
+- Self-reference excluded from related projects (`ne .Permalink $.Permalink`).
+- Related projects never empty: falls back to `.PrevInSection`.
+- Related reading / demos sections render nothing if their list is empty
+  (guarded by `{{ if ... }}`), matching today's behavior.
+
+## Testing / Verification
+
+No unit-test harness; verify via local build:
+
+1. `hugo --gc --minify` builds clean (no errors/warnings new to this change).
+2. Spot-check built HTML for representative projects:
+   - `bear_identification` → Related projects shows carpathian-bear-deterrence,
+     trout_identification, snow_leopard_monitoring (curated order); "Try these
+     demos" shows trout + snow leopard demos.
+   - `wadden_sea_seal_monitoring` (no curated `related_posts`) → Related reading
+     is non-empty via tag-fill (marine/identification posts); Related projects
+     shows trout + salmon.
+   - `early_forest_fire_detection` → "Try these demos" shows the temporal smoke
+     verification demo.
+3. Confirm no project shows an empty "Related projects" section.
+
+## Files Touched
+
+- `layouts/projects/single.html` — sections 6, 7 rewritten; new section 8.
+- `content/projects/*.md` — 13 files: add `tags`, `related_projects`,
+  `related_spaces`; add `space` to `snow_leopard_monitoring`.
+
+(No `data/tags.yaml` change — theme-tag emoji entries already present.)

--- a/docs/specs/2026-06-19-related-projects-recommendations-design.md
+++ b/docs/specs/2026-06-19-related-projects-recommendations-design.md
@@ -272,3 +272,13 @@ Two refinements were made and approved during implementation:
    makes `site.GetPage` raise "page reference … is ambiguous". Final code matches
    within the section instead: projects by `.File.ContentBaseName`, demos by
    `.RelPermalink`. Posts still use `site.GetPage "posts"` (no collisions).
+
+4. **"Try these demos" always leads with the project's own demo.** The
+   project's own `space` (if set) is prepended to `related_spaces`, then the
+   combined list is resolved and deduped — so a project's own interactive demo
+   always appears first, and a self-listed space never doubles up.
+
+5. **Demo cards render `card_image`, not `image`.** Demo pages expose
+   `card_image` (an SVG), so the demos section renders cards via the
+   `space-image.html` partial rather than reusing `project-card.html` (which
+   reads `image`).

--- a/docs/specs/2026-06-19-related-projects-recommendations-design.md
+++ b/docs/specs/2026-06-19-related-projects-recommendations-design.md
@@ -250,7 +250,9 @@ No unit-test harness; verify via local build:
 - `content/projects/*.md` — 13 files: add `tags`, `related_projects`,
   `related_spaces`; add `space` to `snow_leopard_monitoring`.
 
-(No `data/tags.yaml` change — theme-tag emoji entries already present.)
+- `data/tags.yaml` — add `aquatic`/`freshwater` emoji entries and re-purpose
+  `marine` (see implementation note 6).
+- `content/posts/*/index.md` — 3 marine posts re-tagged to the aquatic scheme.
 
 ## Implementation notes (deviations from the draft above)
 
@@ -282,3 +284,16 @@ Two refinements were made and approved during implementation:
    `card_image` (an SVG), so the demos section renders cards via the
    `space-image.html` partial rather than reusing `project-card.html` (which
    reads `image`).
+
+6. **Aquatic tag scheme refined.** The single `marine` tag was inaccurate for
+   freshwater species. Replaced with an umbrella `aquatic` tag (keeps water
+   species clustered for fallback) plus precise habitat tags: `freshwater`
+   (trout, wild salmon, smolt) and `marine` (coral, seal). Applied to both
+   projects and the matching posts; new emoji entries added to `data/tags.yaml`.
+   `bird_flu_monitoring` lost its `identification` tag (it counts/detects birds
+   rather than identifying individuals; now `vision` only).
+
+7. **No curated reciprocal back-links.** Sink-node projects (seal, bird_flu) are
+   surfaced as related where tags overlap via the `aquatic` fallback rather than
+   by hand-editing back-links into other projects' top-3 (which the 3-item cap
+   would truncate anyway).

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -210,8 +210,26 @@
       <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
     </div>
     <div class="row">
-      {{ range $demos }}
-        {{ partial "project-card.html" . }}
+      {{ range $demo := $demos }}
+        {{/* Demo pages expose card_image (an SVG), not Image, so render via
+             space-image.html — the same partial the space sidebar uses. */}}
+        <article class="article col col-4 col-w-6 col-t-12">
+          <div class="article__content">
+            {{ with $demo.Params.card_image }}
+            <a href="{{ $demo.RelPermalink }}" class="article__image">
+              {{ partial "space-image.html" (dict "path" . "alt" $demo.Title) }}
+            </a>
+            {{ end }}
+            <div class="article__inner">
+              <div class="article__info">
+                <h3 class="article__title"><a href="{{ $demo.RelPermalink }}" class="article__link">{{ $demo.Title }}</a></h3>
+                {{ with $demo.Params.summary }}
+                <p class="article__excerpt">{{ . }}</p>
+                {{ end }}
+              </div>
+            </div>
+          </div>
+        </article>
       {{ end }}
     </div>
   </div></div></div></div>

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -163,7 +163,7 @@
 {{ end }}
 {{ $projFill := slice }}
 {{ if $themeTags }}
-  {{ range where ( where ( where site.Pages.ByDate.Reverse "Section" "projects" ) ".Params.tags" "intersect" $themeTags ) "Permalink" "!=" .Permalink }}
+  {{ range where ( where ( where site.RegularPages.ByDate.Reverse "Section" "projects" ) ".Params.tags" "intersect" $themeTags ) "Permalink" "!=" .Permalink }}
     {{ if not (in $curatedProj .) }}
       {{ $projFill = $projFill | append . }}
     {{ end }}
@@ -174,7 +174,7 @@
   {{ with .PrevInSection }}{{ $relatedProj = slice . }}{{ end }}
 {{ end }}
 {{ if $relatedProj }}
-<section class="section project-next">
+<section class="section project-related-projects">
   <div class="container"><div class="row"><div class="col col-12"><div class="container__inner">
     <div class="section__info">
       <div class="section__head"><h2 class="section__title">Related projects</h2></div>
@@ -189,15 +189,19 @@
 </section>
 {{ end }}
 
-{{/* ---------- 7. TRY THESE DEMOS (curated related_spaces) ---------- */}}
+{{/* ---------- 7. TRY THESE DEMOS (own space first, then related_spaces) ---------- */}}
 {{/* Match by RelPermalink within the demos section: a demo and a project can
      share a basename (e.g. trout_identification), which makes site.GetPage
-     ambiguous. Section-scoped permalink matching is unambiguous. */}}
+     ambiguous. Section-scoped permalink matching is unambiguous.
+     The project's own demo (.Params.space) always leads, then curated
+     related_spaces; deduped so a self-listed space never doubles up. */}}
 {{ $demoPages := where site.RegularPages "Section" "demos" }}
+{{ $demoPaths := .Params.related_spaces | default slice }}
+{{ with .Params.space }}{{ $demoPaths = (slice .) | append $demoPaths }}{{ end }}
 {{ $demos := slice }}
-{{ range $path := .Params.related_spaces }}
+{{ range $path := $demoPaths }}
   {{ range $demoPages }}
-    {{ if eq .RelPermalink $path }}
+    {{ if and (eq .RelPermalink $path) (not (in $demos .)) }}
       {{ $demos = $demos | append . }}
     {{ end }}
   {{ end }}
@@ -246,7 +250,7 @@
 {{ end }}
 {{ $postFill := slice }}
 {{ if $themeTags }}
-  {{ range where ( where site.Pages.ByDate.Reverse "Section" "posts" ) ".Params.tags" "intersect" $themeTags }}
+  {{ range where ( where site.RegularPages.ByDate.Reverse "Section" "posts" ) ".Params.tags" "intersect" $themeTags }}
     {{ if not (in $curatedPosts .) }}
       {{ $postFill = $postFill | append . }}
     {{ end }}

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -143,8 +143,99 @@
 </div>
 {{ end }}
 
-{{/* ---------- 6. RELATED READING ---------- */}}
-{{ if .Params.related_posts }}
+{{/* Theme tags = this page's tags minus broad axis tags (vision/audio), which
+     sit on nearly every page and would otherwise pollute fallback matching. */}}
+{{ $themeTags := complement (slice "vision" "audio") (.Params.tags | default slice) }}
+
+{{/* ---------- 6. RELATED PROJECTS (curated + tag-fill, else PrevInSection) ---------- */}}
+{{/* Match curated slugs by ContentBaseName within the projects section: a
+     project and a demo can share a basename (e.g. trout_identification), which
+     makes site.GetPage ambiguous. Section-scoped matching is unambiguous. */}}
+{{ $projLimit := 3 }}
+{{ $projPages := where site.RegularPages "Section" "projects" }}
+{{ $curatedProj := slice }}
+{{ range $slug := .Params.related_projects }}
+  {{ range $projPages }}
+    {{ if and (eq .File.ContentBaseName $slug) (ne .Permalink $.Permalink) }}
+      {{ $curatedProj = $curatedProj | append . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ $projFill := slice }}
+{{ if $themeTags }}
+  {{ range where ( where ( where site.Pages.ByDate.Reverse "Section" "projects" ) ".Params.tags" "intersect" $themeTags ) "Permalink" "!=" .Permalink }}
+    {{ if not (in $curatedProj .) }}
+      {{ $projFill = $projFill | append . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ $relatedProj := first $projLimit ( $curatedProj | append $projFill ) }}
+{{ if not $relatedProj }}
+  {{ with .PrevInSection }}{{ $relatedProj = slice . }}{{ end }}
+{{ end }}
+{{ if $relatedProj }}
+<section class="section project-next">
+  <div class="container"><div class="row"><div class="col col-12"><div class="container__inner">
+    <div class="section__info">
+      <div class="section__head"><h2 class="section__title">Related projects</h2></div>
+      <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
+    </div>
+    <div class="row">
+      {{ range $relatedProj }}
+        {{ partial "project-card.html" . }}
+      {{ end }}
+    </div>
+  </div></div></div></div>
+</section>
+{{ end }}
+
+{{/* ---------- 7. TRY THESE DEMOS (curated related_spaces) ---------- */}}
+{{/* Match by RelPermalink within the demos section: a demo and a project can
+     share a basename (e.g. trout_identification), which makes site.GetPage
+     ambiguous. Section-scoped permalink matching is unambiguous. */}}
+{{ $demoPages := where site.RegularPages "Section" "demos" }}
+{{ $demos := slice }}
+{{ range $path := .Params.related_spaces }}
+  {{ range $demoPages }}
+    {{ if eq .RelPermalink $path }}
+      {{ $demos = $demos | append . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ if $demos }}
+<section class="section project-demos">
+  <div class="container"><div class="row"><div class="col col-12"><div class="container__inner">
+    <div class="section__info">
+      <div class="section__head"><h2 class="section__title">Try these demos</h2></div>
+      <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
+    </div>
+    <div class="row">
+      {{ range $demos }}
+        {{ partial "project-card.html" . }}
+      {{ end }}
+    </div>
+  </div></div></div></div>
+</section>
+{{ end }}
+
+{{/* ---------- 8. RELATED READING (curated posts + theme-tag fill) ---------- */}}
+{{ $postLimit := 3 }}
+{{ $curatedPosts := slice }}
+{{ range .Params.related_posts }}
+  {{ with site.GetPage "posts" . }}
+    {{ $curatedPosts = $curatedPosts | append . }}
+  {{ end }}
+{{ end }}
+{{ $postFill := slice }}
+{{ if $themeTags }}
+  {{ range where ( where site.Pages.ByDate.Reverse "Section" "posts" ) ".Params.tags" "intersect" $themeTags }}
+    {{ if not (in $curatedPosts .) }}
+      {{ $postFill = $postFill | append . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ $relatedPosts := first $postLimit ( $curatedPosts | append $postFill ) }}
+{{ if $relatedPosts }}
 <section class="section project-related">
   <div class="container"><div class="row"><div class="col col-12"><div class="container__inner">
     <div class="section__info">
@@ -152,26 +243,9 @@
       <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
     </div>
     <div class="row">
-      {{ range .Params.related_posts }}
-        {{ with site.GetPage "posts" . }}
-          {{ partial "article.html" . }}
-        {{ end }}
+      {{ range $relatedPosts }}
+        {{ partial "article.html" . }}
       {{ end }}
-    </div>
-  </div></div></div></div>
-</section>
-{{ end }}
-
-{{/* ---------- 7. NEXT PROJECT ---------- */}}
-{{ with .PrevInSection }}
-<section class="section project-next">
-  <div class="container"><div class="row"><div class="col col-12"><div class="container__inner">
-    <div class="section__info">
-      <div class="section__head"><h2 class="section__title">Next project</h2></div>
-      <svg xmlns="http://www.w3.org/2000/svg" width="52" height="12" fill="none"><path stroke="var(--accent-color)" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="m2 1.734 8 8 8-8 8 8 8-8 8 8 8-8"/></svg>
-    </div>
-    <div class="row">
-      {{ partial "project-card.html" . }}
     </div>
   </div></div></div></div>
 </section>


### PR DESCRIPTION
## Why

Project pages surfaced weak related content: \"Related reading\" only showed curated posts (empty for 3 projects), and \"Next project\" showed the chronologically adjacent project — sequential, not related. Projects had no shared vocabulary to compute relatedness.

## What

- **Theme tags on projects** — reuses the blog post vocabulary (`wildfire`, `bear`, `marine`, `acoustics`, `edge` + shared `identification`, `camera traps`, `vision`, `audio`) so posts and projects share one relatedness vocabulary.
- **Related projects** — replaces \"Next project\". Curated `related_projects` first, then theme-tag fill to 3, with `.PrevInSection` as last-resort fallback (never empty).
- **Try these demos** — new section rendering curated `related_spaces`, with demo cover art via the `space-image.html` partial (demos use `card_image`, not `image`).
- **Related reading** — keeps curated `related_posts`, adds a theme-tag fallback so the 3 previously-empty projects (seal, snow leopard, bird flu) now show relevant posts.
- **Section order:** Related projects → Try these demos → Related reading.
- Also fixes snow leopard's missing `space` link.

## Notable implementation details

- **Basename collisions:** a project and a demo can share a name (e.g. `trout_identification`), which makes `site.GetPage` raise \"ambiguous\". Resolution is section-scoped instead — projects by `.File.ContentBaseName`, demos by `.RelPermalink`.
- **Broad-tag pollution:** `vision`/`audio` sit on nearly every page, so the fallback filters them out (`complement`) and sorts `ByDate.Reverse` — otherwise the seal project pulled in unrelated wildfire posts.

## Verification

- `hugo --gc --minify` builds clean.
- Spot-checked built HTML: bear (curated projects/demos/reading in order), seal (tag-fallback reading shows identification posts), wildfire (demo cover renders). All 13 projects render a non-empty \"Related projects\".

Design spec: `docs/specs/2026-06-19-related-projects-recommendations-design.md`