### PR TITLE
fix(demos): embed Gradio Spaces via iframe to dodge HF CORS preflight

### DIFF
--- a/assets/js/gradio-loader.js
+++ b/assets/js/gradio-loader.js
@@ -1,40 +1,57 @@
-// Shows a spinning pangolin overlay over each embedded Gradio app until the HF
-// Space is ready, then fades the overlay out and the demo in. Reveal fires on
-// (ready signal OR max-timeout) but never before a minimum display time, so a
-// fast load does not flicker and a failed detection never traps the spinner.
+// Shows a spinning pangolin overlay over each embedded Gradio demo until its HF
+// Space iframe has loaded, then fades the overlay out and the demo in. Reveal
+// fires on (iframe load OR max-timeout) but never before a minimum display time,
+// so a fast load does not flicker and a stalled load never traps the spinner.
+//
+// We embed via <iframe> rather than the <gradio-app> web component: HuggingFace's
+// `.hf.space` CORS preflight currently omits `Access-Control-Allow-Credentials`,
+// which blocks the component's credentialed cross-origin /config fetch. Inside an
+// iframe the app talks to its own origin (no cross-origin preflight). HF already
+// serves the iframe-resizer contentWindow script inside every Space, so we load
+// the version-matched parent library to auto-height the iframe to its content.
 (function () {
   "use strict";
 
   var MIN_DISPLAY_MS = 2000;
-  // Cold HF Spaces can take much longer than a warm one to render. Gradio fires
-  // `render` only when the real app mounts (not during the building/sleeping
-  // phase), so we lean on that; this is just a last-resort cap so a Space that
-  // never renders eventually reveals (showing Gradio's own error) rather than
-  // spinning forever.
+  // Last-resort cap so the overlay reveals even if the iframe never fires `load`
+  // (e.g. a cold Space that is slow to serve its first byte).
   var MAX_WAIT_MS = 30000;
   // Must cover the longest reveal transition in _gradio-loader.scss (0.55s)
   // so the loader isn't removed from layout before its dissolve finishes.
   var FADE_MS = 600;
 
+  // iframe-resizer parent library, version-matched to the contentWindow script
+  // HuggingFace embeds inside every Space page (4.3.1). Loaded once.
+  var RESIZER_SRC =
+    "https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.min.js";
+
+  var resizerPromise = null;
+  function loadResizer() {
+    if (resizerPromise) return resizerPromise;
+    resizerPromise = new Promise(function (resolve, reject) {
+      if (window.iFrameResize) return resolve();
+      var s = document.createElement("script");
+      s.src = RESIZER_SRC;
+      s.onload = resolve;
+      s.onerror = reject;
+      document.head.appendChild(s);
+    });
+    return resizerPromise;
+  }
+
   function initEmbed(embed) {
     var loader = embed.querySelector("[data-gradio-loader]");
-    var app = embed.querySelector("gradio-app");
-    if (!loader || !app) return;
+    var iframe = embed.querySelector("[data-gradio-iframe]");
+    if (!loader || !iframe) return;
 
     var start = Date.now();
     var revealed = false;
-    var observer = null;
-    var maxTimer = null;
-
-    function cleanup() {
-      if (observer) { observer.disconnect(); observer = null; }
-      if (maxTimer) { clearTimeout(maxTimer); maxTimer = null; }
-    }
+    var maxTimer = setTimeout(requestReveal, MAX_WAIT_MS);
 
     function reveal() {
       if (revealed) return;
       revealed = true;
-      cleanup();
+      clearTimeout(maxTimer);
       embed.classList.add("is-ready");
       setTimeout(function () { loader.style.display = "none"; }, FADE_MS);
     }
@@ -48,21 +65,16 @@
       }
     }
 
-    // Primary signal: gradio dispatches "render" on the element only once the
-    // real app has mounted — NOT during the building/sleeping/error phase.
-    app.addEventListener("render", requestReveal, { once: true });
-
-    // Backstop (in case `render` is absent on some gradio version): reveal when
-    // actual interactive content exists. The building/sleeping screen has no
-    // form controls, so this won't fire prematurely the way watching for the
-    // bare .gradio-container shell did.
-    observer = new MutationObserver(function () {
-      if (app.querySelector("button, input, textarea")) requestReveal();
+    iframe.addEventListener("load", function () {
+      loadResizer()
+        .then(function () {
+          if (window.iFrameResize) {
+            window.iFrameResize({ checkOrigin: false, log: false }, iframe);
+          }
+        })
+        .catch(function () { /* keep the iframe's fixed fallback height */ })
+        .then(requestReveal);
     });
-    observer.observe(app, { childList: true, subtree: true });
-
-    // Hard fallback so the overlay never sticks if no signal arrives.
-    maxTimer = setTimeout(requestReveal, MAX_WAIT_MS);
   }
 
   function init() {

--- a/assets/sass/3-modules/_gradio-loader.scss
+++ b/assets/sass/3-modules/_gradio-loader.scss
@@ -1,14 +1,13 @@
-// Pangolin loading overlay shown over an embedded Gradio app while the HF Space
-// wakes up. The <gradio-app> itself is held invisible (opacity:0) until ready,
-// so Gradio's own building/sleeping/error UI — including high-z-index toasts,
-// which inherit an ancestor's opacity — never shows through. JS
-// (assets/js/gradio-loader.js) adds .is-ready once Gradio fires `render`.
+// Pangolin loading overlay shown over an embedded Gradio demo while its HF Space
+// iframe loads. The iframe is held invisible (opacity:0) until ready, so Gradio's
+// own building/sleeping screen never flashes through. JS
+// (assets/js/gradio-loader.js) adds .is-ready once the iframe has loaded.
 
 .gradio-embed {
   position: relative;
   // Reserve height in the document flow so the opaque loader covers its own
   // space (and any boot-time Gradio glitch) instead of floating over the
-  // content below it while <gradio-app> is still 0px tall.
+  // content below it while the iframe is still settling.
   min-height: 480px;
   // Ease the reserved height down on reveal so a demo shorter than 480px
   // settles smoothly instead of snapping.
@@ -16,22 +15,24 @@
 }
 
 // Once revealed, stop reserving space — let the embed collapse to the live
-// demo's natural height.
+// demo's natural (resizer-driven) height.
 .gradio-embed.is-ready {
   min-height: 0;
 }
 
-// Keep the live app (and all of Gradio's pre-render UI) invisible and inert
-// until ready. opacity:0 still lets Gradio load, connect, and render offscreen.
-// On reveal the demo fades in quickly so it's solid before the overlay finishes
-// dissolving — avoids a muddy cross-fade where both are half-visible at once.
-.gradio-embed gradio-app {
+// Keep the iframe invisible and inert until ready, then fade it in. The height
+// attribute is a pre-resize floor; the iframe-resizer parent library drives the
+// final height to fit the embedded app's content.
+.gradio-embed__iframe {
+  display: block;
+  width: 100%;
+  border: 0;
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.35s ease;
 }
 
-.gradio-embed.is-ready gradio-app {
+.gradio-embed.is-ready .gradio-embed__iframe {
   opacity: 1;
   pointer-events: auto;
 }
@@ -83,7 +84,7 @@
   }
   .gradio-embed,
   .gradio-embed__loader,
-  .gradio-embed gradio-app {
+  .gradio-embed__iframe {
     transition: none;
   }
 }

--- a/layouts/partials/gradio-embed.html
+++ b/layouts/partials/gradio-embed.html
@@ -14,7 +14,9 @@
   <iframe
     class="gradio-embed__iframe"
     data-gradio-iframe
-    src="https://{{ $src }}.hf.space"
+    {{/* __theme=light keeps parity with the old web component's theme_mode="light"
+         so the embedded app doesn't render dark on a dark-mode visitor. */}}
+    src="https://{{ $src }}.hf.space/?__theme=light"
     title="Live demo"
     height="720"
     frameborder="0"

--- a/layouts/partials/gradio-embed.html
+++ b/layouts/partials/gradio-embed.html
@@ -1,20 +1,23 @@
 {{- $src := .src -}}
-{{- $ver := .gradio_js_version | default "5.4.0" -}}
 <div class="gradio-embed" data-gradio-embed>
   <div class="gradio-embed__loader" data-gradio-loader aria-hidden="true">
     {{ $pangolin := resources.Get "images/logos/etm-logo.png" }}
     {{ with $pangolin }}<img class="gradio-embed__pangolin" src="{{ .RelPermalink }}" alt="" width="72" height="72">{{ end }}
     <p class="gradio-embed__label">Waking up the live demo…</p>
   </div>
-  <script
-    type="module"
-    src="https://gradio.s3-us-west-2.amazonaws.com/{{ $ver }}/gradio.js"
-  ></script>
-  <gradio-app
+  {{/* Embed via <iframe>, not the <gradio-app> web component: HuggingFace's
+       .hf.space CORS preflight omits Access-Control-Allow-Credentials, which
+       blocks the component's cross-origin /config fetch ("Could not get space
+       status"). Inside an iframe the app talks to its own origin, so no
+       cross-origin preflight. HF ships the iframe-resizer content script, so
+       gradio-loader.js loads the matching parent library to auto-height it. */}}
+  <iframe
+    class="gradio-embed__iframe"
+    data-gradio-iframe
     src="https://{{ $src }}.hf.space"
-    initial_height="0px"
-    theme_mode="light"
-    eager="true"
-    container="false"
-  ></gradio-app>
+    title="Live demo"
+    height="720"
+    frameborder="0"
+    allow="camera; microphone; clipboard-read; clipboard-write; fullscreen"
+  ></iframe>
 </div>


### PR DESCRIPTION
## Problem

Every embedded live demo broke site-wide with **"Could not get space status"**.

Root cause: HuggingFace's `.hf.space` CORS **preflight** (`OPTIONS /config`) stopped returning `Access-Control-Allow-Credentials: true`, while the `<gradio-app>` web component fetches `/config` with **credentials included** (which forces a preflight). The browser rejects the preflight → the client can't read the config → error.

Verified:
- `GET /config` returns `access-control-allow-credentials: true`; the `OPTIONS` preflight does **not** — confirmed with curl.
- Platform-wide: the same missing preflight header is present on unrelated public Spaces (FLUX.1-dev, Kolors, DALL·E-mini, Open LLM Leaderboard).
- **Not** fixable on our side and **not** fixed by restarting Spaces (restarted bear-detection + trout-reID — preflight header still missing once `RUNNING`). The fix has to come from HF.

## Change

Embed via `<iframe>` instead of the `<gradio-app>` web component. Inside an iframe the app talks to its **own** origin, so there is no cross-origin preflight. HuggingFace already serves the `iframe-resizer` contentWindow script in every Space, so the loader lazy-loads the version-matched parent library (4.3.1) to **auto-height** the iframe to its content.

- `layouts/partials/gradio-embed.html` — `<gradio-app>` + `gradio.js` loader → `<iframe src=".hf.space">`; pangolin loading overlay kept.
- `assets/js/gradio-loader.js` — reveal on iframe `load`; lazy-load iframe-resizer and auto-height; min-display / max-timeout reveal logic kept.
- `assets/sass/3-modules/_gradio-loader.scss` — drop dead `gradio-app` opacity rules; style `.gradio-embed__iframe`.

Single shared embed path, so this covers both the demo pages (`demos/single.html`) and the `hf_space` shortcode (e.g. the 4 embeds on `/tools/animal-reid/`).

## Verification

- Bear demo renders the real app (input image, Examples, **Identify** button, prediction panel) — no more error box.
- `/tools/animal-reid/` builds 4 iframes with the 4 correct Space URLs; layout intact.
- Clean rebuild: **zero** `<gradio-app>` / `gradio.s3` left in built HTML; single loader bundle containing `iframeResize`.

## Notes

- Reverting to the web component is a small change once HF fixes the preflight; `_gradio-reset.scss` (which restyled the in-DOM web-component UI, now inert for iframe content) was intentionally left untouched to keep that revert easy.
- Out of scope (Space-side, pre-existing): some Spaces emit example-image URLs as `http://0.0.0.0:7860` (mixed-content; example thumbnails don't load) and 404 on gradio fonts. Both are fixed in the Space repos (`root_path` / gradio version bump), not here.